### PR TITLE
make the viz member as a trait

### DIFF
--- a/docs/source/widgets/sepal_widget.rst
+++ b/docs/source/widgets/sepal_widget.rst
@@ -4,7 +4,7 @@ SepalWidget
 Overview
 --------
 
-:code:`SepalWidget` is an abstract object that embed special classes, it can be used with any ipyvuetify widget component:
+:code:`SepalWidget` is an abstract object that embed special methods, it can be used with any ipyvuetify widget component:
 
 .. jupyter-execute::
     :raises:
@@ -53,6 +53,14 @@ Hide the component by changing its class.
             
     sepal_select = SepalSelect()
     sepal_select.hide()
+    
+.. note::
+
+    the component can also be hidden by setting:
+    
+    .. code-block:: python
+        
+        sepal_select.viz = False
 
 show
 ^^^^
@@ -77,6 +85,14 @@ Show the component by changing its class.
             
     sepal_select = SepalSelect()
     sepal_select.hide().show()
+    
+.. note::
+
+    the component can also be shown by setting:
+    
+    .. code-block:: python
+        
+        sepal_select.viz = True
 
 reset
 ^^^^^

--- a/sepal_ui/sepalwidgets/sepalwidget.py
+++ b/sepal_ui/sepalwidgets/sepalwidget.py
@@ -15,7 +15,7 @@ class SepalWidget(v.VuetifyWidget):
     """
 
     viz = Bool(True).tag(sync=True)
-    "Bool: weather the file is displayed or not"
+    "Bool: whether the widget is displayed or not"
 
     old_class = ""
     "str: a saving attribute of the widget class"

--- a/sepal_ui/sepalwidgets/sepalwidget.py
+++ b/sepal_ui/sepalwidgets/sepalwidget.py
@@ -15,7 +15,7 @@ class SepalWidget(v.VuetifyWidget):
     """
 
     viz = Bool(True).tag(sync=True)
-    "bool: weather the file is displayed or not"
+    "Bool: weather the file is displayed or not"
 
     old_class = ""
     "str: a saving attribute of the widget class"

--- a/sepal_ui/sepalwidgets/sepalwidget.py
+++ b/sepal_ui/sepalwidgets/sepalwidget.py
@@ -1,6 +1,6 @@
 import ipyvuetify as v
 from markdown import markdown
-from traitlets import Unicode, Any
+from traitlets import Unicode, Any, Bool, observe
 from ipywidgets import link
 from deprecated.sphinx import versionadded
 
@@ -14,11 +14,24 @@ class SepalWidget(v.VuetifyWidget):
     Custom vuetifyWidget to add specific methods
     """
 
-    viz = True
-    "bool:  weather the file is displayed or not"
+    viz = Bool(True).tag(sync=True)
+    "bool: weather the file is displayed or not"
 
     old_class = ""
     "str: a saving attribute of the widget class"
+
+    @observe("viz")
+    def _set_viz(self, change):
+        """
+        hide or show the component according to its viz param value
+
+        Args:
+            change: the dict of a trait callback
+        """
+
+        self.show() if change["new"] else self.hide()
+
+        return
 
     def toggle_viz(self):
         """
@@ -28,7 +41,9 @@ class SepalWidget(v.VuetifyWidget):
             self
         """
 
-        return self.hide() if self.viz else self.show()
+        self.viz = not self.viz
+
+        return self
 
     def hide(self):
         """
@@ -68,7 +83,7 @@ class SepalWidget(v.VuetifyWidget):
 
     def reset(self):
         """
-        Clear the widget v_model. Need to be extented in custom widgets to fit the structure of the actual input
+        Clear the widget v_model. Need to be extented in custom widgets to fit the structure of the actual input.
 
         Return:
             self

--- a/tests/test_SepalWidget.py
+++ b/tests/test_SepalWidget.py
@@ -10,6 +10,18 @@ class TestSepalWidget:
 
         return
 
+    def test_set_viz(self, widget):
+
+        # hide the widget
+        widget.viz = False
+        assert "d-none" in str(widget.class_)
+
+        # show it
+        widget.viz = True
+        assert not "d-none" in str(widget.class_)
+
+        return
+
     def test_show(self, widget):
 
         widget.class_ = "d-none"


### PR DESCRIPTION
fix #341 

- set the viz member as a bool trait 
- call `hide`or `show`according to the value of `viz` trait 
- make the `toggle_viz` simply toggle the viz value (I think it should be deprecated at some point in the future

the only issue is that when you call `hide` (or `show`) and there is effectivelly a modification, it will be called twice:

1. byt the effective call to `hide`
2. by the callback when the viz value is changed

That is not costing any sensible time but if you have any idea on how to fix it ;-)