### PR TITLE
refactor: use kwargs pop

### DIFF
--- a/sepal_ui/mapping/mapping.py
+++ b/sepal_ui/mapping/mapping.py
@@ -50,6 +50,7 @@ class SepalMap(geemap.Map):
         dc (bool, optional): wether or not the drawing control should be displayed. default to false
         vinspector (bool, optional): Add value inspector to map, useful to inspect pixel values. default to false
         ee (bool, optional): wether or not to use the ee binding. If False none of the earthengine display fonctionalities can be used. default to True
+        kwargs (optional): any parameter from a geemap.Map. if set ['ee_initialize'] will be overwritten.
 
 
     Attributes:
@@ -67,14 +68,16 @@ class SepalMap(geemap.Map):
 
         self.world_copy_jump = True
 
+        # set the default parameters
+        kwargs[
+            "ee_initialize"
+        ] = False  # we take care of the initialization on our side
+        kwargs["add_google_map"] = kwargs.pop("add_google_map", False)
+        kwargs["center"] = kwargs.pop("center", [0, 0])
+        kwargs["zoom"] = kwargs.pop("zoom", 2)
+
         # Init the map
-        super().__init__(
-            ee_initialize=False,  # we take care of the initialization on our side
-            add_google_map=False,
-            center=[0, 0],
-            zoom=2,
-            **kwargs,
-        )
+        super().__init__(**kwargs)
 
         # init ee
         self.ee = gee

--- a/sepal_ui/mapping/mapping.py
+++ b/sepal_ui/mapping/mapping.py
@@ -69,9 +69,7 @@ class SepalMap(geemap.Map):
         self.world_copy_jump = True
 
         # set the default parameters
-        kwargs[
-            "ee_initialize"
-        ] = False  # we take care of the initialization on our side
+        kwargs["ee_initialize"] = False  # we do it ourselves
         kwargs["add_google_map"] = kwargs.pop("add_google_map", False)
         kwargs["center"] = kwargs.pop("center", [0, 0])
         kwargs["zoom"] = kwargs.pop("zoom", 2)

--- a/sepal_ui/mapping/mapping.py
+++ b/sepal_ui/mapping/mapping.py
@@ -50,7 +50,7 @@ class SepalMap(geemap.Map):
         dc (bool, optional): wether or not the drawing control should be displayed. default to false
         vinspector (bool, optional): Add value inspector to map, useful to inspect pixel values. default to false
         ee (bool, optional): wether or not to use the ee binding. If False none of the earthengine display fonctionalities can be used. default to True
-        kwargs (optional): any parameter from a geemap.Map. if set ['ee_initialize'] will be overwritten.
+        kwargs (optional): any parameter from a geemap.Map. if set, 'ee_initialize' will be overwritten.
 
 
     Attributes:

--- a/sepal_ui/message/en.json
+++ b/sepal_ui/message/en.json
@@ -8,7 +8,8 @@
 			"custom": "Custom",
 			"no_access": "It seems like you do not have access to the input asset or it does not exist.",
             "wrong_type": "The type of the selected asset ({}) does not match authorized asset type ({}).",
