### PR TITLE
change the value of the datepicker y changing its v_model

### DIFF
--- a/docs/source/modules/sepal_ui.sepalwidgets.DatePicker.rst
+++ b/docs/source/modules/sepal_ui.sepalwidgets.DatePicker.rst
@@ -9,6 +9,7 @@ sepal\_ui.sepalwidgets.DatePicker
     
         ~DatePicker.menu
         ~DatePicker.disabled
+        ~DatePicker.date_text
         
     .. rubric:: Methods
     
@@ -17,7 +18,13 @@ sepal\_ui.sepalwidgets.DatePicker
         
         ~Datepicker.close_menu
         ~DatePicker.disable
+        ~DatePicker.is_valid_date
+        ~DatePicker.check_date
         
 .. automethod:: sepal_ui.sepalwidgets.DatePicker.close_menu
 
 .. automethod:: sepal_ui.sepalwidgets.DatePicker.disable
+
+.. automethod:: sepal_ui.sepalwidgets.DatePicker.check_date
+
+.. autofunction:: sepal_ui.sepalwidgets.DatePicker.disable

--- a/tests/test_DatePicker.py
+++ b/tests/test_DatePicker.py
@@ -17,6 +17,11 @@ class TestDatePicker:
         datepicker = sw.DatePicker("toto")
         assert isinstance(datepicker, sw.DatePicker)
 
+        # datepicker with default value
+        value = "2022-03-14"
+        datepicker = sw.DatePicker(v_model=value)
+        assert datepicker.v_model == value
+
         return
 
     def test_bind(self, datepicker):
@@ -40,6 +45,34 @@ class TestDatePicker:
         for boolean in [True, False]:
             datepicker.disabled = boolean
             assert datepicker.menu.v_slots[0]["children"].disabled == boolean
+
+        return
+
+    def test_is_valid_date(self, datepicker):
+
+        # a nicely shaped date
+        test = "2022-03-14"
+        assert datepicker.is_valid_date(test) is True
+
+        # a badly shaped date
+        test = "2022-50-14"
+        assert datepicker.is_valid_date(test) is False
+
+        return
+
+    def test_check_date(self, datepicker):
+
+        # manually update the value with a badely shaped date
+        test = "2022-50-14"
+        datepicker.v_model = test
+        assert datepicker.v_model == test
+        assert datepicker.date_text.error_messages is not None
+
+        # manually update the value with a nicely shaped date
+        test = "2022-03-14"
+        datepicker.v_model = test
+        assert datepicker.v_model == test
+        assert datepicker.date_text.error_messages is None
 
         return
 


### PR DESCRIPTION
Fix #417 

I think that this function is intended for developers as it's a programmatically triggered change so I didn't put much effort into error catching.

- the `v_model` can be set on object build
```python
d = sw.DatePicker(v_model="2022-03-14")
d
```
- the `v_model` can be changed on the fly 
```python
d = sw.DatePicker()
d.v_model = "2022-03-14"
d
```
- There is error catching on manual set so that we throw an error when a badly shaped str ins used as v_model
```python 
d = sw.DatePicker()
d.v_model = "2022-50-12"
d
```