### PR TITLE
add a new bin file to deal with module requirements

### DIFF
--- a/docs/source/tutorials/send-to-sepal.rst
+++ b/docs/source/tutorials/send-to-sepal.rst
@@ -47,8 +47,68 @@ To customize this environment add any libs that are useful for your module. For 
 
 .. code-block:: console
 
+    $ cd <my_module_path>
+    $ module_deploy
+
+    ##########################################
+    #                                        #
+    #      SEPAL MODULE DEPLOYMENT TOOL      #
+    #                                        #
+    ##########################################
+    
+    Welcome in the module deployment interface.
+    This interface will help you prepare your module for deployment.
+    Please read the documentation of the library before launching this script
+    
+    
+    Export the env configuration of your module
+    ‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾
+    INFO: Successfully saved requirements file in /home/prambaud/modules/sepal_ui_template/req_tmp.txt
+    Removing sepal_ui from reqs, duplicated from default.
+    Removing earthengine_api from reqs, included in sepal_ui.
+    Removing ee from reqs, included in sepal_ui.
+    sepal_ui version have been freezed to  2.0.6
+    
+    WARNING: The requirements.txt file have been updated. The tool does not cover every possible configuration so don't forget to check the final file before pushing to release
+
 Check your env
 ^^^^^^^^^^^^^^
+
+As mentioned at the end of the the command you should test your environment in sepal to check if everything is working. 
+
+first create a new **venv** anywhere in your home directory: 
+
+.. code-block:: console
+
+    $ python3 -m venv <path_to_venv_folder/venv_name>
+    
+Then activate this virtual environment: 
+
+.. code-block:: console
+
+    $ source <path_to_venv_folder/venv_name>/bin/activate
+    (venv_name) $
+    
+the name in parenthesis show to the user that the terminal is now running in a specific environment. 
+
+.. tips::
+
+    to return to the general environment simply run:
+    
+    .. cod-block:: console
+    
+        (venv_name) $ deactivate
+        $ 
+        
+    The parenthesis should disapear.
+    
+in this new environment run the following command using your requirement.txt file:
+
+.. code-block:: console 
+
+    $ grep -v "^#" <path-to-module>/requirements.txt | xargs -n 1 -L 1 pip3 install
+
+It will recursivelly install all your libs in the virtual env. If you are expeincing difficulties, please contact us in the `issue tracker <https://github.com/12rambau/sepal_ui/issues>`_. 
 
 Add documentation
 -----------------

--- a/docs/source/tutorials/send-to-sepal.rst
+++ b/docs/source/tutorials/send-to-sepal.rst
@@ -12,12 +12,43 @@ During your development, you may have encounter some trouble  using the preinsta
 
     $ pip install <my_lib>
 
-As a regular Sepal user, you don't have the rights to write in the :code:`usr/` so your installation have been performed using the :code:`--user` option. All the other Sepal user thus don't have access to your lib. 
-To verify that your module is still working try to launch it using the :code:`python3 module` kernel. This kernel only use the default libraries and will help you pinpoint what is missing in Sepal. 
+As a regular Sepal user, you don't have the rights to write in the :code:`/usr/` folder so your installations have been performed using the :code:`--user` option. All the other Sepal user thus don't have access to your libs. 
+in order to make your application work, Sepal will create a specific virtual environment (:code:`venv`) for your specific application. for that purpose you need to update the :code:`requirements.txt` file that is hold at the root of your module. By default the following content is already set: 
 
-.. tip::
+Standard environment
+^^^^^^^^^^^^^^^^^^^^
+.. code-block:: console
 
-    keep a list of all the missing python libraries
+    # these libs are requested to build common python libs 
+    # if you are an advance user and are sure to not use them you can comment the following lines
+    wheel
+    Cython
+    pybind11
+
+    # if you require GDAL and or pyproj in your module please uncomment these lines
+    # there are set up to be inlined with SEPAL implementation of GDAL and PROJ version
+    GDAL==3.0.4
+    pyproj<3.0.0
+
+    # the base lib to run any sepal_ui based app 
+    # don't forget to fix it to a specific version when you're app is ready
+    sepal_ui
+    
+The 3 first libs are compiling tools that are usually required for common Python libs, comment them only if you are sure that none of your libs are using them. 
+
+The gdal and pyproj libs are working on top of the PROJ and GDAL C++ libs that are already installed in SEPAL. The version suggested here are inlined with the current SEPAL release. If you need a specific version please let us know by sending us a request in the `issue tracker of the SEPAL repository <https://github.com/openforis/sepal/issues>`_.
+
+Sepal_ui is off course a mandatory requirements.
+
+Customize the env
+^^^^^^^^^^^^^^^^^
+
+To customize this environment add any libs that are useful for your module. For this purpose use the :code:`module_deploy` command. it will automatically add your dependencies to the requirements and deal with the already known troubleshoutings:
+
+.. code-block:: console
+
+Check your env
+^^^^^^^^^^^^^^
 
 Add documentation
 -----------------