-			"hint": "Select an asset in the list or write a custom asset name. Be careful, you need to have access to this asset to use it"
+			"hint": "Select an asset in the list or write a custom asset name. Be careful, you need to have access to this asset to use it",
+            "placeholder": "users/custom_user/custom_asset"
 		},
 		"load_table": {
 			"too_small": "The provided file have less than 3 columns. Please provide a complete point file with at least ID, lattitude and longitude columns."

--- a/sepal_ui/message/es.json
+++ b/sepal_ui/message/es.json
@@ -7,7 +7,8 @@
 			"custom": "Personalizado",
 			"no_access": "Parece que no tienes acceso al asset seleccionado o este no existe.",
             "wrong_type": "El tipo del asset seleccionado: ({}), no coincide con ninguno de los tipos permitidos por el widget: ({}).",
-			"hint": "Selecciona un asset en la lista o escribe el id de un asset personalizado. Recuerda que necesitas tener acceso a este para usarlo."
+			"hint": "Selecciona un asset en la lista o escribe el id de un asset personalizado. Recuerda que necesitas tener acceso a este para usarlo.",
+            "placeholder": "users/custom_user/custom_asset"
 		},
 		"load_table": {
 			"too_small": "El archivo indicado tiene menos de 3 columnas. Por favor, indique un archivo de puntos completo con al menos las columnas de ID, latitud y longitud."

--- a/sepal_ui/message/fr.json
+++ b/sepal_ui/message/fr.json
@@ -8,7 +8,8 @@
 			"custom": "Personnaliser",
 			"no_access": "Il semble que vous n'ayez pas accès à l'Asset selectionné ou qu'il n'existe pas.",
             "wrong_type": "Le type de l'asset selectioné ({}) ne correspond pas aux type autorisés par le widget ({}).",
-			"hint": "Sélectionnez un Asset dans la liste ou choisissez un Asset personnalisé. Attention, vous devez avoir accès à cet asset pour l'utiliser."
+			"hint": "Sélectionnez un Asset dans la liste ou choisissez un Asset personnalisé. Attention, vous devez avoir accès à cet asset pour l'utiliser.",
+            "placeholder": "users/custom_user/custom_asset"
 		},
 		"load_table": {
 			"too_small": "Le fichier fourni comporte moins de 3 colonnes. Veuillez fournir un fichier de points complet avec au moins les colonnes ID, lattitude et longitude."

--- a/sepal_ui/model/model.py
+++ b/sepal_ui/model/model.py
@@ -12,18 +12,7 @@ class Model(HasTraits):
     The Model structure is based on traitlets and embed function for export or import in json format.
     The model traintlets can be bind to any widget field.
 
-    Args:
-        traits ([str], optional): a list of traits names (not functional). default to none
-
     """
-
-    def __init__(self, traits=[]):
-
-        # didn't manage to make it work and it seems dodgy has it creates a simlink to new class at each call
-        # if len(traits):
-        #    [self.add_traits(Any(val).tag(sync=True), label) for label, val in traits.items()]
-
-        super().__init__()
 
     def __repr__(self):
         """Method to represent the Model objects as a string"""

--- a/sepal_ui/sepalwidgets/alert.py
+++ b/sepal_ui/sepalwidgets/alert.py
@@ -18,7 +18,7 @@ class Divider(v.Divider, SepalWidget):
 
     Args:
         class\_ (str, optional): the initial color of the divider
-        kwargs (optional): any parameter from a v.Divider. if set  again, ['class_'] will be overwritten
+        kwargs (optional): any parameter from a v.Divider. if set, 'class_' will be overwritten.
 
     Attributes:
         type_ (str): the current color of the divider
@@ -65,7 +65,7 @@ class Alert(v.Alert, SepalWidget):
 
     Args:
         type\_ (str, optional): The color of the Alert
-        kwargs (optional): any parameter from a v.Alert. If set ['type'] will be overwritten.
+        kwargs (optional): any parameter from a v.Alert. If set, 'type' will be overwritten.
     """
 
     def __init__(self, type_=None, **kwargs):
@@ -314,7 +314,7 @@ class StateBar(v.SystemBar):
     """Widget to display quick messages on simple inline status bar
 
     Args:
-       kwargs (optional): any parameter from a v.SystemBar. If set, ['children'] will be overwritten.
+       kwargs (optional): any parameter from a v.SystemBar. If set, 'children' will be overwritten.
 
     Attributes:
         msg (Unicode): the msg to be displayed

--- a/sepal_ui/sepalwidgets/alert.py
+++ b/sepal_ui/sepalwidgets/alert.py
@@ -18,7 +18,7 @@ class Divider(v.Divider, SepalWidget):
 
     Args:
         class\_ (str, optional): the initial color of the divider
-        kwargs (optional): any parameter from a v.Divider. ['class_'] cannot be overwritten
+        kwargs (optional): any parameter from a v.Divider. if set  again, ['class_'] will be overwritten
 
     Attributes:
         type_ (str): the current color of the divider

--- a/sepal_ui/sepalwidgets/alert.py
+++ b/sepal_ui/sepalwidgets/alert.py
@@ -18,6 +18,7 @@ class Divider(v.Divider, SepalWidget):
 
     Args:
         class\_ (str, optional): the initial color of the divider
+        kwargs (optional): any parameter from a v.Divider. ['class_'] cannot be overwritten
 
     Attributes:
         type_ (str): the current color of the divider
@@ -27,7 +28,7 @@ class Divider(v.Divider, SepalWidget):
     type_ = Unicode("").tag(sync=True)
 
     def __init__(self, class_="", **kwargs):
-        self.class_ = class_
+        kwargs["class_"] = class_
         super().__init__(**kwargs)
 
     @observe("type_")
@@ -64,14 +65,17 @@ class Alert(v.Alert, SepalWidget):
 
     Args:
         type\_ (str, optional): The color of the Alert
+        kwargs (optional): any parameter from a v.Alert. If set ['type'] will be overwritten.
     """
 
     def __init__(self, type_=None, **kwargs):
 
-        self.text = True
-        self.type = type_ if (type_ in TYPES) else TYPES[0]
-        self.class_ = "mt-5"
+        # set default parameters
+        kwargs["text"] = kwargs.pop("text", True)
+        kwargs["type"] = type_ if (type_ in TYPES) else TYPES[0]
+        kwargs["class_"] = kwargs.pop("class_", "mt-5")
 
+        # call the constructor
         super().__init__(**kwargs)
 
         self.hide()
@@ -309,6 +313,9 @@ class StateBar(v.SystemBar):
 
     """Widget to display quick messages on simple inline status bar
 
+    Args:
+       kwargs (optional): any parameter from a v.SystemBar. If set, ['children'] will be overwritten.
+
     Attributes:
         msg (Unicode): the msg to be displayed
         loading (Bool): State of bar, it will display a loading spin wheel if not loading.
@@ -329,8 +336,10 @@ class StateBar(v.SystemBar):
             class_="mr-2",
         )
 
-        self.children = [self.progress, self.msg]
+        # set default parameter
+        kwargs["children"] = [self.progress, self.msg]
 
+        # call the constructor
         super().__init__(**kwargs)
 
         jslink((self, "loading"), (self.progress, "indeterminate"))

--- a/sepal_ui/sepalwidgets/app.py
+++ b/sepal_ui/sepalwidgets/app.py
@@ -20,6 +20,7 @@ class AppBar(v.AppBar, SepalWidget):
 
     Args:
         title (str, optional): the title of the app
+        kwargs(dict, optional): any parameters from a v.AppBar
 
     Attributes:
         toggle_button (v.Btn): the btn to display or hide the drawer to the user
@@ -35,14 +36,14 @@ class AppBar(v.AppBar, SepalWidget):
 
         self.title = v.ToolbarTitle(children=[title])
 
-        super().__init__(
-            color=sepal_main,
-            class_="white--text",
-            dense=True,
-            app=True,
-            children=[self.toggle_button, self.title],
-            **kwargs
-        )
+        # set the default parameters
+        kwargs["color"] = kwargs.pop("color", sepal_main)
+        kwargs["class_"] = kwargs.pop("class_", "white--text")
+        kwargs["dense"] = kwargs.pop("dense", True)
+        kwargs["app"] = kwargs.pop("app", True)
+        kwargs["children"] = kwargs.pop("children", [self.toggle_button, self.title])
+
+        super().__init__(**kwargs)
 
     def set_title(self, title):
         """
@@ -71,6 +72,7 @@ class DrawerItem(v.ListItem, SepalWidget):
         icon(str, optional): the full name of a mdi-icon
         card (str, optional): the mount_id of tiles in the app
         href (str, optional): the absolute link to an external web page
+        kwargs (optional): any parameter from a v.ListItem
 
     Attributes:
         href (str): the absolute link to follow on click
@@ -92,13 +94,18 @@ class DrawerItem(v.ListItem, SepalWidget):
             ),
         ]
 
-        super().__init__(link=True, children=children, **kwargs)
+        # set default parameters
+        kwargs["link"] = kwargs.pop("link", True)
+        kwargs["children"] = kwargs.pop("children", children)
 
         if href:
-            self.href = href
-            self.target = "_blank"
+            kwargs["href"] = kwargs.pop("href", href)
+            kwargs["target"] = kwargs.pop("target", "_blank")
         elif card:
-            self._metadata = {"card_id": card}
+            kwargs["_metadata"] = kwargs.pop("_metadata", {"card_id": card})
+
+        # call the constructor
+        super().__init__(**kwargs)
 
     def display_tile(self, tiles):
         """
@@ -143,6 +150,7 @@ class NavDrawer(v.NavigationDrawer, SepalWidget):
         code (str, optional): the absolute link to the source code
         wiki (str, optional): the absolute link the the wiki page
         issue (str, optional): the absolute link to the issue tracker
+        kwargs (optional) any parameter from a v.NavigationDrawer
     """
 
     def __init__(self, items=[], code=None, wiki=None, issue=None, **kwargs):
@@ -160,17 +168,20 @@ class NavDrawer(v.NavigationDrawer, SepalWidget):
             item_bug = DrawerItem("Bug report", icon="mdi-bug", href=issue)
             code_link.append(item_bug)
 
-        super().__init__(
-            v_model=True,
-            app=True,
-            color=sepal_darker,
-            children=[
-                v.List(dense=True, children=self.items),
-                v.Divider(),
-                v.List(dense=True, children=code_link),
-            ],
-            **kwargs
-        )
+        children = [
+            v.List(dense=True, children=self.items),
+            v.Divider(),
+            v.List(dense=True, children=code_link),
+        ]
+
+        # set default parameters
+        kwargs["v_model"] = kwargs.pop("v_model", True)
+        kwargs["app"] = kwargs.pop("app", True)
+        kwargs["color"] = kwargs.pop("color", sepal_darker)
+        kwargs["children"] = kwargs.pop("children", children)
+
+        # call the constructor
+        super().__init__(**kwargs)
 
         # bind the javascripts behavior
         for i in self.items:
@@ -219,15 +230,21 @@ class Footer(v.Footer, SepalWidget):
 
     Args:
         text (str, optional): the text to display in the future
