### PR TITLE
fix: solve the build issue in SEPAL

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -65,7 +65,18 @@ setup_params = {
             "pandoc",
         ],
     },
-    "packages": ["sepal_ui"],
+    "packages": [
+        "sepal_ui",
+        "sepal_ui.scripts",
+        "sepal_ui.frontend",
+        "sepal_ui.sepalwidgets",
+        "sepal_ui.aoi",
+        "sepal_ui.message",
+        "sepal_ui.mapping",
+        "sepal_ui.translator",
+        "sepal_ui.model",
+        "sepal_ui.reclassify",
+    ],
     "package_data": {
         "sepal_ui": [
             "scripts/*.csv",

--- a/setup.py
+++ b/setup.py
@@ -45,6 +45,7 @@ setup_params = {
         "Unidecode",
         "natsort",
         "pipreqs",
+        "cryptography",
     ],
     "extras_require": {
         "dev": [
@@ -52,7 +53,6 @@ setup_params = {
         ],
         "test": [
             "coverage",
-            "cryptography",
             "pytest",
         ],
         "doc": [


### PR DESCRIPTION
- the previous build was not instaling all the packages when coming from pipy
- the previous build was missing cryptography that is imported even if it's never used outside of a test env (thank you flake8)
- I'll publish the fix directly and import it to my local computer to test it. If it doesn't work I can still remove this release from pipy