@@ -48,7 +79,6 @@ You'll be asked to provide :
 - the name of the repository 
 - the name of the app to display in the dashboard
 - a short description of the module (1 liner)
-- the missing python libraries
 
 Our maintainers will then study your request and may ask you to make modifications to your repository before pulling. 
 

--- a/docs/source/tutorials/send-to-sepal.rst
+++ b/docs/source/tutorials/send-to-sepal.rst
@@ -91,11 +91,11 @@ Then activate this virtual environment:
     
 the name in parenthesis show to the user that the terminal is now running in a specific environment. 
 
-.. tips::
+.. tip::
 
     to return to the general environment simply run:
     
-    .. cod-block:: console
+    .. code-block:: console
     
         (venv_name) $ deactivate
         $ 

--- a/docs/source/tutorials/send-to-sepal.rst
+++ b/docs/source/tutorials/send-to-sepal.rst
@@ -17,7 +17,7 @@ in order to make your application work, Sepal will create a specific virtual env
 
 Standard environment
 ^^^^^^^^^^^^^^^^^^^^
-.. code-block:: console
+.. code-block:: python
 
     # these libs are requested to build common python libs 
     # if you are an advance user and are sure to not use them you can comment the following lines
@@ -70,7 +70,17 @@ To customize this environment add any libs that are useful for your module. For 
     sepal_ui version have been freezed to  2.0.6
     
     WARNING: The requirements.txt file have been updated. The tool does not cover every possible configuration so don't forget to check the final file before pushing to release
+    
+.. note::
 
+    If you want to import a file directly from the source, use the git import syntaxt: 
+    
+    .. code-block::
+    
+        git+git://github.com/12rambau/sepal_ui.git#egg=sepal_ui
+        
+    with everything after "git+" being the ssh link to the repository and "egg=" the name used by the lib in your file. If you want to know more about this method please refer to `this blog post <https://codeinthehole.com/tips/using-pip-and-requirementstxt-to-install-from-the-head-of-a-github-branch/>`_.
+    
 Check your env
 ^^^^^^^^^^^^^^
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -25,3 +25,4 @@ ipykernel
 sphinx-copybutton
 sepal_ui
 natsort
+pipreqs

