### PR TITLE
Command script to activate virtual envs

### DIFF
--- a/sepal_ui/bin/activate_venv
+++ b/sepal_ui/bin/activate_venv
@@ -22,7 +22,6 @@ if __name__ == "__main__":
             for line in result.stdout.decode("utf-8").splitlines()
             if ".local" not in line
         ],
-        # columns=["name", "path"]
     ).iloc[1:]
 
     # Check if user has test envs
@@ -62,8 +61,6 @@ if __name__ == "__main__":
 
     activate_path = "bin/activate" if test else "venv/bin/activate"
     print(f"{Fore.GREEN}Activating: {kernel_path} {Fore.RESET}")
-
-    cmd = ["source", str(kernel_path / activate_path)]
 
     # Based on https://stackoverflow.com/questions/6943208/activate-a-virtualenv-with-a-python-script
     # It won't return anything to know if the the command was succesfully done

--- a/sepal_ui/bin/activate_venv
+++ b/sepal_ui/bin/activate_venv
@@ -1,0 +1,81 @@
+#!/usr/bin/python3
+import subprocess
+from pathlib import Path
+import pandas as pd
+from colorama import init, Fore
+
+# init colors for all plateforms
+init()
+
+if __name__ == "__main__":
+
+    print(
+        f"{Fore.CYAN} Welcome to the virtual env activation, loading your venvs... \n{Fore.RESET}"
+    )
+    
+    # Get usr kernels
+    result = subprocess.run(["jupyter", "kernelspec", "list"], stdout=subprocess.PIPE)
+
+    kernels = pd.DataFrame(
+        [
+            line.split()
+            for line in result.stdout.decode("utf-8").splitlines()
+            if ".local" not in line
+        ],
+        # columns=["name", "path"]
+    ).iloc[1:]
+
+    # Check if user has test envs
+    test_venv_path = Path.home() / "module-venv"
+    if test_venv_path.exists():
+        test_envs = pd.DataFrame(
+            list(
+                [f"test {el.stem}", str(el)]
+                for el in test_venv_path.glob("[!.]*")
+                if el.is_dir()
+            )
+        )
+        kernels = pd.concat([kernels, test_envs]).reset_index(drop=True)
+    kernels.columns = ["env name", "path"]
+
+    print(f"{Fore.CYAN} You can activate any of the following venvs: \n{Fore.RESET}")
+    print(kernels)
+
+    valid = False
+
+    while not valid:
+
+        selection = int(
+            input(
+                f"{Fore.CYAN} Select the venv number you want to activate: \n{Fore.RESET}"
+            )
+        )
+
+        if selection not in kernels.index.unique():
+            print(f"{Fore.RED}Your selection is not valid {Fore.RESET}")
+        else:
+            valid = True
+    
+    # Activate virtual env
+    kernel_path = Path(kernels.iloc[selection]["path"])
+    test = "module-venv" in str(kernel_path)
+
+    activate_path = "bin/activate" if test else "venv/bin/activate"
+    print(f"{Fore.GREEN}Activating: {kernel_path} {Fore.RESET}")
+
+    cmd = ["source", str(kernel_path / activate_path)]
+
+    # Based on https://stackoverflow.com/questions/6943208/activate-a-virtualenv-with-a-python-script
+    # It won't return anything to know if the the command was succesfully done
+    subprocess.run(
+        ["/bin/bash", "--rcfile", str(kernel_path / activate_path)],
+    )
+
+    # The following lines won't be executed because the previous subprocess kill the kernel
+
+    # Confirm that we are in the new env
+    result = subprocess.run(
+        ["echo", "$VIRTUAL_ENV"], shell=True, stdout=subprocess.PIPE
+    )
+
+    print(f"The current env is: {result.stdout}")

--- a/sepal_ui/bin/activate_venv
+++ b/sepal_ui/bin/activate_venv
@@ -29,7 +29,7 @@ if __name__ == "__main__":
     if test_venv_path.exists():
         test_envs = pd.DataFrame(
             list(
-                [f"test {el.stem}", str(el)]
+                [f"test {el.name}", str(el)]
                 for el in test_venv_path.glob("[!.]*")
                 if el.is_dir()
             )

--- a/sepal_ui/bin/activate_venv
+++ b/sepal_ui/bin/activate_venv
@@ -13,10 +13,10 @@ if __name__ == "__main__":
         f"{Fore.CYAN} Welcome to the virtual env activation, loading your venvs... \n{Fore.RESET}"
     )
     
-    # Get usr kernels
+    # Get usr venvs
     result = subprocess.run(["jupyter", "kernelspec", "list"], stdout=subprocess.PIPE)
 
-    kernels = pd.DataFrame(
+    venvs = pd.DataFrame(
         [
             line.split()
             for line in result.stdout.decode("utf-8").splitlines()
@@ -34,11 +34,13 @@ if __name__ == "__main__":
                 if el.is_dir()
             )
         )
-        kernels = pd.concat([kernels, test_envs]).reset_index(drop=True)
-    kernels.columns = ["env name", "path"]
+        venvs = pd.concat([venvs, test_envs])
+    
+    venvs = venvs.reset_index(drop=True)
+    venvs.columns = ["env name", "path"]
 
     print(f"{Fore.CYAN} You can activate any of the following venvs: \n{Fore.RESET}")
-    print(kernels)
+    print(venvs)
 
     valid = False
 
@@ -50,13 +52,13 @@ if __name__ == "__main__":
             )
         )
 
-        if selection not in kernels.index.unique():
+        if selection not in venvs.index.unique():
             print(f"{Fore.RED}Your selection is not valid {Fore.RESET}")
         else:
             valid = True
     
     # Activate virtual env
-    kernel_path = Path(kernels.iloc[selection]["path"])
+    kernel_path = Path(venvs.iloc[selection]["path"])
     test = "module-venv" in str(kernel_path)
 
     activate_path = "bin/activate" if test else "venv/bin/activate"

--- a/setup.py
+++ b/setup.py
@@ -94,6 +94,7 @@ setup_params = {
         "sepal_ui/bin/module_l10n",
         "sepal_ui/bin/module_theme",
         "sepal_ui/bin/module_venv",
+        "sepal_ui/bin/activate_venv",
     ],
     "classifiers": [
         "Development Status :: 5 - Production/Stable",


### PR DESCRIPTION
This command script is intended to make easier the search and activation process of the virtual envs in the platform.

Basically, it will look at the installed venvs in both usr and local module-venvs, and you can choose which one you want to activate.

what do you think? I found a little bit different way to activate the ven but it is working, do you mind taking a review?