### PR TITLE
feat: Copy to clipboard

### DIFF
--- a/docs/source/widgets/clip.rst
+++ b/docs/source/widgets/clip.rst
@@ -1,0 +1,43 @@
+Copy to clipboard
+=================
+
+Overview
+--------
+
+:code:`Clip` is a custom textField that provides a handy copy-to-clipboard javascript behaviour. When the clipboard btn is clicked the :code:`v_model` will be copied in the local browser clipboard. You just have to change the clipboard :code:`v_model`before displaying it to the end user to have a custom value. When copied, the icon change from a copy to a check.
+Any argument from the original :code:`TextField` ipyvuetify class can be used to complement it.
+
+.. jupyter-execute:: 
+
+    from sepal_ui import sepalwidgets as sw
+    
+    # correct colors for the documentation 
+    # set to dark in SEPAL by default 
+    import ipyvuetify as v
+    v.theme.dark = False
+
+    clip = sw.Clip(v_model="toto")
+    clip
+
+You can also dynamically change the :code:`v_model` value. 
+
+.. note::
+
+    The :code:`TextField` widget is in readonly mode to aoid modifications from the end user.
+    
+.. jupyter-execute:: 
+
+    from sepal_ui import sepalwidgets as sw
+    
+    # correct colors for the documentation 
+    # set to dark in SEPAL by default 
+    import ipyvuetify as v
+    v.theme.dark = False
+
+    clip = sw.Clip()
+    clip.v_model = "toto"
+    clip
+
+.. note::
+
+    More information can be found `here <../modules/sepal_ui.sepalwidgets.html#sepal_ui.sepalwidgets.sepalwidget.Clip>`__.

--- a/docs/source/widgets/clip.rst
+++ b/docs/source/widgets/clip.rst
@@ -1,10 +1,10 @@
-Copy to clipboard
-=================
+CopyToClip
+==========
 
 Overview
 --------
 
-:code:`Clip` is a custom textField that provides a handy copy-to-clipboard javascript behaviour. When the clipboard btn is clicked the :code:`v_model` will be copied in the local browser clipboard. You just have to change the clipboard :code:`v_model`before displaying it to the end user to have a custom value. When copied, the icon change from a copy to a check.
+:code:`CopyToClip` is a custom textField that provides a handy copy-to-clipboard javascript behaviour. When the clipboard btn is clicked the :code:`v_model` will be copied in the local browser clipboard. You just have to change the clipboard :code:`v_model`before displaying it to the end user to have a custom value. When copied, the icon change from a copy to a check.
 Any argument from the original :code:`TextField` ipyvuetify class can be used to complement it.
 
 .. jupyter-execute:: 
@@ -16,7 +16,7 @@ Any argument from the original :code:`TextField` ipyvuetify class can be used to
     import ipyvuetify as v
     v.theme.dark = False
 
-    clip = sw.Clip(v_model="toto")
+    clip = sw.CopyToClip(v_model="toto")
     clip
 
 You can also dynamically change the :code:`v_model` value. 
@@ -34,10 +34,10 @@ You can also dynamically change the :code:`v_model` value.
     import ipyvuetify as v
     v.theme.dark = False
 
-    clip = sw.Clip()
+    clip = sw.CopyToClip()
     clip.v_model = "toto"
     clip
 
 .. note::
 
-    More information can be found `here <../modules/sepal_ui.sepalwidgets.html#sepal_ui.sepalwidgets.sepalwidget.Clip>`__.
+    More information can be found `here <../modules/sepal_ui.sepalwidgets.html#sepal_ui.sepalwidgets.sepalwidget.CopyToClip>`__.

--- a/docs/source/widgets/index.rst
+++ b/docs/source/widgets/index.rst
@@ -37,6 +37,7 @@ In this section, an example of each of our component will be given. You should r
     sepal_widget
     markdown
     tooltip
+    clip
     
     alert
     statebar

--- a/sepal_ui/sepalwidgets/sepalwidget.py
+++ b/sepal_ui/sepalwidgets/sepalwidget.py
@@ -3,7 +3,7 @@ from markdown import markdown
 from traitlets import Unicode, Any
 from ipywidgets import link
 
-__all__ = ["TYPES", "SepalWidget", "Markdown", "Tooltip", "Clip"]
+__all__ = ["TYPES", "SepalWidget", "Markdown", "Tooltip", "CopyToClip"]
 
 TYPES = ("info", "secondary", "primary", "error", "warning", "success", "accent")
 
@@ -147,7 +147,7 @@ class Tooltip(v.Tooltip):
         super().__setattr__(name, value)
 
 
