### PR TITLE
DownloadBtn links

### DIFF
--- a/sepal_ui/scripts/utils.py
+++ b/sepal_ui/scripts/utils.py
@@ -13,6 +13,7 @@ from itertools import product
 import ee
 from cryptography.fernet import Fernet
 from matplotlib import colors as c
+from deprecated.sphinx import deprecated
 
 import sepal_ui
 
@@ -64,21 +65,29 @@ def create_download_link(pathname):
         (str): the download link
     """
 
-    if type(pathname) == str:
-        pathname = Path(pathname)
+    # return the link if it's an absolute url
+    if isinstance(pathname, str) and bool(urlparse(str(pathname)).netloc):
+        return pathname
 
-    result_path = Path(pathname).expanduser()
-    home_path = Path("~").expanduser()
+    # create a downloadable link from the jupyter node
+    pathname = Path(pathname)
+    try:
+        download_path = pathname.relative_to(Path.home())
+    except ValueError:
+        download_path = pathname
 
-    # will be available with python 3.9
-    # download_path = result_path.relative_to(home_path) if result_path.is_relative_to(home_path) else result_path
-    download_path = os.path.relpath(result_path, home_path)
-
-    link = f"/api/files/download?path=/{download_path}"
+    # I want to use the ipyurl lib to guess the url of the Jupyter server on the fly
+    # but I don't really understand how it works
+    # so here is an ugly fix only compatible with SEPAL
+    link = f"https://sepal.io/api/sandbox/jupyter/files/{download_path}"
 
     return link
 
 
+@deprecated(
+    version="2.5.4",
+    reason="This function makes no sense outside of create_download_link. It will be removed in the next minor version",
+)
 def is_absolute(url):
     """
     Check if the given URL is an absolute or relative path

--- a/sepal_ui/sepalwidgets/btn.py
+++ b/sepal_ui/sepalwidgets/btn.py
@@ -1,7 +1,8 @@
+from pathlib import Path
 import ipyvuetify as v
 
 from sepal_ui.sepalwidgets.sepalwidget import SepalWidget
-from ..scripts import utils as su
+from sepal_ui.scripts import utils as su
 
 __all__ = ["Btn", "DownloadBtn"]
 
@@ -73,7 +74,7 @@ class DownloadBtn(v.Btn, SepalWidget):
 
     Args:
         text (str): the message inside the btn
-        path (str, optional): the absolute to a downloadable content
+        path (str|pathlib.Path, optional): the absoluteor relative path to a downloadable content
         args (dict, optional): any parameter from a v.Btn. if set, 'children' and 'target' will be overwritten.
     """
 
@@ -88,6 +89,7 @@ class DownloadBtn(v.Btn, SepalWidget):
         kwargs["color"] = kwargs.pop("color", "success")
         kwargs["children"] = [v_icon, text]
         kwargs["target"] = "_blank"
+        kwargs["attributes"] = {"download": True}
 
         # call the constructor
         super().__init__(**kwargs)
@@ -101,18 +103,20 @@ class DownloadBtn(v.Btn, SepalWidget):
         If nothing is provided the btn is disabled
 
         Args:
-            path (str): the absolute path to a downloadable content
+            path (str|pathlib.Path): the absolute path to a downloadable content
 
         Return:
             self
         """
 
-        if su.is_absolute(path):
-            url = path
-        else:
-            url = su.create_download_link(path)
-
+        # set the url
+        url = su.create_download_link(path)
         self.href = url
-        self.disabled = path == "#"
+
+        # set the download attribute
+        self.attributes = {"download": Path(path).name}
+
+        # unable or disable the btn
+        self.disabled = str(path) == "#"
 
         return self

--- a/sepal_ui/sepalwidgets/btn.py
+++ b/sepal_ui/sepalwidgets/btn.py
@@ -89,7 +89,7 @@ class DownloadBtn(v.Btn, SepalWidget):
         kwargs["color"] = kwargs.pop("color", "success")
         kwargs["children"] = [v_icon, text]
         kwargs["target"] = "_blank"
-        kwargs["attributes"] = {"download": True}
+        kwargs["attributes"] = {"download": None}
 
         # call the constructor
         super().__init__(**kwargs)
@@ -113,10 +113,11 @@ class DownloadBtn(v.Btn, SepalWidget):
         url = su.create_download_link(path)
         self.href = url
 
-        # set the download attribute
-        self.attributes = {"download": Path(path).name}
-
         # unable or disable the btn
         self.disabled = str(path) == "#"
+
+        # set the download attribute
+        name = None if str(path) == "#" else Path(path).name
+        self.attributes = {"download": name}
 
         return self

--- a/tests/test_DownloadBtn.py
+++ b/tests/test_DownloadBtn.py
@@ -1,28 +1,31 @@
+import pytest
+
 from sepal_ui import sepalwidgets as sw
 from sepal_ui.scripts.utils import create_download_link
 
 
 class TestDownloadBtn:
-    def test_init(self):
+    def test_init(self, file_start):
 
         # default init
         txt = "toto"
         btn = sw.DownloadBtn(txt)
-        start = "/api/files/download?path="
 
         assert isinstance(btn, sw.DownloadBtn)
         assert btn.children[0].children[0] == "mdi-download"
         assert btn.children[1] == txt
-        assert start in btn.href
+        assert file_start in btn.href
         assert "#" in btn.href
         assert btn.target == "_blank"
         assert btn.disabled is True
+        assert btn.attributes["download"] is None
 
         # exhaustive
         link = "toto/ici"
         btn = sw.DownloadBtn(txt, link)
         assert link in btn.href
         assert btn.disabled is False
+        assert btn.attributes["download"] is not None
 
         # absolute link
         absolute_link = "http://www.fao.org/home/en/"
@@ -46,23 +49,30 @@ class TestDownloadBtn:
         assert res == btn
         assert link in btn.href
         assert btn.disabled is False
+        assert btn.attributes["download"] is not None
 
         # reset
         btn.set_url()
         assert "#" in btn.href
         assert btn.disabled is True
+        assert btn.attributes["download"] is None
 
         return
 
-    def test_create_download_link(self):
+    def test_create_download_link(self, file_start):
 
         # relative link
-        start = "/api/files/download?path="
         relative_link = "toto/ici"
 
         path = create_download_link(relative_link)
 
-        assert start in path
+        assert file_start in path
         assert relative_link in path
 
         return
+
+    @pytest.fixture
+    def file_start(self):
+        """the start of any link to the sepal platform"""
+
+        return "https://sepal.io/api/sandbox/jupyter/files/"

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -47,7 +47,7 @@ class TestUtils:
         # check the URL for a 'toto/tutu.png' path
         path = "toto/tutu.png"
 
-        expected_link = "/api/files/download?path="
+        expected_link = "https://sepal.io/api/sandbox/jupyter/files/"
 
         res = su.create_download_link(path)
 
@@ -296,3 +296,5 @@ class TestUtils:
         assert su.next_string(input_string) == output_string
         assert su.next_string(input_string)[-1].isdigit()
         assert su.next_string("name_1") == "name_2"
+
+        return


### PR DESCRIPTION
The SEPAL framework have changed and the entrypoint to file is no longer `/api/files/download?path=`. Instead of relying on SEPAL I tried to use the Jupyter entrypoint (that is always active as the apps are running through Jupyter notebook). 

i.e. I'm now using `https://sepal.io/api/sandbox/jupyter/files`and add 1 extra `download` attribute to the btn. 