### PR TITLE
use fontawesome instead of mdi icons

### DIFF
--- a/docs/source/tutorials/add-tile.rst
+++ b/docs/source/tutorials/add-tile.rst
@@ -135,7 +135,7 @@ in the :code:`app_items` list, add a :code:`DrawerItem` corresponding to your ti
         # [...]
         sw.DrawerItem(
             title = ms.app.drawer_item.aoi, 
-            icon 'mdi-cog',  # optional
+            icon 'fas fa-cogs',  # optional
             card="my_tile"
         )
     ]

--- a/docs/source/tutorials/custom-widget.rst
+++ b/docs/source/tutorials/custom-widget.rst
@@ -69,7 +69,7 @@ Here we will create the object with its expected attributes
         def __init__(self, label="Password", **kwargs):
 
             # create the eye icon
-            self.eye = v.Icon(class_ = 'ml-1', children=['mdi-eye'])
+            self.eye = v.Icon(class_ = 'ml-1', children=['fas fa-eye'])
 
             # create the texfied 
             self.text_field = v.TextField(
@@ -99,7 +99,7 @@ toggle the visibility
 
 Now we want to add a behavior to our object. When we click on the eye, the :code:`PasswordField` should toggle its visibility: 
 
-* The eye should switch from :code:`mdi-eye` and :code:`mdi-eye-off`
+* The eye should switch from :code:`fas fa-eye` and :code:`fas fa-eye-slash`
 * The text_field should switch from type :code:`password` to :code:`text`
 
 To do so we will first add 2 class static variable (caps lock) to list the 2 types and icon and set them on the two attributes of my class. a new attribute needs to be created to remind the current state of the password. 
@@ -114,7 +114,7 @@ I'll call it :code:`password_viz` as the :code:`viz` parameter is already an att
 
     class PasswordField(sw.SepalWidget, v.Layout):
 
-        EYE_ICONS = ['mdi-eye', 'mdi-eye-off'] # new icon list
+        EYE_ICONS = ['fas fa-eye', 'fas fa-eye-slash'] # new icon list
         TYPES = ['password', 'text'] # new type list
    
         def __init__(self, label="Password", **kwargs):
@@ -200,7 +200,7 @@ finally we obtain the following reusable widget :
 
     class PasswordField(sw.SepalWidget, v.Layout):
 
-        EYE_ICONS = ['mdi-eye', 'mdi-eye-off'] # new icon list
+        EYE_ICONS = ['fas fa-eye', 'fas fa-eye-slash'] # new icon list
         TYPES = ['password', 'text'] # new type list
    
         def __init__(self, label="Password", **kwargs):

--- a/docs/source/widgets/btn.rst
+++ b/docs/source/widgets/btn.rst
@@ -5,7 +5,7 @@ Overview
 --------
 
 :code:`Btn` is custom widget to provide easy to use button in the sepal_ui framework. it inherits from the :code:`SepalWidget` class.
-Any argument from the original :code:`Btn` ipyvuetify class can be used to complement it. The button icon needs to be searched in the `mdi library <https://materialdesignicons.com>`_, if none is set, a :code:`mdi-check` will be used.
+Any argument from the original :code:`Btn` ipyvuetify class can be used to complement it. The button icon needs to be searched in the `fontAwesome library <https://fontawesome.com/v5.15/icons>`__ or mdi library <https://materialdesignicons.com>`_, if none is set, a :code:`fas fa-check` will be used.
 The default color is set to "primary".  
 
 .. jupyter-execute:: 
@@ -20,7 +20,7 @@ The default color is set to "primary".
     
     btn = sw.Btn(
         text = "The One btn",
-        icon = "mdi-cogs"
+        icon = "fas fa-cogs"
     )
     btn
     
@@ -41,7 +41,7 @@ Btn can be used to launch function on any Javascript event such as "click".
     
     btn = sw.Btn(
         text = "The One btn",
-        icon = "mdi-cogs"
+        icon = "fas fa-cogs"
     )
     btn.on_event('click', lambda *args: print('Hello world!'))
     

--- a/sepal_ui/frontend/styles.py
+++ b/sepal_ui/frontend/styles.py
@@ -34,6 +34,7 @@ class Styles(v.VuetifyTemplate):
             .leaflet-top, .leaflet-bottom {z-index : 2 !important;}
             main.v-content {padding-top: 0px !important;}
         </style>
+        <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.4/css/all.min.css"/>
     """
     ).tag(sync=True)
     "Unicode: the trait embeding the maps style"
@@ -60,12 +61,12 @@ AOI_STYLE = {
 }
 
 
-_folder = {"color": "amber", "icon": "mdi-folder-outline"}
-_table = {"color": "green accent-4", "icon": "mdi-border-all"}
-_vector = {"color": "deep-purple", "icon": "mdi-vector-polyline"}
-_other = {"color": "light-blue", "icon": "mdi-file-outline"}
-_parent = {"color": "white", "icon": "mdi-folder-upload-outline"}
-_image = {"color": "deep-purple", "icon": "mdi-image-outline"}
+_folder = {"color": "amber", "icon": "far fa-folder"}
+_table = {"color": "green accent-4", "icon": "far fa-table"}
+_vector = {"color": "deep-purple", "icon": "far fa-vector-square"}
+_other = {"color": "light-blue", "icon": "far fa-file"}
+_parent = {"color": "white", "icon": "far fa-folder-open"}
+_image = {"color": "deep-purple", "icon": "far fa-image"}
 
 ICON_TYPES = {
     "": _folder,

--- a/sepal_ui/reclassify/reclassify_view.py
+++ b/sepal_ui/reclassify/reclassify_view.py
@@ -489,16 +489,16 @@ class ReclassifyView(sw.Card):
         self.save_dialog = SaveMatrixDialog(folder=out_path)
         self.import_dialog = ImportMatrixDialog(folder=out_path)
         self.get_table = sw.Btn(
-            ms.rec.rec.input.btn, "mdi-table", color="success", small=True
+            ms.rec.rec.input.btn, "far fa-table", color="success", small=True
         )
         self.import_table = sw.Btn(
-            "import", "mdi-download", color="secondary", small=True, class_="ml-2 mr-2"
+            "import", "fas fa-download", color="secondary", small=True, class_="ml-2 mr-2"
         )
         self.save_table = sw.Btn(
-            "save", "mdi-content-save", color="secondary", small=True
+            "save", "fas fa-save", color="secondary", small=True
         )
         self.reclassify_btn = sw.Btn(
-            ms.rec.rec.btn, "mdi-checkerboard", small=True, disabled=True
+            ms.rec.rec.btn, "fas fa-chess-board", small=True, disabled=True
         )
 
         self.toolbar = v.Toolbar(

--- a/sepal_ui/reclassify/table_view.py
+++ b/sepal_ui/reclassify/table_view.py
@@ -50,19 +50,19 @@ class ClassTable(sw.DataTable):
         # and set them in the top slot of the table
         self.edit_btn = sw.Btn(
             ms.rec.table.btn.edit,
-            icon="mdi-pencil",
+            icon="fas fa-pencil-alt",
             class_="ml-2 mr-2",
             color="secondary",
             small=True,
         )
         self.delete_btn = sw.Btn(
-            ms.rec.table.btn.delete, icon="mdi-delete", color="error", small=True
+            ms.rec.table.btn.delete, icon="fas fa-trash-alt", color="error", small=True
         )
         self.add_btn = sw.Btn(
-            ms.rec.table.btn.add, icon="mdi-plus", color="success", small=True
+            ms.rec.table.btn.add, icon="fas fa-plus", color="success", small=True
         )
         self.save_btn = sw.Btn(
-            ms.rec.table.btn.save, icon="mdi-content-save", small=True
+            ms.rec.table.btn.save, icon="far fa-save", small=True
         )
 
         slot = v.Toolbar(
@@ -593,7 +593,7 @@ class TableView(sw.Card):
             folder=self.class_path,
         )
         self.btn = sw.Btn(
-            ms.rec.table.classif.btn, icon="mdi-table", color="success", outlined=True
+            ms.rec.table.classif.btn, icon="far fa-table", color="success", outlined=True
         )
         w_panels = v.ExpansionPanels(
             children=[

--- a/sepal_ui/sepalwidgets/app.py
+++ b/sepal_ui/sepalwidgets/app.py
@@ -31,7 +31,7 @@ class AppBar(v.AppBar, SepalWidget):
 
         self.toggle_button = v.Btn(
             icon=True,
-            children=[v.Icon(class_="white--text", children=["mdi-dots-vertical"])],
+            children=[v.Icon(class_="white--text", children=["fas fa-ellipsis-v"])],
         )
 
         self.title = v.ToolbarTitle(children=[title])
@@ -69,7 +69,7 @@ class DrawerItem(v.ListItem, SepalWidget):
 
     Args:
         title (str): the title of the drawer item
-        icon(str, optional): the full name of a mdi-icon
+        icon(str, optional): the full name of a mdi/fa icon
         card (str, optional): the mount_id of tiles in the app
         href (str, optional): the absolute link to an external web page
         kwargs (optional): any parameter from a v.ListItem. If set, '_metadata', 'target', 'link' and 'children' will be overwritten.
@@ -83,7 +83,7 @@ class DrawerItem(v.ListItem, SepalWidget):
         # set the resizetrigger
         self.rt = js.rt
 
-        icon = icon if icon else "mdi-folder-outline"
+        icon = icon if icon else "far fa-folder"
 
         children = [
             v.ListItemAction(children=[v.Icon(class_="white--text", children=[icon])]),
@@ -163,13 +163,13 @@ class NavDrawer(v.NavigationDrawer, SepalWidget):
 
         code_link = []
         if code:
-            item_code = DrawerItem("Source code", icon="mdi-file-code", href=code)
+            item_code = DrawerItem("Source code", icon="far fa-file-code", href=code)
             code_link.append(item_code)
         if wiki:
-            item_wiki = DrawerItem("Wiki", icon="mdi-book-open-page-variant", href=wiki)
+            item_wiki = DrawerItem("Wiki", icon="fas fa-book-open", href=wiki)
             code_link.append(item_wiki)
         if issue:
-            item_bug = DrawerItem("Bug report", icon="mdi-bug", href=issue)
+            item_bug = DrawerItem("Bug report", icon="fas fa-bug", href=issue)
             code_link.append(item_bug)
 
         children = [

--- a/sepal_ui/sepalwidgets/btn.py
+++ b/sepal_ui/sepalwidgets/btn.py
@@ -14,7 +14,7 @@ class Btn(v.Btn, SepalWidget):
 
     Args:
         text (str, optional): the text to display in the btn
-        icon (str, optional): the full name of any mdi-icon
+        icon (str, optional): the full name of any mdi/fa icon
         kwargs (dict, optional): any parameters from v.Btn. if set, 'children' will be overwritten.
     """
 
@@ -39,7 +39,7 @@ class Btn(v.Btn, SepalWidget):
         set a new icon. If the icon is set to "", then it's hidden.
 
         Args:
-            icon (str, optional): the full name of a mdi-icon
+            icon (str, optional): the full name of a mdi/fa icon
 
         Return:
             self
@@ -81,7 +81,7 @@ class DownloadBtn(v.Btn, SepalWidget):
     def __init__(self, text, path="#", **kwargs):
 
         # create a download icon
-        v_icon = v.Icon(left=True, children=["mdi-download"])
+        v_icon = v.Icon(left=True, children=["fas fa-download"])
 
         # set default parameters
         kwargs["class_"] = kwargs.pop("class_", "ma-2")

--- a/sepal_ui/sepalwidgets/inputs.py
+++ b/sepal_ui/sepalwidgets/inputs.py
@@ -183,18 +183,18 @@ class FileInput(v.Flex, SepalWidget):
                     "name": "activator",
                     "variable": "x",
                     "children": Btn(
-                        icon="mdi-file-search", v_model=False, v_on="x.on", text=label
+                        icon="fas fa-search", v_model=False, v_on="x.on", text=label
                     ),
                 }
             ],
         )
 
         self.reload = v.Btn(
-            icon=True, color="primary", children=[v.Icon(children=["mdi-cached"])]
+            icon=True, color="primary", children=[v.Icon(children=["fas fa-sync-alt"])]
         )
 
         self.clear = v.Btn(
-            icon=True, color="primary", children=[v.Icon(children=["mdi-close"])]
+            icon=True, color="primary", children=[v.Icon(children=["fas fa-times"])]
         )
         if not clearable:
             su.hide_component(self.clear)
