### PR TITLE
feat: new fullscreen widget

### DIFF
--- a/docs/source/modules/sepal_ui.mapping.FullScreenControl.rst
+++ b/docs/source/modules/sepal_ui.mapping.FullScreenControl.rst
@@ -1,0 +1,52 @@
+sepal\_ui.mapping.SepalMap
+==========================
+
+.. autoclass:: sepal_ui.mapping.SepalMap
+
+    .. rubric:: Attributes
+    
+    .. autosummary::
+    
+        ~SepalMap.ee
+        ~SepalMap.vinspector
+        ~SepalMap.loaded_rasters
+        ~SepalMap.dc
+        
+    .. rubric:: Methods
+    
+    .. autosummary::
+        :nosignatures:
+        
+        ~SepalMap.set_drawing_controls
+        ~SepalMap.remove_last_layer
+        ~SepalMap.zoom_ee_object
+        ~SepalMap.zoom_bounds
+        ~SepalMap.add_raster
+        ~SepalMap.show_dc
+        ~SepalMap.hide_dc
+        ~SepalMap.add_colorbar
+        ~SepalMap.addLayer
+        ~SepalMap.get_basemap_list
+        ~SepalMap.get_viz_params
+        
+.. automethod:: sepal_ui.mapping.SepalMap.set_drawing_controls
+
+.. automethod:: sepal_ui.mapping.SepalMap.remove_last_layer
+
+.. automethod:: sepal_ui.mapping.SepalMap.zoom_ee_object
+
+.. automethod:: sepal_ui.mapping.SepalMap.zoom_bounds
+
+.. automethod:: sepal_ui.mapping.SepalMap.add_raster
+
+.. automethod:: sepal_ui.mapping.SepalMap.show_dc
+
+.. automethod:: sepal_ui.mapping.SepalMap.hide_dc
+
+.. automethod:: sepal_ui.mapping.SepalMap.add_colorbar
+
+.. automethod:: sepal_ui.mapping.SepalMap.addLayer
+
+.. automethod:: sepal_ui.mapping.SepalMap.get_basemap_list
+
+.. automethod:: sepal_ui.mapping.SepalMap.get_viz_params

--- a/docs/source/modules/sepal_ui.mapping.SepalMap.rst
+++ b/docs/source/modules/sepal_ui.mapping.SepalMap.rst
@@ -1,52 +1,23 @@
-sepal\_ui.mapping.SepalMap
-==========================
+sepal\_ui.mapping.FullScreenControl
+===================================
 
-.. autoclass:: sepal_ui.mapping.SepalMap
+.. autoclass:: sepal_ui.mapping.FullScreenControl
 
     .. rubric:: Attributes
     
     .. autosummary::
     
-        ~SepalMap.ee
-        ~SepalMap.vinspector
-        ~SepalMap.loaded_rasters
-        ~SepalMap.dc
+        ~FullScreenControl.ICONS
+        ~FullScreenControl.METHODS
+        ~FullScreenControl.zoomed
+        ~FullScreenControl.w_btn
+        ~FullScreenControl.template
         
     .. rubric:: Methods
     
     .. autosummary::
         :nosignatures:
         
-        ~SepalMap.set_drawing_controls
-        ~SepalMap.remove_last_layer
-        ~SepalMap.zoom_ee_object
-        ~SepalMap.zoom_bounds
-        ~SepalMap.add_raster
-        ~SepalMap.show_dc
-        ~SepalMap.hide_dc
-        ~SepalMap.add_colorbar
-        ~SepalMap.addLayer
-        ~SepalMap.get_basemap_list
-        ~SepalMap.get_viz_params
+        ~FullScreenControl.toggle_fullscreen
         
-.. automethod:: sepal_ui.mapping.SepalMap.set_drawing_controls
-
-.. automethod:: sepal_ui.mapping.SepalMap.remove_last_layer
-
-.. automethod:: sepal_ui.mapping.SepalMap.zoom_ee_object
-
-.. automethod:: sepal_ui.mapping.SepalMap.zoom_bounds
-
-.. automethod:: sepal_ui.mapping.SepalMap.add_raster
-
-.. automethod:: sepal_ui.mapping.SepalMap.show_dc
-
-.. automethod:: sepal_ui.mapping.SepalMap.hide_dc
-
-.. automethod:: sepal_ui.mapping.SepalMap.add_colorbar
-
-.. automethod:: sepal_ui.mapping.SepalMap.addLayer
-
-.. automethod:: sepal_ui.mapping.SepalMap.get_basemap_list
-
-.. automethod:: sepal_ui.mapping.SepalMap.get_viz_params
+.. automethod:: sepal_ui.mapping.FullScreenControl.toggle_fullscreen