+        kwargs (optional): any parameter from a v.Footer
     """
 
     def __init__(self, text="", **kwargs):
 
         text = text if text != "" else "SEPAL \u00A9 {}".format(datetime.today().year)
 
-        super().__init__(
-            color=sepal_main, class_="white--text", app=True, children=[text], **kwargs
-        )
+        # set default parameters
+        kwargs["color"] = kwargs.pop("color", sepal_main)
+        kwargs["class_"] = kwargs.pop("class_", "white--text")
+        kwargs["app"] = kwargs.pop("app", True)
+        kwargs["children"] = kwargs.pop("children", [text])
+
+        # call the constructor
+        super().__init__(**kwargs)
 
 
 class App(v.App, SepalWidget):
@@ -242,6 +259,7 @@ class App(v.App, SepalWidget):
         appBar (sw.AppBar, optional): the appBar of the application
         footer (sw.Footer, optional): the footer of the application
         navDrawer (sw.NavDrawer): the navdrawer of the application
+        kwargs (optional) any parameter from a v.App
 
     Attributes:
         tiles ([sw.Tile]): the tiles of the app
@@ -290,7 +308,12 @@ class App(v.App, SepalWidget):
         # create a negative overlay to force the background color
         bg = v.Overlay(color=color.bg, opacity=1, style_="transition:unset", z_index=-1)
 
-        super().__init__(v_model=None, children=[bg, *app_children], **kwargs)
+        # set default parameters
+        kwargs["v_model"] = kwargs.pop("v_model", None)
+        kwargs["children"] = kwargs.pop("children", [bg, *app_children])
+
+        # call the constructor
+        super().__init__(**kwargs)
 
     def show_tile(self, name):
         """
@@ -325,30 +348,22 @@ class App(v.App, SepalWidget):
 
         Args:
             msg (str): the message to write in the Alert
-            kwargs: any arguments of the v.Alert constructor
+            kwargs: any arguments of the v.Alert constructor. [children] cannot be overwitten
 
         Return:
             self
         """
 
-        default_params = {
-            "type": "info",
-            "border": "left",
-            "class_": "mt-5",
-            "transition": "slide-x-transition",
-            "prominent": True,
-            "dismissible": True,
-        }
-
-        for p, val in default_params.items():
-            if not p in kwargs:
-                kwargs[p] = val
-
-        # remove children from kwargs if set to avoid duplication
-        kwargs.pop("children", None)
+        kwargs["type"] = kwargs.pop("type", "info")
+        kwargs["border"] = kwargs.pop("border", "left")
+        kwargs["class_"] = kwargs.pop("class_", "mt-5")
+        kwargs["transition"] = kwargs.pop("transition", "slide-x-transition")
+        kwargs["prominent"] = kwargs.pop("prominent", True)
+        kwargs["dismissible"] = kwargs.pop("dismissible", True)
+        kwargs["children"] = [msg]  # cannot be overwritten
 
         # create the alert
-        alert = v.Alert(children=[msg], **kwargs)
+        alert = v.Alert(**kwargs)
 
         # add the alert to the app
         self.content.children = [alert] + self.content.children.copy()

--- a/sepal_ui/sepalwidgets/app.py
+++ b/sepal_ui/sepalwidgets/app.py
@@ -20,7 +20,7 @@ class AppBar(v.AppBar, SepalWidget):
 
     Args:
         title (str, optional): the title of the app
-        kwargs(dict, optional): any parameters from a v.AppBar
+        kwargs(dict, optional): any parameters from a v.AppBar. If set ['children', 'app'] will be overwritten.
 
     Attributes:
         toggle_button (v.Btn): the btn to display or hide the drawer to the user
@@ -40,8 +40,8 @@ class AppBar(v.AppBar, SepalWidget):
         kwargs["color"] = kwargs.pop("color", sepal_main)
         kwargs["class_"] = kwargs.pop("class_", "white--text")
         kwargs["dense"] = kwargs.pop("dense", True)
-        kwargs["app"] = kwargs.pop("app", True)
-        kwargs["children"] = kwargs.pop("children", [self.toggle_button, self.title])
+        kwargs["app"] = True
+        kwargs["children"] = [self.toggle_button, self.title]
 
         super().__init__(**kwargs)
 
@@ -72,7 +72,7 @@ class DrawerItem(v.ListItem, SepalWidget):
         icon(str, optional): the full name of a mdi-icon
         card (str, optional): the mount_id of tiles in the app
         href (str, optional): the absolute link to an external web page
-        kwargs (optional): any parameter from a v.ListItem
+        kwargs (optional): any parameter from a v.ListItem. If set, ['_metadata', 'target', 'link', 'children'] will be overwritten.
 
     Attributes:
         href (str): the absolute link to follow on click
@@ -95,14 +95,16 @@ class DrawerItem(v.ListItem, SepalWidget):
         ]
 
         # set default parameters
-        kwargs["link"] = kwargs.pop("link", True)
-        kwargs["children"] = kwargs.pop("children", children)
-
+        kwargs["link"] = True
+        kwargs["children"] = children
         if href:
-            kwargs["href"] = kwargs.pop("href", href)
-            kwargs["target"] = kwargs.pop("target", "_blank")
+            kwargs["href"] = href  # cannot be set twice anyway
+            kwargs["target"] = "_blank"
+            kwargs.pop("_metadata", None)
         elif card:
-            kwargs["_metadata"] = kwargs.pop("_metadata", {"card_id": card})
+            kwargs["_metadata"] = {"card_id": card}
+            kwargs.pop("href", None)
+            kwargs.pop("target", None)
 
         # call the constructor
         super().__init__(**kwargs)
@@ -150,7 +152,7 @@ class NavDrawer(v.NavigationDrawer, SepalWidget):
         code (str, optional): the absolute link to the source code
         wiki (str, optional): the absolute link the the wiki page
         issue (str, optional): the absolute link to the issue tracker
-        kwargs (optional) any parameter from a v.NavigationDrawer
+        kwargs (optional) any parameter from a v.NavigationDrawer. If set, ['app', 'children'] will be overwritten.
     """
 
     def __init__(self, items=[], code=None, wiki=None, issue=None, **kwargs):
@@ -176,9 +178,9 @@ class NavDrawer(v.NavigationDrawer, SepalWidget):
 
         # set default parameters
         kwargs["v_model"] = kwargs.pop("v_model", True)
-        kwargs["app"] = kwargs.pop("app", True)
+        kwargs["app"] = True
         kwargs["color"] = kwargs.pop("color", sepal_darker)
-        kwargs["children"] = kwargs.pop("children", children)
+        kwargs["children"] = children
 
         # call the constructor
         super().__init__(**kwargs)
@@ -230,7 +232,7 @@ class Footer(v.Footer, SepalWidget):
 
     Args:
         text (str, optional): the text to display in the future
