### PR TITLE
fix: remove type and feat: introducing switch decorator

### DIFF
--- a/sepal_ui/scripts/utils.py
+++ b/sepal_ui/scripts/utils.py
@@ -334,3 +334,32 @@ def to_colors(in_color, out_type="hex"):
             pass
 
     return transform(out_color)
+
+def switch(*params, debug=True):
+    """
+    Decorator to switch the state of input boolean parameters.
+    
+    Args:
+        *params (str): any boolean parameter of a SepalWidget.
+        
+    """
+    def decorator_switch(func):
+        @wraps(func)
+        def wrapper_switch(self, *args, **kwargs):
+            [setattr(self, param, True) for param in params]
+            
+            try:
+                func(self, *args, **kwargs)
+
+            except Exception as e:
+                [setattr(self, param, False) for param in params]
+                if debug:
+                    [setattr(self, param, False) for param in params]
+                    raise e
+
+            [setattr(self, param, False) for param in params]
+
+        return wrapper_switch
+
+    return decorator_switch
+

--- a/sepal_ui/sepalwidgets/inputs.py
+++ b/sepal_ui/sepalwidgets/inputs.py
@@ -490,7 +490,6 @@ class AssetSelect(v.Combobox, SepalWidget):
     ):
         self.valid = False
         self.asset_info = None
-        self.type = None
 
         # Validate the input as soon as the object is insantiated
         self.observe(self._validate, "v_model")
@@ -533,13 +532,11 @@ class AssetSelect(v.Combobox, SepalWidget):
 
             try:
                 self.asset_info = ee.data.getAsset(change["new"])
-                self.type = self.asset_info["type"]
                 self.valid = True
 
             except Exception:
 
                 self.asset_info = None
-                self.type = None
                 self.valid = False
                 self.error = True
                 self.error_messages = ms.widgets.asset_select.no_access


### PR DESCRIPTION
In my last commit I removed the type for two reasons (is should have ammed the last one, sorry):
- its a reserved python keyword, and also was causing problems with the widget.
![image](https://user-images.githubusercontent.com/12363250/131691110-6d9d0ab6-a54f-4a52-915e-448e92f646f9.png)


- there is no need to have it if we are storing all in asset_info