-class Clip(v.VuetifyTemplate):
+class CopyToClip(v.VuetifyTemplate):
     """
     Custom textField that provides a handy copy-to-clipboard javascript behaviour.
     When the clipboard btn is clicked the v_model will be copied in the local browser clipboard. You just have to change the clipboard v_model. when copied, the icon change from a copy to a check.

--- a/sepal_ui/sepalwidgets/sepalwidget.py
+++ b/sepal_ui/sepalwidgets/sepalwidget.py
@@ -175,6 +175,8 @@ class Clip(v.VuetifyTemplate):
             kwargs["append_icon"] = "mdi-clipboard-outline"
         if "v_model" not in kwargs:
             kwargs["v_model"] = None
+        if "class_" not in kwargs:
+            kwargs["class_"] = "ma-5"
 
         # set the default v_model
         self.v_model = kwargs["v_model"]

--- a/sepal_ui/sepalwidgets/sepalwidget.py
+++ b/sepal_ui/sepalwidgets/sepalwidget.py
@@ -1,8 +1,9 @@
 import ipyvuetify as v
 from markdown import markdown
-from traitlets import Unicode
+from traitlets import Unicode, Any
+from ipywidgets import link
 
-__all__ = ["TYPES", "SepalWidget", "Markdown", "Tooltip"]
+__all__ = ["TYPES", "SepalWidget", "Markdown", "Tooltip", "Clip"]
 
 TYPES = ("info", "secondary", "primary", "error", "warning", "success", "accent")
 
@@ -146,11 +147,6 @@ class Tooltip(v.Tooltip):
         super().__setattr__(name, value)
 
 
-import ipyvuetify as v
-from traitlets import Any
-from ipywidgets import link
-
-
 class Clip(v.VuetifyTemplate):
     """
     Custom textField that provides a handy copy-to-clipboard javascript behaviour.
@@ -198,7 +194,7 @@ class Clip(v.VuetifyTemplate):
                     document.body.appendChild(tempInput);
                     tempInput.focus();
                     tempInput.select();
-                    alert(document.execCommand("copy"));
+                    document.execCommand("copy");
                     document.body.removeChild(tempInput); 
                 }
             }}

--- a/tests/test_Clip.py
+++ b/tests/test_Clip.py
@@ -1,0 +1,47 @@
+import ipyvuetify as v
+
+from sepal_ui import sepalwidgets as sw
+
+
+class TestClip:
+    def test_init(self):
+
+        # minimal clip
+        clip = sw.Clip()
+        assert clip.tf.outlined == True
+        assert isinstance(clip.tf.label, str)
+        assert clip.tf.append_icon == "mdi-clipboard-outline"
+        assert clip.tf.v_model == None
+
+        # clip with extra options
+        clip = sw.Clip(outlined=False, dense=True)
+        assert clip.tf.outlined == False
+        assert clip.tf.dense == True
+
+        return
+
+    def test_copy(self):
+
+        clip = sw.Clip(v_model="value")
+        clip.tf.fire_event("click:append", None)
+
+        # I don't know how to check the clipboard
+
+        # check the icon change
+        assert clip.tf.append_icon == "mdi-check"
+
+        return
+
+    def test_change(self):
+
+        # test value
+        test_value = "toto"
+
+        # change the widget value
+        clip = sw.Clip()
+        clip.v_model = test_value
+
+        # check
+        assert clip.tf.v_model == test_value
+
+        return

--- a/tests/test_CopyToClip.py
+++ b/tests/test_CopyToClip.py
@@ -7,14 +7,14 @@ class TestClip:
     def test_init(self):
 
         # minimal clip
-        clip = sw.Clip()
+        clip = sw.CopyToClip()
         assert clip.tf.outlined == True
         assert isinstance(clip.tf.label, str)
         assert clip.tf.append_icon == "mdi-clipboard-outline"
         assert clip.tf.v_model == None
 
         # clip with extra options
-        clip = sw.Clip(outlined=False, dense=True)
+        clip = sw.CopyToClip(outlined=False, dense=True)
         assert clip.tf.outlined == False
         assert clip.tf.dense == True
 
@@ -22,7 +22,7 @@ class TestClip:
 
     def test_copy(self):
 
-        clip = sw.Clip(v_model="value")
+        clip = sw.CopyToClip(v_model="value")
         clip.tf.fire_event("click:append", None)
 
         # I don't know how to check the clipboard
@@ -38,7 +38,7 @@ class TestClip:
         test_value = "toto"
 
         # change the widget value
-        clip = sw.Clip()
+        clip = sw.CopyToClip()
         clip.v_model = test_value
 
         # check


### PR DESCRIPTION
# overview 

It finally works, the RPC way of calling javascripts methods directly from python will be super useful. We needed to wait for voila XX.12 to make javascript executable from dashboards (that was already working from Jupyter notebook and lab). 

## Note 

The javascript command used here (`document.execCommand("copy")`) is not working on every browser.... but as a first step I would like to make it available as it's working on the big 3: 
- chrome
- firefox
- opera

It will need further work to make it compatible with everything (hello IE7) but that's another story. I'll wait for people to complain.

Fix #163 