--- a/docs/source/modules/sepal_ui.mapping.rst
+++ b/docs/source/modules/sepal_ui.mapping.rst
@@ -9,3 +9,4 @@ sepal\_ui.mapping
       :toctree:
       
       sepal_ui.mapping.SepalMap
+      sepal_ui.mapping.FullScreenControl

--- a/sepal_ui/frontend/styles.py
+++ b/sepal_ui/frontend/styles.py
@@ -24,7 +24,12 @@ bg_color = "#121212" if v.theme.dark else "#fff"
 
 class Styles(v.VuetifyTemplate):
     """
-    Fixed styles to avoid leaflet maps overlap sepal widgets
+    Fixed styles to fix display issues in the lib:
+
+    - avoid leaflet maps overlap sepal widgets
+    - remove shadow of widget-control
+    - remove padding of the main content
+    - load fontawsome as a resource
     """
 
     template = Unicode(

--- a/sepal_ui/mapping/__init__.py
+++ b/sepal_ui/mapping/__init__.py
@@ -1,1 +1,2 @@
 from .mapping import *
+from .fullscreen_control import *

--- a/sepal_ui/mapping/fullscreen_control.py
+++ b/sepal_ui/mapping/fullscreen_control.py
@@ -89,7 +89,7 @@ class FullScreenControl(WidgetControl):
 
     def toggle_fullscreen(self, widget):
         """
-        Toggle the fullscreen state of the map by sending the required javascript method
+        Toggle the fullscreen state of the map by sending the required javascript method, changing the w_btn icons and the zoomed state of the control.
         """
 
         # change the zoom state

--- a/sepal_ui/mapping/fullscreen_control.py
+++ b/sepal_ui/mapping/fullscreen_control.py
@@ -11,6 +11,8 @@ class FullScreenControl(WidgetControl):
     This button will force the display of the map in fullscreen mode. It should be used instead of the built-in ipyleaflet FullscreenControl if your map is embeding ipyvuetify widgets. I tends to solve the issue raised here: https://github.com/widgetti/ipyvuetify/issues/141. The idea is to fake the fullscreen display by forcing the map container to extend to the full extend of the screen without using a z-index superior to the ipyvuetify overlay.
     simply click on it and the map will automatically expand
 
+    .. versionadded:: 2.7.0
+
     Args:
         kwargs (optional): any availabel arguments from a ipyleaflet WidgetControl
     """

--- a/sepal_ui/mapping/fullscreen_control.py
+++ b/sepal_ui/mapping/fullscreen_control.py
@@ -1,0 +1,104 @@
+from ipyleaflet import WidgetControl
+from IPython.display import display
+import ipyvuetify as v
+from ipywidgets import Button, Layout
+
+
+class FullScreenControl(WidgetControl):
+    """
+    A custom Fullscreen Button ready to be embed in a map object.
+
+    This button will force the display of the map in fullscreen mode. It should be used instead of the built-in ipyleaflet FullscreenControl if your map is embeding ipyvuetify widgets. I tends to solve the issue raised here: https://github.com/widgetti/ipyvuetify/issues/141. The idea is to fake the fullscreen display by forcing the map container to extend to the full extend of the screen without using a z-index superior to the ipyvuetify overlay.
+    simply click on it and the map will automatically expand
+
+    Args:
+        kwargs (optional): any availabel arguments from a ipyleaflet WidgetControl
+    """
+
+    ICONS = ["expand", "compress"]
+    "list: The icons that will be used to toggle between expand and compressed mode"
+
+    METHODS = ["embed", "fullscreen"]
+    "list: The javascript methods name to be used to switch from expand to compress mode"
+
+    zoomed = False
+    "bool: the current zoomed level (``True`` for expanded and ``False`` for compressed"
+
+    w_btn = None
+    "ipywidget.Button: the btn to display on the map"
+
+    template = None
+    "ipyvuetify.VuetifyTemplate: embeds the 2 javascripts methods to change the rendering of the map"
+
+    def __init__(self, **kwargs):
+
+        # create a btn
+        self.w_btn = Button(
+            tooltip="set fullscreen",
+            icon=self.ICONS[self.zoomed],
+            layout=Layout(
+                width="30px", height="30px", line_height="30px", padding="0px"
+            ),
+        )
+
+        # overwrite the widget set in the kwargs (if any)
+        kwargs["widget"] = self.w_btn
+        kwargs["position"] = kwargs.pop("position", "topleft")
+        kwargs["transparent_bg"] = True
+
+        # create the widget
+        super().__init__(**kwargs)
+
+        # add javascrip behaviour
+        self.w_btn.on_click(self.toggle_fullscreen)
+
+        # template with js behaviour
+        # "jupyter_fullscreen" place tje "leaflet-container element on the front screen
+        # and expand it's display to the full screen
+        # "jupyter_embed" reset all the changed parameter
+        # both trigger the resize event to force the reload of the Tilelayers
+        self.template = v.VuetifyTemplate(
+            template="""
+        <script>
+            {methods: {
+                jupyter_fullscreen() {
+                    var element = document.getElementsByClassName("leaflet-container")[0];
+                    element.style.position = "fixed";
+                    element.style.width = "100vw";
+                    element.style.height = "100vh";
+                    element.style.zIndex = 800;
+                    element.style.top = 0;
+                    element.style.left = 0;
+                    window.dispatchEvent(new Event('resize'));
+                },
+                jupyter_embed() {
+                    var element = document.getElementsByClassName("leaflet-container")[0];
+                    element.style.position = "";
+                    element.style.width = "";
+                    element.style.height = "";
+                    element.style.zIndex = "";
+                    element.style.top = "";
+                    element.style.left = "";
+                    window.dispatchEvent(new Event('resize'));
+                }
+            }}
+        </script>
+        """
+        )
+        display(self.template)
+
+    def toggle_fullscreen(self, widget):
+        """
+        Toggle the fullscreen state of the map by sending the required javascript method
+        """
+
+        # change the zoom state
+        self.zoomed = not self.zoomed
+
+        # change button icon
+        self.w_btn.icon = self.ICONS[self.zoomed]
+
+        # zoom
+        self.template.send({"method": self.METHODS[self.zoomed], "args": []})
+
+        return

--- a/tests/test_FullScreenControl.py
+++ b/tests/test_FullScreenControl.py
@@ -1,0 +1,40 @@
+from sepal_ui import mapping as sm
+
+
+class TestFullScreenControl:
+    def test_init(self):
+
+        # check that the map start with no info
+        map_ = sm.SepalMap()
+
+        # add a fullscreenControl
+        control = sm.FullScreenControl()
+        map_.add_control(control)
+
+        assert isinstance(control, sm.FullScreenControl)
+        assert control in map_.controls
+        assert control.zoomed is False
+        assert control.w_btn.icon == "expand"
+
+        return
+
+    def test_toggle_fullscreen(self):
+
+        map_ = sm.SepalMap()
+        control = sm.FullScreenControl()
+        map_.add_control(control)
+
+        # trigger the click
+        # I cannot test the javascript but i can test everything else
+        control.toggle_fullscreen(None)
+
+        assert control.zoomed is True
+        assert control.w_btn.icon == "compress"
+
+        # click again to reset to initial state
+        control.toggle_fullscreen(None)
+
+        assert control.zoomed is False
+        assert control.w_btn.icon == "expand"
+
+        return


### PR DESCRIPTION
create a custom `FullscreenControl`to solve the issue raised in https://github.com/widgetti/ipyvuetify/issues/141. 

This is still a WIP but the results are already promising. I still need to add documentation and tests but that is worth testing on someone else's side. I think some improvement is required on the JS script as it gives funny results in jupyterlab an jupyternotebook at the moment.

Here is an example code for testing :  

```python
from sepal_ui import mapping as sm
from sepal_ui import sepalwidgets as sw
import ipyvuetify as v
from ipyleaflet import WidgetControl

map_=sm.SepalMap(center=[4,-74], zoom=5)
map_.add_control(sm.FullScreenControl(position="topleft"))

dropdown = sw.Select(label="titi", items=["toto",2,3,4,5,], v_model=None)
widget_control = WidgetControl(widget=dropdown)
map_.add_control(widget_control)

map_
```

Happy to here your thoughts

## EDIT

I was afraid about how it would render in a deployed app so I tested it in the alert verification application on test server and it work like a charm: 
![Capture d’écran 2022-02-28 à 13 24 37](https://user-images.githubusercontent.com/12596392/155983310-21ec3388-3b21-40e9-ae66-0fe61073ac37.png)

