### PR TITLE
use SEPAL viz params embeded in the Image metadata to display asset

### DIFF
--- a/docs/source/modules/sepal_ui.mapping.SepalMap.rst
+++ b/docs/source/modules/sepal_ui.mapping.SepalMap.rst
@@ -25,7 +25,9 @@ sepal\_ui.mapping.SepalMap
         ~SepalMap.show_dc
         ~SepalMap.hide_dc
         ~SepalMap.add_colorbar
+        ~SepalMap.addLayer
         ~SepalMap.get_basemap_list
+        ~SepalMap.get_viz_params
         
 .. automethod:: sepal_ui.mapping.SepalMap.set_drawing_controls
 
@@ -43,4 +45,8 @@ sepal\_ui.mapping.SepalMap
 
 .. automethod:: sepal_ui.mapping.SepalMap.add_colorbar
 
+.. automethod:: sepal_ui.mapping.SepalMap.addLayer
+
 .. automethod:: sepal_ui.mapping.SepalMap.get_basemap_list
+
+.. automethod:: sepal_ui.mapping.SepalMap.get_viz_params

--- a/sepal_ui/mapping/mapping.py
+++ b/sepal_ui/mapping/mapping.py
@@ -622,6 +622,14 @@ class SepalMap(geemap.Map):
                 args[0] = args[0].select(args[1]["bands"][0]).sldStyle(sld_intervals)
                 args[1] = {}
 
+            # specific case of hsv
+            elif args[1]["type"] == "hsv":
+
+                args[0] = args[0].select(args[1]["bands"]).rgbToHsv()
+                args[1]["bands"] = ["hue", "saturation", "value"]
+                args[1]["max"] = [1, 1, 1]
+                args[1]["min"] = [0, 0, 0]
+
         # call the function using the replacing the empty viz params with the new one.
         super().addLayer(*args, **kwargs)
 

--- a/sepal_ui/mapping/mapping.py
+++ b/sepal_ui/mapping/mapping.py
@@ -603,6 +603,20 @@ class SepalMap(geemap.Map):
                     f"the provided viz_name ({viz_name}) cannot be found in the image metadata"
                 )
 
+            # invert the bands if needed
+            inverted = args[1].pop("inverted", None)
+            if inverted is not None:
+
+                # get the index of the bands taht need to be inverted
+                index_list = [i for i, v in enumerate(inverted) if v is True]
+
+                # multiply everything by -1
+                for i in index_list:
+                    min_ = args[1]["min"][i]
+                    max_ = args[1]["max"][i]
+                    args[1]["min"][i] = max_
+                    args[1]["max"][i] = min_
+
             # specific case of categorical images
             # Pad the palette when using non-consecutive values
             # instead of remapping or using sldStyle
@@ -656,8 +670,6 @@ class SepalMap(geemap.Map):
                 # set the arguments
                 args[0] = asset.select(args[1]["bands"]).hsvToRgb()
                 args[1]["bands"] = ["red", "green", "blue"]
-                args[1]["max"] = 1
-                args[1]["min"] = 0
 
         # call the function using the replacing the empty viz params with the new one.
         super().addLayer(*args, **kwargs)

--- a/sepal_ui/mapping/mapping.py
+++ b/sepal_ui/mapping/mapping.py
@@ -604,23 +604,29 @@ class SepalMap(geemap.Map):
                 )
 
             # specific case of categorical images
-            # define an SLD style for each value
+            # Pad the palette when using non-consecutive values
+            # instead of remapping or using sldStyle
+            # to preserve the class values in the image, for inspection
             if args[1]["type"] == "categorical":
 
-                sld_intervals = (
-                    '<RasterSymbolizer><ColorMap type="intervals" extended="false">'
-                )
-                for i in range(len(args[1]["palette"])):
-                    c = args[1]["palette"][i]
-                    v = args[1]["values"][i]
-                    l = args[1]["labels"][i]
-                    sld_intervals += (
-                        f'<ColorMapEntry color="{c}" quantity="{v}" label="{l}"/>'
-                    )
-                sld_intervals += "</ColorMap></RasterSymbolizer>"
+                colors = args[1]["palette"]
+                values = args[1]["values"]
+                min_ = min(values)
+                max_ = max(values)
 
-                args[0] = args[0].select(args[1]["bands"][0]).sldStyle(sld_intervals)
-                args[1] = {}
+                # set up a black palette of correct length
+                palette = ["#000000"] * (max_ - min_ + 1)
+
+                print(len(palette))
+
+                # replace the values within the palette
+                for i, v in enumerate(values):
+                    palette[v - min_] = colors[i]
+
+                # adapt the vizparams
+                args[1]["palette"] = palette
+                args[1]["min"] = min_
+                args[1]["max"] = max_
 
             # specific case of hsv
             elif args[1]["type"] == "hsv":

--- a/sepal_ui/mapping/mapping.py
+++ b/sepal_ui/mapping/mapping.py
@@ -592,8 +592,14 @@ class SepalMap(geemap.Map):
 
         # apply it to args[1]
         if args[1] == {} and viz_params != {}:
-            props = next(i for p, i in viz_params.items() if i["name"] == viz_name)
-            args[1] = props or {}
+            try:
+                args[1] = next(
+                    i for p, i in viz_params.items() if i["name"] == viz_name
+                )
+            except StopIteration:
+                raise ValueError(
+                    f"the provided viz_name ({viz_name}) cannot be found in the image metadata"
+                )
 
         # call the function using the replacing the empty viz params with the new one.
         super().addLayer(*args, **kwargs)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -101,3 +101,10 @@ def asset_id(asset_description):
     """return a test asset id"""
 
     return f"users/bornToBeAlive/sepal_ui_test/{asset_description}"
+
+
+@pytest.fixture(scope="session")
+def asset_image_viz():
+    """return a test asset id"""
+
+    return "users/bornToBeAlive/sepal_ui_test/imageViZExample"

--- a/tests/test_SepalMap.py
+++ b/tests/test_SepalMap.py
@@ -260,3 +260,70 @@ class TestSepalMap:
         assert len(m.controls) == 6  # only thing I can check
 
         return
+
+    def test_addLayer(self, asset_image_viz):
+
+        # create map and image
+        image = ee.Image(asset_image_viz)
+        m = sm.SepalMap()
+
+        # display all the viz available in the image
+        for viz in sm.SepalMap.get_viz_params(image).values():
+            m.addLayer(image, {}, viz["name"], viz_name=viz["name"])
+
+        assert len(m.layers) == 5
+
+        return
+
+    def test_get_viz_params(self, asset_image_viz):
+
+        image = ee.Image(asset_image_viz)
+
+        res = sm.SepalMap.get_viz_params(image)
+
+        expected = {
+            "1": {
+                "bands": ["ndwi_phase_1", "ndwi_amplitude_1", "ndwi_rmse"],
+                "max": [2.40625, 3296.0, 1792.0],
+                "name": "NDWI harmonics",
+                "min": [-2.1875, 352.0, 320.0],
+                "type": "hsv",
+                "inverted": [False, False, True],
+            },
+            "3": {
+                "labels": ["Foo", "Bar", "Baz"],
+                "bands": ["class"],
+                "type": "categorical",
+                "name": "Classification",
+                "values": [5, 200, 1000],
+                "palette": ["#042333", "#b15f82", "#e8fa5b"],
+            },
+            "2": {
+                "bands": ["ndwi"],
+                "name": "NDWI",
+                "min": -8450,
+                "max": 6610,
+                "type": "continuous",
+                "palette": [
+                    "#042333",
+                    "#2c3395",
+                    "#744992",
+                    "#b15f82",
+                    "#eb7958",
+                    "#fbb43d",
+                    "#e8fa5b",
+                ],
+            },
+            "0": {
+                "max": 2000,
+                "type": "rgb",
+                "min": 0,
+                "name": "RGB",
+                "gamma": 1.2,
+                "bands": ["red", "green", "blue"],
+            },
+        }
+
+        assert res == expected
+
+        return

--- a/tests/test_gee.py
+++ b/tests/test_gee.py
@@ -57,7 +57,7 @@ class TestGee:
         list_ = gee.get_assets(gee_dir)
 
         # check that they are all there
-        names = ["corsica_template", "folder", "france", "italy"]
+        names = ["corsica_template", "folder", "france", "imageViZExample", "italy"]
 
         for item, name in zip(list_, names):
             assert item["name"] == f"{gee_dir}/{name}"


### PR DESCRIPTION
Fix #278  

Here is an example file to discover the display options: users/bornToBeAlive/imageViZExample

It is embeding all the possible combination of viz params that SEPAL produces. 

to get them all displayed: 
```python
from sepal_ui import mapping as sm
import ee

image = ee.Image("users/bornToBeAlive/imageViZExample")
sm.SepalMap.get_viz_params(image)
```

display this asset in a map using one of the available viz params: 

```python
from sepal_ui import mapping as sm 
import ee

m = sm.SepalMap()
image = ee.Image("users/bornToBeAlive/imageViZExample")
m.addLayer(image, {}, "test", viz_name="NDWI")
m.zoom_ee_object(image.geometry())
m
```
![Capture d’écran 2021-12-03 à 22 55 34](https://user-images.githubusercontent.com/12596392/144677925-eff2504c-cf15-41cb-95eb-d4c529af4751.png)

I still cannot manage to deal with inverted bands (in `NDWI harmonics`), if you have any idea be my guest ;-) 

## EDIT

managed inverted and hsv images: 

```python
from sepal_ui import mapping as sm 
import ee

ee.Initialize() 

m = sm.SepalMap()
image = ee.Image("users/bornToBeAlive/sepal_ui_test/imageViZExample")
m.addLayer(image, {}, "test", viz_name="NDWI harmonics")
m.zoom_ee_object(image.geometry())
m
```

![Capture d’écran 2021-12-06 à 17 22 49](https://user-images.githubusercontent.com/12596392/144883044-ece4dc3d-981c-40ce-99af-56c348b9d841.png)