-        kwargs (optional): any parameter from a v.Footer
+        kwargs (optional): any parameter from a v.Footer. If set ['app', 'children'] will be overwritten.
     """
 
     def __init__(self, text="", **kwargs):
@@ -240,8 +242,8 @@ class Footer(v.Footer, SepalWidget):
         # set default parameters
         kwargs["color"] = kwargs.pop("color", sepal_main)
         kwargs["class_"] = kwargs.pop("class_", "white--text")
-        kwargs["app"] = kwargs.pop("app", True)
-        kwargs["children"] = kwargs.pop("children", [text])
+        kwargs["app"] = True
+        kwargs["children"] = [text]
 
         # call the constructor
         super().__init__(**kwargs)
@@ -259,7 +261,7 @@ class App(v.App, SepalWidget):
         appBar (sw.AppBar, optional): the appBar of the application
         footer (sw.Footer, optional): the footer of the application
         navDrawer (sw.NavDrawer): the navdrawer of the application
-        kwargs (optional) any parameter from a v.App
+        kwargs (optional) any parameter from a v.App. If set, ['children'] will be overwritten.
 
     Attributes:
         tiles ([sw.Tile]): the tiles of the app
@@ -310,7 +312,7 @@ class App(v.App, SepalWidget):
 
         # set default parameters
         kwargs["v_model"] = kwargs.pop("v_model", None)
-        kwargs["children"] = kwargs.pop("children", [bg, *app_children])
+        kwargs["children"] = [bg, *app_children]
 
         # call the constructor
         super().__init__(**kwargs)
@@ -348,7 +350,7 @@ class App(v.App, SepalWidget):
 
         Args:
             msg (str): the message to write in the Alert
-            kwargs: any arguments of the v.Alert constructor. [children] cannot be overwitten
+            kwargs: any arguments of the v.Alert constructor. if set, ['children'] will be overwritten.
 
         Return:
             self

--- a/sepal_ui/sepalwidgets/app.py
+++ b/sepal_ui/sepalwidgets/app.py
@@ -20,7 +20,7 @@ class AppBar(v.AppBar, SepalWidget):
 
     Args:
         title (str, optional): the title of the app
-        kwargs(dict, optional): any parameters from a v.AppBar. If set ['children', 'app'] will be overwritten.
+        kwargs(dict, optional): any parameters from a v.AppBar. If set, 'children' and 'app' will be overwritten.
 
     Attributes:
         toggle_button (v.Btn): the btn to display or hide the drawer to the user
@@ -72,7 +72,7 @@ class DrawerItem(v.ListItem, SepalWidget):
         icon(str, optional): the full name of a mdi-icon
         card (str, optional): the mount_id of tiles in the app
         href (str, optional): the absolute link to an external web page
-        kwargs (optional): any parameter from a v.ListItem. If set, ['_metadata', 'target', 'link', 'children'] will be overwritten.
+        kwargs (optional): any parameter from a v.ListItem. If set, '_metadata', 'target', 'link' and 'children' will be overwritten.
 
     Attributes:
         href (str): the absolute link to follow on click
@@ -152,7 +152,7 @@ class NavDrawer(v.NavigationDrawer, SepalWidget):
         code (str, optional): the absolute link to the source code
         wiki (str, optional): the absolute link the the wiki page
         issue (str, optional): the absolute link to the issue tracker
-        kwargs (optional) any parameter from a v.NavigationDrawer. If set, ['app', 'children'] will be overwritten.
+        kwargs (optional) any parameter from a v.NavigationDrawer. If set, 'app' and 'children' will be overwritten.
     """
 
     def __init__(self, items=[], code=None, wiki=None, issue=None, **kwargs):
@@ -261,7 +261,7 @@ class App(v.App, SepalWidget):
         appBar (sw.AppBar, optional): the appBar of the application
         footer (sw.Footer, optional): the footer of the application
         navDrawer (sw.NavDrawer): the navdrawer of the application
-        kwargs (optional) any parameter from a v.App. If set, ['children'] will be overwritten.
+        kwargs (optional) any parameter from a v.App. If set, 'children' will be overwritten.
 
     Attributes:
         tiles ([sw.Tile]): the tiles of the app
@@ -350,7 +350,7 @@ class App(v.App, SepalWidget):
 
         Args:
             msg (str): the message to write in the Alert
-            kwargs: any arguments of the v.Alert constructor. if set, ['children'] will be overwritten.
+            kwargs: any arguments of the v.Alert constructor. if set, 'children' will be overwritten.
 
         Return:
             self

--- a/sepal_ui/sepalwidgets/btn.py
+++ b/sepal_ui/sepalwidgets/btn.py
@@ -14,7 +14,7 @@ class Btn(v.Btn, SepalWidget):
     Args:
         text (str, optional): the text to display in the btn
         icon (str, optional): the full name of any mdi-icon
-        kwargs (dict, optional): any parameters from v.Btn. if set, ['children'] will be overwritten.
+        kwargs (dict, optional): any parameters from v.Btn. if set, 'children' will be overwritten.
 
     Attributes:
         v_icon (v.icon): the icon in the btn
@@ -68,7 +68,7 @@ class DownloadBtn(v.Btn, SepalWidget):
     Args:
         text (str): the message inside the btn
         path (str, optional): the absolute to a downloadable content
-        args (dict, optional): any parameter from a v.Btn. if set, ['children', 'target'] will be overwritten.
+        args (dict, optional): any parameter from a v.Btn. if set, 'children' and 'target' will be overwritten.
     """
 
     def __init__(self, text, path="#", **kwargs):

--- a/sepal_ui/sepalwidgets/btn.py
+++ b/sepal_ui/sepalwidgets/btn.py
@@ -14,7 +14,7 @@ class Btn(v.Btn, SepalWidget):
     Args:
         text (str, optional): the text to display in the btn
         icon (str, optional): the full name of any mdi-icon
-        kwargs (dict, optional): any parameters from v.Btn
+        kwargs (dict, optional): any parameters from v.Btn. if set, ['children'] will be overwritten.
 
     Attributes:
         v_icon (v.icon): the icon in the btn
@@ -27,7 +27,7 @@ class Btn(v.Btn, SepalWidget):
 
         # set the default parameters
         kwargs["color"] = kwargs.pop("color", "primary")
-        kwargs["children"] = kwargs.pop("children", [self.v_icon, text])
+        kwargs["children"] = [self.v_icon, text]
 
         # call the constructor
         super().__init__(**kwargs)
@@ -68,7 +68,7 @@ class DownloadBtn(v.Btn, SepalWidget):
     Args:
         text (str): the message inside the btn
         path (str, optional): the absolute to a downloadable content
-        args (dict, optional): any parameter from a v.Btn
+        args (dict, optional): any parameter from a v.Btn. if set, ['children', 'target'] will be overwritten.
     """
 
     def __init__(self, text, path="#", **kwargs):
@@ -80,8 +80,8 @@ class DownloadBtn(v.Btn, SepalWidget):
         kwargs["class_"] = kwargs.pop("class_", "ma-2")
         kwargs["xs5"] = kwargs.pop("xs5", True)
         kwargs["color"] = kwargs.pop("color", "success")
-        kwargs["children"] = kwargs.pop("children", [v_icon, text])
-        kwargs["target"] = kwargs.pop("target", "_blank")
+        kwargs["children"] = [v_icon, text]
+        kwargs["target"] = "_blank"
 
         # call the constructor
         super().__init__(**kwargs)

--- a/sepal_ui/sepalwidgets/btn.py
+++ b/sepal_ui/sepalwidgets/btn.py
@@ -14,20 +14,22 @@ class Btn(v.Btn, SepalWidget):
     Args:
         text (str, optional): the text to display in the btn
         icon (str, optional): the full name of any mdi-icon