@@ -583,7 +583,7 @@ class AssetSelect(v.Combobox, SepalWidget):
         kwargs["v_model"] = kwargs.pop("v_model", None)
         kwargs["clearable"] = kwargs.pop("clearable", True)
         kwargs["dense"] = kwargs.pop("dense", True)
-        kwargs["prepend_icon"] = kwargs.pop("prepend_icon", "mdi-cached")
+        kwargs["prepend_icon"] = kwargs.pop("prepend_icon", "fas fa-sync-alt")
         kwargs["class_"] = kwargs.pop("class_", "my-5")
         kwargs["placeholder"] = kwargs.pop(
             "placeholder", ms.widgets.asset_select.placeholder
@@ -715,7 +715,7 @@ class PasswordField(v.TextField, SepalWidget):
         kwargs["class_"] = kwargs.pop("class_", "mr-2")
         kwargs["v_model"] = kwargs.pop("v_model", "")
         kwargs["type"] = "password"
-        kwargs["append_icon"] = kwargs.pop("append_icon", "mdi-ey-off")
+        kwargs["append_icon"] = kwargs.pop("append_icon", "far fa-eye-slash")
 
         # init the widget with the remaining kwargs
         super().__init__(**kwargs)
@@ -728,10 +728,10 @@ class PasswordField(v.TextField, SepalWidget):
 
         if self.type == "text":
             self.type = "password"
-            self.append_icon = "mdi-eye-off"
+            self.append_icon = "far fa-eye-slash"
         else:
             self.type = "text"
-            self.append_icon = "mdi-eye"
+            self.append_icon = "far fa-eye"
 
 
 class NumberField(v.TextField, SepalWidget):
@@ -763,8 +763,8 @@ class NumberField(v.TextField, SepalWidget):
 
         # set default params
         kwargs["type"] = "number"
-        kwargs["append_outer_icon"] = kwargs.pop("append_outer_icon", "mdi-plus")
-        kwargs["prepend_icon"] = kwargs.pop("prepend_icon", "mdi-minus")
+        kwargs["append_outer_icon"] = kwargs.pop("append_outer_icon", "fas fa-plus")
+        kwargs["prepend_icon"] = kwargs.pop("prepend_icon", "fas fa-minus")
         kwargs["v_model"] = kwargs.pop("v_model", 0)
         kwargs["readonly"] = kwargs.pop("readonly", True)
 

--- a/sepal_ui/sepalwidgets/widget.py
+++ b/sepal_ui/sepalwidgets/widget.py
@@ -98,7 +98,7 @@ class CopyToClip(v.VuetifyTemplate):
         kwargs["outlined"] = kwargs.pop("outlined", True)
         kwargs["label"] = kwargs.pop("label", "Copy To clipboard")
         kwargs["readonly"] = kwargs.pop("readonly", True)
-        kwargs["append_icon"] = kwargs.pop("append_icon", "mdi-clipboard-outline")
+        kwargs["append_icon"] = kwargs.pop("append_icon", "fas fa-clipboard")
         kwargs["v_model"] = kwargs.pop("v_model", None)
         kwargs["class_"] = kwargs.pop("class_", "ma-5")
 
@@ -134,4 +134,6 @@ class CopyToClip(v.VuetifyTemplate):
 
     def _clip(self, widget, event, data):
         self.send({"method": "clip", "args": [self.tf.v_model]})
-        self.tf.append_icon = "mdi-check"
+        self.tf.append_icon = "fas fa-clipboard-check"
+        
+        return

--- a/tests/test_Btn.py
+++ b/tests/test_Btn.py
@@ -14,24 +14,24 @@ class TestBtn:
         assert btn.children[1] == "Click"
 
         # extensive btn
-        btn = sw.Btn("toto", "mdi-folder")
+        btn = sw.Btn("toto", "fas fa-folder")
         assert btn.children[1] == "toto"
         assert isinstance(btn.v_icon, v.Icon)
-        assert btn.v_icon.children[0] == "mdi-folder"
+        assert btn.v_icon.children[0] == "fas fa-folder"
 
         return
 
     def test_set_icon(self, btn):
 
         # new icon
-        icon = "mdi-folder"
+        icon = "fas fa-folder"
         btn = btn.set_icon(icon)
 
         assert isinstance(btn.v_icon, v.Icon)
         assert btn.v_icon.children[0] == icon
 
         # change existing icon
-        icon = "mdi-file"
+        icon = "fas fa-file"
         btn.set_icon(icon)
         assert btn.v_icon.children[0] == icon
 

--- a/tests/test_CopyToClip.py
+++ b/tests/test_CopyToClip.py
@@ -10,7 +10,7 @@ class TestClip:
         clip = sw.CopyToClip()
         assert clip.tf.outlined is True
         assert isinstance(clip.tf.label, str)
-        assert clip.tf.append_icon == "mdi-clipboard-outline"
+        assert clip.tf.append_icon == "fas fa-clipboard"
         assert clip.tf.v_model is None
 
         # clip with extra options
@@ -27,7 +27,7 @@ class TestClip:
         # I don't know how to check the clipboard
 
         # check the icon change
-        assert clip.tf.append_icon == "mdi-check"
+        assert clip.tf.append_icon == "fas fa-clipboard-check"
 
         return
 

--- a/tests/test_DownloadBtn.py
+++ b/tests/test_DownloadBtn.py
@@ -12,7 +12,7 @@ class TestDownloadBtn:
         btn = sw.DownloadBtn(txt)
 
         assert isinstance(btn, sw.DownloadBtn)
-        assert btn.children[0].children[0] == "mdi-download"
+        assert btn.children[0].children[0] == "fas fa-download"
         assert btn.children[1] == txt
         assert file_start in btn.href
         assert "#" in btn.href

--- a/tests/test_DrawerItem.py
+++ b/tests/test_DrawerItem.py
@@ -7,13 +7,13 @@ class TestDrawerItem:
     def test_init_cards(self):
         title = "toto"
         id_ = "toto_id"
-        icon = "mdi-folder"
+        icon = "fas fa-folder"
 
         # default init
         drawerItem = sw.DrawerItem(title)
         assert isinstance(drawerItem, v.ListItem)
         assert isinstance(drawerItem.children[0].children[0], v.Icon)
-        assert drawerItem.children[0].children[0].children[0] == "mdi-folder-outline"
+        assert drawerItem.children[0].children[0].children[0] == "far fa-folder"
         assert isinstance(drawerItem.children[1].children[0], v.ListItemTitle)
         assert drawerItem.children[1].children[0].children[0] == title
 

--- a/tests/test_PasswordField.py
+++ b/tests/test_PasswordField.py
@@ -16,12 +16,12 @@ class TestPasswordField:
         # change the viz once
         password._toggle_pwd(None, None, None)
         assert password.type == "text"
-        assert password.append_icon == "mdi-eye"
+        assert password.append_icon == "fas fa-eye"
 
         # change it a second time
         password._toggle_pwd(None, None, None)
         assert password.type == "password"
-        assert password.append_icon == "mdi-eye-off"
+        assert password.append_icon == "fas fa-eye-slash"
 
         return
 


### PR DESCRIPTION
The font awesome libs is the one used by SEPAL nativelly. to make sure that the display is the same I decided to change what we use commonly in `sepal-ui` to match SEPAL main framework style.

- add an extra link in the html output (even though it's natively supported by voila, the display was funny in JupyterLab) 
- change every icon in the lib
- change the documentation accordingly

Could you test it from your side and let me know if anything behaves strangely? 