### PR TITLE
fix: don't use the named 'tmp' directory

### DIFF
--- a/sepal_ui/aoi/aoi_model.py
+++ b/sepal_ui/aoi/aoi_model.py
@@ -2,6 +2,7 @@ import json
 from pathlib import Path
 from traitlets import Any
 from urllib.request import urlretrieve
+import tempfile
 
 import pandas as pd
 import geopandas as gpd
@@ -421,19 +422,19 @@ class AoiModel(Model):
             # save the country iso_code
             iso_3 = admin[:3]
 
-            # download the geopackage in tmp
-            zip_file = self.GADM_ZIP_DIR / f"{iso_3}.zip"
+            # download the geopackage in a tmp directory
+            with tempfile.TemporaryDirectory() as tmp_dir:
 
-            if not zip_file.is_file():
+                zip_file = Path(tmp_dir) / f"{iso_3}.zip"
 
                 # get the zip from GADM server only the ISO_3 code need to be used
                 urlretrieve(self.GADM_BASE_URL.format(iso_3), zip_file)
 
-            # read the geopackage
-            layer_name = f"gadm36_{iso_3}_{level}"
-            level_gdf = gpd.read_file(
-                f"{zip_file}!gadm36_{iso_3}.gpkg", layer=layer_name
-            )
+                # read the geopackage
+                layer_name = f"gadm36_{iso_3}_{level}"
+                level_gdf = gpd.read_file(
+                    f"{zip_file}!gadm36_{iso_3}.gpkg", layer=layer_name
+                )
 
             # get the exact admin from this layer
             self.gdf = level_gdf[level_gdf[self.CODE[self.ee].format(level)] == admin]


### PR DESCRIPTION
Fix #391

The file needs to be downloaded anyway as `Geopandas` does not read `StringIO` or `ByteIO` objects. Instead of pointing to the "tmp" folder, I decided to use the `tempfile` Python lib. It creates the tmp directory in (and only in) the `with` statement. This lib being compatible with every OS, it will be more robust than the previous implementation. 