+        kwargs (dict, optional): any parameters from v.Btn
 
     Attributes:
         v_icon (v.icon): the icon in the btn
     """
 
-    def __init__(self, text="Click", icon=None, **kwargs):
+    def __init__(self, text="Click", icon="", **kwargs):
 
-        self.color = "primary"
-        self.v_icon = None
-        self.children = [text]
+        # create the default v_icon
+        self.v_icon = v.Icon(left=True, children=[icon])
 
-        if icon:
-            self.set_icon(icon)
+        # set the default parameters
+        kwargs["color"] = kwargs.pop("color", "primary")
+        kwargs["children"] = kwargs.pop("children", [self.v_icon, text])
 
+        # call the constructor
         super().__init__(**kwargs)
 
     def set_icon(self, icon):
@@ -40,17 +42,13 @@ class Btn(v.Btn, SepalWidget):
         Return:
             self
         """
-        if self.v_icon:
-            self.v_icon.children = [icon]
-        else:
-            self.v_icon = v.Icon(left=True, children=[icon])
-            self.children = [self.v_icon] + self.children
+        self.v_icon.children = [icon]
 
         return self
 
     def toggle_loading(self):
         """
-        Jump between to states : disabled and loading - enabled and not loading
+        Jump between two states : disabled and loading - enabled and not loading
 
         Return:
             self
@@ -70,15 +68,22 @@ class DownloadBtn(v.Btn, SepalWidget):
     Args:
         text (str): the message inside the btn
         path (str, optional): the absolute to a downloadable content
+        args (dict, optional): any parameter from a v.Btn
     """
 
     def __init__(self, text, path="#", **kwargs):
 
-        self.class_ = "ma-2"
-        self.xs5 = True
-        self.color = "success"
-        self.children = [v.Icon(left=True, children=["mdi-download"]), text]
-        self.target = "_blank"
+        # create a download icon
+        v_icon = v.Icon(left=True, children=["mdi-download"])
+
+        # set default parameters
+        kwargs["class_"] = kwargs.pop("class_", "ma-2")
+        kwargs["xs5"] = kwargs.pop("xs5", True)
+        kwargs["color"] = kwargs.pop("color", "success")
+        kwargs["children"] = kwargs.pop("children", [v_icon, text])
+        kwargs["target"] = kwargs.pop("target", "_blank")
+
+        # call the constructor
         super().__init__(**kwargs)
 
         # create the URL

--- a/sepal_ui/sepalwidgets/inputs.py
+++ b/sepal_ui/sepalwidgets/inputs.py
@@ -34,7 +34,7 @@ class DatePicker(v.Layout, SepalWidget):
 
     Args:
         label (str, optional): the label of the datepicker field
-        kwargs (dict): any parameter from a v.Layout abject
+        kwargs (optional): any parameter from a v.Layout abject. If set, ['children'] will be overwritten.
 
     Attributes:
         menu (v.Menu): the menu widget to display the datepicker
@@ -76,9 +76,7 @@ class DatePicker(v.Layout, SepalWidget):
         kwargs["row"] = kwargs.pop("row", True)
         kwargs["class_"] = kwargs.pop("class_", "pa-5")
         kwargs["align_center"] = kwargs.pop("align_center", True)
-        kwargs["children"] = kwargs.pop(
-            "children", [v.Flex(xs10=True, children=[self.menu])]
-        )
+        kwargs["children"] = [v.Flex(xs10=True, children=[self.menu])]
 
         # call the constructor
         super().__init__(**kwargs)
@@ -100,6 +98,7 @@ class FileInput(v.Flex, SepalWidget):
         label (str): the label of the input
         v_model (str, optional): the default value
         clearable (bool, optional): wether or not to make the widget clearable. default to False
+        kwargs (optional): any parameter from a v.Flex abject. If set, ['children'] will be overwritten.
 
     Attributes:
         extentions ([str]): the extention list
@@ -179,9 +178,12 @@ class FileInput(v.Flex, SepalWidget):
         kwargs["row"] = kwargs.pop("row", True)
         kwargs["class_"] = kwargs.pop("class_", "d-flex align-center mb-2")
         kwargs["align_center"] = kwargs.pop("align_center", True)
-        kwargs["children"] = kwargs.pop(
-            "children", [self.clear, self.reload, self.file_menu, self.selected_file]
-        )
+        kwargs["children"] = [
+            self.clear,
+            self.reload,
+            self.file_menu,
+            self.selected_file,
+        ]
 
         # call the constructor
         super().__init__(**kwargs)
@@ -344,6 +346,10 @@ class LoadTableField(v.Col, SepalWidget):
     The relevant columns (lat, long and id) can then be identified in the updated select. Once everything is set, the widget will populate itself with a json dict.
     {pathname, id_column, lat_column,lng_column}
 
+    Args:
+        label (str, optional): the label of the widget
+        kwargs (optional): any parameter from a v.Col. If set, ['children', 'v_model'] will be overwritten.
+
     Attributes:
         fileInput (sw.FileInput): the file input to select the .csv or .txt file
         v_model (Traitlet): the json saved v_model shaped as {'pathname': xx, 'id_column': xx, 'lat_column': xx, 'lng_column': xx} The values can be accessed separately with the appropriate getter methods
@@ -359,7 +365,7 @@ class LoadTableField(v.Col, SepalWidget):
         "lng_column": None,
     }
 
-    def __init__(self, label="Table file"):
+    def __init__(self, label="Table file", **kwargs):
 
         self.fileInput = FileInput([".csv", ".txt"], label=label)
 
@@ -373,10 +379,17 @@ class LoadTableField(v.Col, SepalWidget):
             _metadata={"name": "lat_column"}, items=[], label="Latitude", v_model=None
         )
 
-        super().__init__(
-            v_model=self.default_v_model,
-            children=[self.fileInput, self.IdSelect, self.LngSelect, self.LatSelect],
-        )
+        # set default parameters
+        kwargs["v_model"] = self.default_v_model  # format of v_model is fixed
+        kwargs["children"] = [
+            self.fileInput,
+            self.IdSelect,
+            self.LngSelect,
+            self.LatSelect,
+        ]
+
+        # call the constructor
+        super().__init__(**kwargs)
 
         # link the dropdowns
         jslink((self.IdSelect, "items"), (self.LngSelect, "items"))
@@ -469,7 +482,7 @@ class AssetSelect(v.Combobox, SepalWidget):
         folder (str): the folder of the user assets
         default_asset (str, list): the id of a default asset or a list of defaults
         types ([str]): the list of asset type you want to display to the user. type need to be from: ['IMAGE', 'FOLDER', 'IMAGE_COLLECTION', 'TABLE','ALGORITHM']. Default to 'IMAGE' & 'TABLE'
-        kwargs (dict): any parameter from a v.ComboBox
+        kwargs (optional): any parameter from a v.ComboBox.
 
     Attributes:
         TYPES (dict, const): Valid ypes of asset.
@@ -507,7 +520,7 @@ class AssetSelect(v.Combobox, SepalWidget):
         self.folder = folder if folder else ee.data.getAssetRoots()[0]["id"]
         self.types = types
 
-        # Validate the input as soon as the object is insantiated
+        # Validate the input as soon as the object is instantiated
         self.observe(self._validate, "v_model")
 
         # load the assets in the combobox
