### PR TITLE
docs: expose the code in the doc

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -5,4 +5,4 @@
 ignore = E501, W605, W503
 
 # init file are here to hide the internal structure to the user of the lib
-exclude = */__init__.py
+exclude = */__init__.py, docs/source/conf.py

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -46,6 +46,7 @@ extensions = [
     "sphinx_copybutton",
     "sphinx.ext.napoleon",
     "sphinx.ext.autosummary",
+    "sphinx.ext.viewcode",
     "notfound.extension",
     "sphinxcontrib.spelling",
     "_extentions.video",


### PR DESCRIPTION
I wanted to overwrite a method from a specific object. I was scrolling in the doc and I realized that I was unable to really dive into my function if I wanted to remember how it works. 

I simply added an extension to Sphinx and now the classes and functions have a little `[source]` link. click it and you'll see the corresponding code highlighted in the specific doc page. 

I found it useful. let me know what you think.
a demo page with multiple source entries: https://sepal-ui--367.org.readthedocs.build/en/367/modules/sepal_ui.aoi.AoiModel.html#sepal_ui.aoi.AoiModel.set_default