### PR TITLE
build: set a minimal python version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,6 +26,7 @@ setup(
             "bin/module_factory",
         ]
     },
+    python_requires=">=3.6.9",
     version=version,
     license="MIT",
     description="Wrapper for ipyvuetify widgets to unify the display of voila dashboards in SEPAL platform",
@@ -60,5 +61,8 @@ setup(
         "Topic :: Software Development :: Build Tools",
         "License :: OSI Approved :: MIT License",
         "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
     ],
 )


### PR DESCRIPTION
As some of our build will be blocked when 3.6 will be dropped, I suggest we enforce the python version in setup as suggested [here](https://stackoverflow.com/questions/13924931/setup-py-restrict-the-allowable-version-of-the-python-interpreter). When we'll drop the 3.6 build, the previous version will be retreive automatically by pip if needed