@@ -520,7 +533,7 @@ class AssetSelect(v.Combobox, SepalWidget):
         kwargs["prepend_icon"] = kwargs.pop("prepend_icon", "mdi-cached")
         kwargs["class_"] = kwargs.pop("class_", "my-5")
         kwargs["placeholder"] = kwargs.pop(
-            "placeholder", "users/someCustomUser/customAsset"
+            "placeholder", ms.widgets.asset_select.placeholder
         )
 
         # create the widget
@@ -639,7 +652,7 @@ class PasswordField(v.TextField, SepalWidget):
 
     Args:
         label (str, optional): Header displayed in text area. Defaults to Password.
-        kwargs (dict); any parameter from a v.TextField
+        kwargs (dict); any parameter from a v.TextField. If set, ["type"] will be overwritten.
     """
 
     def __init__(self, **kwargs):
@@ -648,7 +661,7 @@ class PasswordField(v.TextField, SepalWidget):
         kwargs["label"] = kwargs.pop("label", "Password")
         kwargs["class_"] = kwargs.pop("class_", "mr-2")
         kwargs["v_model"] = kwargs.pop("v_model", "")
-        kwargs["type"] = kwargs.pop("type", "password")
+        kwargs["type"] = "password"
         kwargs["append_icon"] = kwargs.pop("append_icon", "mdi-ey-off")
 
         # init the widget with the remaining kwargs
@@ -675,7 +688,7 @@ class NumberField(v.TextField, SepalWidget):
     Args:
         max_ (int, optional): Maximum selectable number. Defaults to 10.
         min_ (int, optional): Minimum selectable number. Defaults to 0.
-        kwargs (dict, optional): Any parameter from a v.TextField
+        kwargs (dict, optional): Any parameter from a v.TextField. If set, ['type'] will be overwritten.
 
     """
 
@@ -685,7 +698,7 @@ class NumberField(v.TextField, SepalWidget):
     def __init__(self, **kwargs):
 
         # set default params
-        kwargs["type"] = kwargs.pop("type", "number")
+        kwargs["type"] = "number"
         kwargs["append_outer_icon"] = kwargs.pop("append_outer_icon", "mdi-plus")
         kwargs["prepend_icon"] = kwargs.pop("prepend_icon", "mdi-minus")
         kwargs["v_model"] = kwargs.pop("v_model", 0)
@@ -717,7 +730,7 @@ class VectorField(v.Col, SepalWidget):
         label (str): the label of the file input field, default to 'vector file'.
         gee (bool, optional): whether to use GEE assets or local vectors.
         folder (str, optional): When gee=True, extra args will be used for AssetSelect
-        kwargs (dict, optional): any parameter from a v.Col
+        kwargs (dict, optional): any parameter from a v.Col. if set, ['children'] will be overwritten.
 
     Attributes:
         original_gdf (geopandas.gdf): The originally selected dataframe
@@ -767,9 +780,7 @@ class VectorField(v.Col, SepalWidget):
         su.hide_component(self.w_value)
 
         # create the Col Field
-        kwargs["children"] = kwargs.pop(
-            "children", [self.w_file, self.w_column, self.w_value]
-        )
+        kwargs["children"] = [self.w_file, self.w_column, self.w_value]
 
         super().__init__(**kwargs)
 

--- a/sepal_ui/sepalwidgets/inputs.py
+++ b/sepal_ui/sepalwidgets/inputs.py
@@ -34,6 +34,7 @@ class DatePicker(v.Layout, SepalWidget):
 
     Args:
         label (str, optional): the label of the datepicker field
+        kwargs (dict): any parameter from a v.Layout abject
 
     Attributes:
         menu (v.Menu): the menu widget to display the datepicker
@@ -70,14 +71,17 @@ class DatePicker(v.Layout, SepalWidget):
             ],
         )
 
