### PR TITLE
build: use the master version of the doc template

### DIFF
--- a/docs/source/_static/css/custom.css
+++ b/docs/source/_static/css/custom.css
@@ -24,7 +24,7 @@ div.jupyter_container.docutils {
   display: inline-block;
 }
 .footer-item:not(:last-child) {
-  border-right: 1px solid rgba(var(--pst-color-text-base), 1);
+  border-right: 1px solid var(--pst-color-text-base);
   margin-right: .5em;
   padding-right: .5em;
 }

--- a/setup.py
+++ b/setup.py
@@ -58,7 +58,7 @@ setup_params = {
         ],
         "doc": [
             "jupyter-sphinx @ git+https://github.com/jupyter/jupyter-sphinx.git",
-            "pydata-sphinx-theme",
+            "pydata-sphinx-theme @ git+https://github.com/pydata/pydata-sphinx-theme.git",
             "sphinx-notfound-page",
             "Sphinx",
             "sphinxcontrib-spelling",


### PR DESCRIPTION
https://sepal-ui--446.org.readthedocs.build/en/446/

![Capture](https://user-images.githubusercontent.com/12596392/163412508-19ac9abc-d822-4c89-a60f-28aba609a6cc.PNG)


implementing the dark theme I developed for the pydata-sphinx-theme in https://github.com/pydata/pydata-sphinx-theme/pull/540. The idea will be to us it as well in the SEPAL doc. 