### PR TITLE
improve factory and venv command

### DIFF
--- a/sepal_ui/bin/module_factory
+++ b/sepal_ui/bin/module_factory
@@ -85,10 +85,9 @@ def set_module_name(folder, module_name):
     print("Update the module name in the json translation dictionaries")
 
     # loop in the available languages
-    languages = ["en", "fr", "es"]
-    for lang in languages:
-
-        file = folder / "component" / "message" / lang / "locale.json"
+    message_dir = folder / "component" / "message"
+    json_files = [d / "locale.json" for d in message_dir.iterdir() if d.is_dir()]
+    for file in json_files:
 
         with file.open("r") as f:
             data = json.load(f)
@@ -137,11 +136,11 @@ def set_module_name_doc(folder, url, module_name):
         module_name (str): the module name
     """
 
-    # loop in the available languages
-    languages = ["fr", "en", "es"]
-    for lang in languages:
+    # get the documentation folder
+    doc_dir = folder / "doc"
 
-        file = folder / "doc" / f"{lang}.rst"
+    # loop in the available languages
+    for file in doc_dir.glob("*.rst"):
 
         with file.open() as f:
             text = f.read()
@@ -298,7 +297,7 @@ if __name__ == "__main__":
     subprocess.run(["git", "branch", "-M", "master"], cwd=folder)
 
     # add the remote
-    subprocess.run(["git", "remote", "add", "origin", str(github_url)], cwd=folder)
+    subprocess.run(["git", "remote", "set-url", "origin", str(github_url)], cwd=folder)
 
     # make the first push
     subprocess.run(["git", "push", "-u", "origin", "master"], cwd=folder)

--- a/sepal_ui/bin/module_venv
+++ b/sepal_ui/bin/module_venv
@@ -42,8 +42,8 @@ if __name__ == "__main__":
     venv_dir.mkdir(exist_ok=True)
 
     # create a venv folder associated with the current repository
-    print(f'create a venv directory for the current app: "{Path.cwd().stem}"')
-    current_dir_venv = venv_dir / Path.cwd().stem
+    print(f'create a venv directory for the current app: "{Path.cwd().name}"')
+    current_dir_venv = venv_dir / Path.cwd().name
 
     # empty the folder from anything already in there
     # equivalement to flushing the existing venv (it's just faster than pip)


### PR DESCRIPTION
Some minor change to bin commands: 
- the `module_factory`command was relying on a predifined set of languages. to improve robustness, we simply guess the available one. If the key is not there it will be automatically added anyway. same for the doc files. 

-use "set-url" instead of "add" to rewire the git repository. add cannot be used in the new git CLI release when origin already exist 

- use the name of the repository in `module_venv` to prevent funny behaviour when the repo has "." in the name. 
previously runnning it in "se.plan" was crating a "module-venv/se" venv. now it's nicely called "module-venv/se.plan"  