-        super().__init__(
-            v_model=None,
-            row=True,
-            class_="pa-5",
-            align_center=True,
-            children=[v.Flex(xs10=True, children=[self.menu])],
-            **kwargs,
+        # set the default parameter
+        kwargs["v_model"] = kwargs.pop("v_model", None)
+        kwargs["row"] = kwargs.pop("row", True)
+        kwargs["class_"] = kwargs.pop("class_", "pa-5")
+        kwargs["align_center"] = kwargs.pop("align_center", True)
+        kwargs["children"] = kwargs.pop(
+            "children", [v.Flex(xs10=True, children=[self.menu])]
         )
+
+        # call the constructor
+        super().__init__(**kwargs)
 
         jslink((date_picker, "v_model"), (date_text, "v_model"))
         jslink((date_picker, "v_model"), (self, "v_model"))
@@ -171,18 +175,16 @@ class FileInput(v.Flex, SepalWidget):
         if not clearable:
             su.hide_component(self.clear)
 
-        super().__init__(
-            row=True,
-            class_="d-flex align-center mb-2",
-            align_center=True,
-            children=[
-                self.clear,
-                self.reload,
-                self.file_menu,
-                self.selected_file,
-            ],
-            **kwargs,
+        # set default parameters
+        kwargs["row"] = kwargs.pop("row", True)
+        kwargs["class_"] = kwargs.pop("class_", "d-flex align-center mb-2")
+        kwargs["align_center"] = kwargs.pop("align_center", True)
+        kwargs["children"] = kwargs.pop(
+            "children", [self.clear, self.reload, self.file_menu, self.selected_file]
         )
+
+        # call the constructor
+        super().__init__(**kwargs)
 
         link((self.selected_file, "v_model"), (self, "file"))
         link((self.selected_file, "v_model"), (self, "v_model"))
@@ -467,6 +469,7 @@ class AssetSelect(v.Combobox, SepalWidget):
         folder (str): the folder of the user assets
         default_asset (str, list): the id of a default asset or a list of defaults
         types ([str]): the list of asset type you want to display to the user. type need to be from: ['IMAGE', 'FOLDER', 'IMAGE_COLLECTION', 'TABLE','ALGORITHM']. Default to 'IMAGE' & 'TABLE'
+        kwargs (dict): any parameter from a v.ComboBox
 
     Attributes:
         TYPES (dict, const): Valid ypes of asset.
@@ -507,18 +510,18 @@ class AssetSelect(v.Combobox, SepalWidget):
         # Validate the input as soon as the object is insantiated
         self.observe(self._validate, "v_model")
 
-        self.label = label
-
-        self.v_model = None
-        self.clearable = True
-        self.dense = True
-        self.prepend_icon = "mdi-cached"
-
-        self.class_ = "my-5"
-        self.placeholder = "users/someCustomUser/customAsset"
-
         # load the assets in the combobox
         self._get_items()
+
+        # set the default parameters
+        kwargs["v_model"] = kwargs.pop("v_model", None)
+        kwargs["clearable"] = kwargs.pop("clearable", True)
+        kwargs["dense"] = kwargs.pop("dense", True)
+        kwargs["prepend_icon"] = kwargs.pop("prepend_icon", "mdi-cached")
+        kwargs["class_"] = kwargs.pop("class_", "my-5")
+        kwargs["placeholder"] = kwargs.pop(
+            "placeholder", "users/someCustomUser/customAsset"
+        )
 
         # create the widget
         super().__init__(**kwargs)
@@ -636,16 +639,17 @@ class PasswordField(v.TextField, SepalWidget):
 
     Args:
         label (str, optional): Header displayed in text area. Defaults to Password.
+        kwargs (dict); any parameter from a v.TextField
     """
 
     def __init__(self, **kwargs):
 
         # default behavior
-        self.label = "Password"
-        self.class_ = "mr-2"
-        self.v_model = ""
-        self.type = "password"
-        self.append_icon = "mdi-eye-off"
+        kwargs["label"] = kwargs.pop("label", "Password")
+        kwargs["class_"] = kwargs.pop("class_", "mr-2")
+        kwargs["v_model"] = kwargs.pop("v_model", "")
+        kwargs["type"] = kwargs.pop("type", "password")
+        kwargs["append_icon"] = kwargs.pop("append_icon", "mdi-ey-off")
 
         # init the widget with the remaining kwargs
         super().__init__(**kwargs)
@@ -671,6 +675,7 @@ class NumberField(v.TextField, SepalWidget):
     Args:
         max_ (int, optional): Maximum selectable number. Defaults to 10.
         min_ (int, optional): Minimum selectable number. Defaults to 0.
+        kwargs (dict, optional): Any parameter from a v.TextField
 
     """
 
@@ -679,12 +684,14 @@ class NumberField(v.TextField, SepalWidget):
 
     def __init__(self, **kwargs):
 
-        self.type = "number"
-        self.append_outer_icon = "mdi-plus"
-        self.prepend_icon = "mdi-minus"
-        self.v_model = 0
-        self.readonly = True
+        # set default params
+        kwargs["type"] = kwargs.pop("type", "number")
+        kwargs["append_outer_icon"] = kwargs.pop("append_outer_icon", "mdi-plus")
+        kwargs["prepend_icon"] = kwargs.pop("prepend_icon", "mdi-minus")
+        kwargs["v_model"] = kwargs.pop("v_model", 0)
+        kwargs["readonly"] = kwargs.pop("readonly", True)
 
+        # call the constructor
         super().__init__(**kwargs)
 
         self.on_event("click:append-outer", self.increment)
@@ -709,7 +716,8 @@ class VectorField(v.Col, SepalWidget):
     Args:
         label (str): the label of the file input field, default to 'vector file'.
         gee (bool, optional): whether to use GEE assets or local vectors.
-        **asset_select_kwargs: When gee=True, extra args will be used for AssetSelect
+        folder (str, optional): When gee=True, extra args will be used for AssetSelect
+        kwargs (dict, optional): any parameter from a v.Col
 
     Attributes:
         original_gdf (geopandas.gdf): The originally selected dataframe
@@ -744,7 +752,7 @@ class VectorField(v.Col, SepalWidget):
             self.w_file = FileInput([".shp", ".geojson", ".gpkg", ".kml"], label=label)
         else:
             # Don't care about 'types' arg. It will only work with tables.
-            asset_select_kwargs = {k: v for k, v in kwargs.items() if k in ["folder"]}
+            asset_select_kwargs = {"folder": kwargs.pop("folder", None)}
             self.w_file = AssetSelect(types=["TABLE"], **asset_select_kwargs)
 
         self.w_column = v.Select(
@@ -759,7 +767,9 @@ class VectorField(v.Col, SepalWidget):
         su.hide_component(self.w_value)
 
         # create the Col Field
-        self.children = [self.w_file, self.w_column, self.w_value]
+        kwargs["children"] = kwargs.pop(
+            "children", [self.w_file, self.w_column, self.w_value]
+        )
 
         super().__init__(**kwargs)
 

--- a/sepal_ui/sepalwidgets/inputs.py
+++ b/sepal_ui/sepalwidgets/inputs.py
@@ -34,7 +34,7 @@ class DatePicker(v.Layout, SepalWidget):
 
     Args:
         label (str, optional): the label of the datepicker field
-        kwargs (optional): any parameter from a v.Layout abject. If set, ['children'] will be overwritten.
+        kwargs (optional): any parameter from a v.Layout abject. If set, 'children' will be overwritten.
 
     Attributes:
         menu (v.Menu): the menu widget to display the datepicker
@@ -98,7 +98,7 @@ class FileInput(v.Flex, SepalWidget):
         label (str): the label of the input
         v_model (str, optional): the default value
         clearable (bool, optional): wether or not to make the widget clearable. default to False
-        kwargs (optional): any parameter from a v.Flex abject. If set, ['children'] will be overwritten.
+        kwargs (optional): any parameter from a v.Flex abject. If set, 'children' will be overwritten.
 
     Attributes:
         extentions ([str]): the extention list
@@ -348,7 +348,7 @@ class LoadTableField(v.Col, SepalWidget):
 
     Args:
         label (str, optional): the label of the widget
-        kwargs (optional): any parameter from a v.Col. If set, ['children', 'v_model'] will be overwritten.
+        kwargs (optional): any parameter from a v.Col. If set, 'children' and 'v_model' will be overwritten.
 
     Attributes:
         fileInput (sw.FileInput): the file input to select the .csv or .txt file
@@ -652,7 +652,7 @@ class PasswordField(v.TextField, SepalWidget):
 
     Args:
         label (str, optional): Header displayed in text area. Defaults to Password.
-        kwargs (dict); any parameter from a v.TextField. If set, ["type"] will be overwritten.
+        kwargs (dict); any parameter from a v.TextField. If set, 'type' will be overwritten.
     """
 
     def __init__(self, **kwargs):
@@ -688,7 +688,7 @@ class NumberField(v.TextField, SepalWidget):
     Args:
         max_ (int, optional): Maximum selectable number. Defaults to 10.
         min_ (int, optional): Minimum selectable number. Defaults to 0.
-        kwargs (dict, optional): Any parameter from a v.TextField. If set, ['type'] will be overwritten.
+        kwargs (dict, optional): Any parameter from a v.TextField. If set, 'type' will be overwritten.
 
     """
 
@@ -730,7 +730,7 @@ class VectorField(v.Col, SepalWidget):
         label (str): the label of the file input field, default to 'vector file'.
         gee (bool, optional): whether to use GEE assets or local vectors.
         folder (str, optional): When gee=True, extra args will be used for AssetSelect
-        kwargs (dict, optional): any parameter from a v.Col. if set, ['children'] will be overwritten.
+        kwargs (dict, optional): any parameter from a v.Col. if set, 'children' will be overwritten.
 
     Attributes:
         original_gdf (geopandas.gdf): The originally selected dataframe

--- a/sepal_ui/sepalwidgets/sepalwidget.py
+++ b/sepal_ui/sepalwidgets/sepalwidget.py
@@ -90,7 +90,7 @@ class Markdown(v.Layout, SepalWidget):
 
     Args:
         mkd_str (str): the text to display using the markdown convention. multi-line string are also interpreted
-        kwargs (optional): Any parameter from a v.Layout. If set, ['children'] will be overwritten
+        kwargs (optional): Any parameter from a v.Layout. If set, 'children' will be overwritten
     """
 
     def __init__(self, mkd_str="", **kwargs):

--- a/sepal_ui/sepalwidgets/sepalwidget.py
+++ b/sepal_ui/sepalwidgets/sepalwidget.py
@@ -90,6 +90,7 @@ class Markdown(v.Layout, SepalWidget):
 
     Args:
         mkd_str (str): the text to display using the markdown convention. multi-line string are also interpreted
+        kwargs (optional): Any parameter from a v.Layout. If set, ['children'] will be overwritten
     """
 
     def __init__(self, mkd_str="", **kwargs):
@@ -112,9 +113,7 @@ class Markdown(v.Layout, SepalWidget):
         kwargs["row"] = kwargs.pop("row", True)
         kwargs["class_"] = kwargs.pop("class_", "pa-5")
         kwargs["align_center"] = kwargs.pop("align_center", True)
-        kwargs["children"] = kwargs.pop(
-            "children", [v.Flex(xs12=True, children=[content])]
-        )
+        kwargs["children"] = [v.Flex(xs12=True, children=[content])]
 
         # call the constructor
         super().__init__(**kwargs)

--- a/sepal_ui/sepalwidgets/sepalwidget.py
+++ b/sepal_ui/sepalwidgets/sepalwidget.py
@@ -108,13 +108,16 @@ class Markdown(v.Layout, SepalWidget):
 
         content = MyHTML()
 
-        super().__init__(
-            row=True,
-            class_="pa-5",
-            align_center=True,
-            children=[v.Flex(xs12=True, children=[content])],
-            **kwargs,
+        # set default parameters
+        kwargs["row"] = kwargs.pop("row", True)
+        kwargs["class_"] = kwargs.pop("class_", "pa-5")
+        kwargs["align_center"] = kwargs.pop("align_center", True)
+        kwargs["children"] = kwargs.pop(
+            "children", [v.Flex(xs12=True, children=[content])]
         )
+
+        # call the constructor
+        super().__init__(**kwargs)
 
 
 class Tooltip(v.Tooltip):
@@ -168,18 +171,12 @@ class CopyToClip(v.VuetifyTemplate):
     def __init__(self, **kwargs):
 
         # add the default params to kwargs
-        if "outlined" not in kwargs:
-            kwargs["outlined"] = True
-        if "label" not in kwargs:
-            kwargs["label"] = "Copy to clipboard"
-        if "readonly" not in kwargs:
-            kwargs["readonly"] = True
-        if "append_icon" not in kwargs:
-            kwargs["append_icon"] = "mdi-clipboard-outline"
-        if "v_model" not in kwargs:
-            kwargs["v_model"] = None
-        if "class_" not in kwargs:
-            kwargs["class_"] = "ma-5"
+        kwargs["outlined"] = kwargs.pop("outlined", True)
+        kwargs["label"] = kwargs.pop("label", "Copy To clipboard")
+        kwargs["readonly"] = kwargs.pop("readonly", True)
+        kwargs["append_icon"] = kwargs.pop("append_icon", "mdi-clipboard-outline")
+        kwargs["v_model"] = kwargs.pop("v_model", None)
+        kwargs["class_"] = kwargs.pop("class_", "ma-5")
 
         # set the default v_model
         self.v_model = kwargs["v_model"]

--- a/sepal_ui/sepalwidgets/tile.py
+++ b/sepal_ui/sepalwidgets/tile.py
@@ -22,6 +22,7 @@ class Tile(v.Layout, SepalWidget):
         inputs ([list]): the list of widget to display inside the tile
         btn (v.Btn): the process btn
         alert (sw.Alert): the alert to display process informations to the end user
+        kwargs (optional): any parameter from a v.Layout. if set, ['children', '_metadata'] will be overwritten.
     """
 
     def __init__(self, id_, title, inputs=[""], btn=None, alert=None, **kwargs):
@@ -43,11 +44,11 @@ class Tile(v.Layout, SepalWidget):
         )
 
         # set some default parameters
-        kwargs["_metadata"] = kwargs.pop("_metadata", {"mount_id": id_})
+        kwargs["_metadata"] = {"mount_id": id_}
         kwargs["row"] = kwargs.pop("row", True)
         kwargs["align_center"] = kwargs.pop("align_center", True)
         kwargs["class_"] = kwargs.pop("class_", "ma-5 d-inline")
-        kwargs["children"] = kwargs.pop("children", [card])
+        kwargs["children"] = [card]
 
         # call the constructor
         super().__init__(**kwargs)
@@ -189,7 +190,7 @@ class TileAbout(Tile):
 
         content = Markdown(about)
 
-        super().__init__("about_tile", "About", inputs=[content], **kwargs)
+        super().__init__("about_tile", "About", inputs=[content])
 
 
 class TileDisclaimer(Tile):
@@ -198,7 +199,7 @@ class TileDisclaimer(Tile):
     This tile will have the "about_widget" id and "Disclaimer" title.
     """
 
-    def __init__(self, **kwargs):
+    def __init__(self):
 
         pathname = Path(__file__).parents[1] / "scripts" / "disclaimer.md"
 
@@ -208,4 +209,4 @@ class TileDisclaimer(Tile):
 
         content = Markdown(disclaimer)
 
-        super().__init__("about_tile", "Disclaimer", inputs=[content], **kwargs)
+        super().__init__("about_tile", "Disclaimer", inputs=[content])

--- a/sepal_ui/sepalwidgets/tile.py
+++ b/sepal_ui/sepalwidgets/tile.py
@@ -42,15 +42,15 @@ class Tile(v.Layout, SepalWidget):
             class_="pa-5", raised=True, xs12=True, children=[self.title] + content
         )
 
-        super().__init__(
-            _metadata={"mount_id": id_},
-            row=True,
-            align_center=True,
-            class_="ma-5 d-inline",
-            xs12=True,
-            children=[card],
-            **kwargs
-        )
+        # set some default parameters
+        kwargs["_metadata"] = kwargs.pop("_metadata", {"mount_id": id_})
+        kwargs["row"] = kwargs.pop("row", True)
+        kwargs["align_center"] = kwargs.pop("align_center", True)
+        kwargs["class_"] = kwargs.pop("class_", "ma-5 d-inline")
+        kwargs["children"] = kwargs.pop("children", [card])
+
+        # call the constructor
+        super().__init__(**kwargs)
 
     def nest(self):
         """

--- a/sepal_ui/sepalwidgets/tile.py
+++ b/sepal_ui/sepalwidgets/tile.py
@@ -22,7 +22,7 @@ class Tile(v.Layout, SepalWidget):
         inputs ([list]): the list of widget to display inside the tile
         btn (v.Btn): the process btn
         alert (sw.Alert): the alert to display process informations to the end user
-        kwargs (optional): any parameter from a v.Layout. if set, ['children', '_metadata'] will be overwritten.
+        kwargs (optional): any parameter from a v.Layout. if set, 'children' and '_metadata' will be overwritten.
     """
 
     def __init__(self, id_, title, inputs=[""], btn=None, alert=None, **kwargs):

--- a/tests/test_Btn.py
+++ b/tests/test_Btn.py
@@ -10,8 +10,8 @@ class TestBtn:
         # minimal btn
         btn = sw.Btn()
         assert btn.color == "primary"
-        assert btn.v_icon == None
-        assert btn.children[0] == "Click"
+        assert btn.v_icon.children[0] == ""
+        assert btn.children[1] == "Click"
 
         # extensive btn
         btn = sw.Btn("toto", "mdi-folder")


### PR DESCRIPTION
- Avoid the duplication of parameters using an elegant and more pythonic method.
- force the values of the one that we don't want user to overwrite (`children` usually) 
- easyer to read 
- faster to execute as it doesn't require updating traits but just a dict