### PR TITLE
Datepicker disabled trait 

### DIFF
--- a/docs/source/modules/sepal_ui.sepalwidgets.DatePicker.rst
+++ b/docs/source/modules/sepal_ui.sepalwidgets.DatePicker.rst
@@ -8,6 +8,7 @@ sepal\_ui.sepalwidgets.DatePicker
     .. autosummary::
     
         ~DatePicker.menu
+        ~DatePicker.disabled
         
     .. rubric:: Methods
     
@@ -15,5 +16,8 @@ sepal\_ui.sepalwidgets.DatePicker
         :nosignatures:
         
         ~Datepicker.close_menu
+        ~DatePicker.disable
         
 .. automethod:: sepal_ui.sepalwidgets.DatePicker.close_menu
+
+.. automethod:: sepal_ui.sepalwidgets.DatePicker.disable

--- a/sepal_ui/sepalwidgets/inputs.py
+++ b/sepal_ui/sepalwidgets/inputs.py
@@ -1,7 +1,7 @@
 from pathlib import Path
 
 import ipyvuetify as v
-from traitlets import link, Int, Any, List, observe, Dict, Unicode
+from traitlets import link, Int, Any, List, observe, Dict, Unicode, Bool
 from ipywidgets import jslink
 import pandas as pd
 import ee
@@ -39,6 +39,9 @@ class DatePicker(v.Layout, SepalWidget):
 
     menu = None
     "v.Menu: the menu widget to display the datepicker"
+
+    disabled = Bool(False).tag(sync=True)
+    "traitlets.Bool: the disabled status of the Datepicker object"
 
     def __init__(self, label="Date", **kwargs):
 
@@ -90,6 +93,14 @@ class DatePicker(v.Layout, SepalWidget):
 
         # set the visibility
         self.menu.v_model = False
+
+        return
+
+    @observe("disabled")
+    def disable(self, change):
+        """A method to disabled the appropriate components in the datipkcer object"""
+
+        self.menu.v_slots[0]["children"].disabled = self.disabled
 
         return
 

--- a/tests/test_DatePicker.py
+++ b/tests/test_DatePicker.py
@@ -35,6 +35,14 @@ class TestDatePicker:
 
         return
 
+    def test_disable(self, datepicker):
+
+        for boolean in [True, False]:
+            datepicker.disabled = boolean
+            assert datepicker.menu.v_slots[0]["children"].disabled == boolean
+
+        return
+
     @pytest.fixture
     def datepicker(self):
         """create a default datepicker"""


### PR DESCRIPTION
Fix #409 Add the missing disabled trait to the Datpicker object so that it can be manipulated as any other input:

```python
from sepal_ui import sepalwidgets as sw 

picker = sw.DatePicker()
picker.disabled = True
picker
```