--- a/sepal_ui/bin/module_deploy
+++ b/sepal_ui/bin/module_deploy
@@ -1,0 +1,182 @@
+#!/usr/bin/python3
+
+from pathlib import Path
+import subprocess
+
+from colorama import init, Fore, Style
+import sepal_ui
+
+#init colors for all plateforms
+init()
+
+def write_reqs(file):
+    """write the requirements in the req file"""
+    
+    with file.open('a') as f: 
+        f.write("\n")
+        f.write("\n# custom libs")
+        f.write("\n")
+    
+    ############################### not working for no reason
+    # add the custom libs 
+    #command = ["pipreqs", '--print', str(Path.cwd()), '>>', str(req_file)]
+    #res = subprocess.run(command, cwd=Path.cwd())
+    ##########################################################
+    
+    # until I understand use a proxy tmp file
+    tmp_file = Path.cwd()/'req_tmp.txt'
+    command = ['pipreqs', '--savepath', str(tmp_file), str(Path.cwd())]
+    res = subprocess.run(command, cwd=Path.cwd())
+    
+    # add the libs in the final file 
+    
+    with file.open('a') as dst:
+        dst.write(tmp_file.read_text())
+        
+    # remove the tmp file
+    tmp_file.unlink()
+        
+    return
+    
+def clean_dulpicate(file):
+    """remove the requirements that are already part of the default installation"""
+    
+    # already available libs 
+    libs = ['wheel', 'Cython', 'pybind11', 'GDAL', 'pyproj', 'sepal_ui']
+    
+    text = file.read_text().split('\n')
+        
+    # search for the custom line index 
+    idx = text.index("# custom libs")
+    
+    final_text = text[:idx]
+    for line in text[idx:]:
+        if any(lib in line for lib in libs):
+            lib = next(l for l in libs if l in line)
+            print(f"Removing {Style.BRIGHT}{lib}{Style.NORMAL} from reqs, duplicated from default.")
+            continue
+        final_text.append(line)
+    
+    file.write_text('\n'.join(final_text))
+        
+    return
+
+def clean_troubleshouting(file):
+    """remove any ee import from requirement file"""
+    
+    # the pipreqs is creating the file based on the import statements in .py files
+    # some libs doesn't have the same name as the pip command
+    # we are replacing/deleting the known one
+    
+    text = file.read_text().split('\n')
+        
+    # search for the custom line index 
+    idx = text.index("# custom libs")
+    
+    final_text = text[:idx]
+    for line in text[idx:]:
+        
+        # ee is imported as ee but the real name of the lib is earthengine api
+        # simply discard it as it's already included in sepal_ui 
+        if 'ee' in line:
+            print(f"Removing {Style.BRIGHT}ee{Style.NORMAL} from reqs, included in sepal_ui.")
+            continue
+        elif any(lib in line for lib in ['osgeo', 'gdal']):
+            print(f"Removing {Style.BRIGHT}'osgeo & gdal'{Style.NORMAL} from reqs, included in GDAL.")
+            continue
+        elif 'earthengine_api' in line:
+            print(f"Removing {Style.BRIGHT}earthengine_api{Style.NORMAL} from reqs, included in sepal_ui.")
+            continue
+          
+        # if I'm here nothing needed to be removed 
+        final_text.append(line)
+        
+    file.write_text('\n'.join(final_text))
+        
+    return
+
+def freeze_sepal_ui(file):
+    """set the sepal version to the currently used sepal version"""
+    
+    text = file.read_text().split('\n')
+        
+    # search for the sepal_ui line
+    idx, _ = next((i, l) for i, l in enumerate(text) if not "#" in l and 'sepal_ui' in l)
+    
+    text[idx] = f"sepal_ui=={sepal_ui.__version__}"
+    
+    file.write_text('\n'.join(text))
+        
+    print(f"sepal_ui version have been freezed to  {Style.BRIGHT}{sepal_ui.__version__}{Style.NORMAL}")
+        
+    return
+
+def clean_custom(file):
+    """remove the previous custom installation and requirements"""
+    
+    text = file.read_text().split('\n')
+        
+    # search for the custom line index 
+    try:
+        idx = text.index("# custom libs")
+        
+        # remove everything after it 
+        file.write_text('\n'.join(text[:idx-1]))
+            
+        print("the previously set custom requirements have been cleaned from the file")
+        
+    except ValueError:
+        pass
+    
+    return
+    
+if __name__ == "__main__":
+    
+    # welcome the user
+    print(Fore.YELLOW)
+    print("##########################################")
+    print("#                                        #")
+    print("#      SEPAL MODULE DEPLOYMENT TOOL      #")
+    print("#                                        #")
+    print("##########################################")
+    print(Fore.RESET)
+    print(f"Welcome in the {Style.BRIGHT}module deployment{Style.NORMAL} interface.")
+    print("This interface will help you prepare your module for deployment.")
+    print("Please read the documentation of the library before launching this script")
+    print()
+    print()
+    
+    print("Export the env configuration of your module")
+    print("‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾")
+    
+    # check that the local folder is a module folder
+    ui_file = Path.cwd()/'ui.ipynb'
+    if not ui_file.is_file():
+        raise Exception(f"{Fore.RED}This is not a module folder.")   
+    
+    # add the requirements to the requirements.txt file 
+    req_file = Path.cwd()/'requirements.txt'
+    
+    # clean the already existing custom installation
+    # if it was done manually nothing will be removed
+    clean_custom(req_file)
+    
+    # write the new requirements
+    write_reqs(req_file)    
+    
+    # clean the requirement file from known troubleshoutings 
+    clean_dulpicate(req_file)
+    clean_troubleshouting(req_file)
+    
+    # set the sepal version 
+    freeze_sepal_ui(req_file)
+    
+    # exit message 
+    print(Fore.YELLOW)
+    print("WARNING: The requirements.txt file have been updated. The tool does not cover every possible configuration so don't forget to check the final file before pushing to release") 
+    print(Fore.RESET)
+    
+    
+    
+    
+    

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,8 @@ setup(
         'colorama',
         'Deprecated',
         'Unidecode',
-        'natsort'
+        'natsort',
+        'pipreqs'
     ],
     classifiers=[
         'Development Status :: 5 - Production/Stable',


### PR DESCRIPTION
Fix #228 

In the next SEPAL release we will be given the oportunity to add requirements file for our module. I don't want to spend my entire time to edit requirements.txt file for others so I created this script that is retrieving the used libs from the folder and then edit automatically a requirements.txt file. 

It is based on the default requirements.txt file that is available in sepal_ui_template: https://github.com/12rambau/sepal_ui_template/blob/master/requirements.txt

Some libs are known troubleshoutings (GDAL, PROJ, earthengine) and are handle by the script. Any new strange behaviour should be added in this method: https://github.com/12rambau/sepal_ui/blob/9b1387c1727e35ba4891f4e361ee531adedf35bd/sepal_ui/bin/module_deploy#L64
