### PR TITLE
Sepalwidget

### DIFF
--- a/docs/source/modules/sepal_ui.sepalwidgets.SepalWidget.rst
+++ b/docs/source/modules/sepal_ui.sepalwidgets.SepalWidget.rst
@@ -19,6 +19,8 @@ sepal\_ui.sepalwidgets.SepalWidget
         ~SepalWidget.hide
         ~SepalWidget.show
         ~SepalWidget.reset
+        ~SepalWidget.get_children
+        ~SepalWidget.set_children
         
 .. automethod:: sepal_ui.sepalwidgets.SepalWidget.toggle_viz
 
@@ -27,3 +29,7 @@ sepal\_ui.sepalwidgets.SepalWidget
 .. automethod:: sepal_ui.sepalwidgets.SepalWidget.show
 
 .. automethod:: sepal_ui.sepalwidgets.SepalWidget.reset
+
+.. automethod:: sepal_ui.sepalwidgets.SepalWidget.get_children
+
+.. automethod:: sepal_ui.sepalwidgets.SepalWidget.set_children

--- a/sepal_ui/sepalwidgets/__init__.py
+++ b/sepal_ui/sepalwidgets/__init__.py
@@ -18,6 +18,9 @@ for c in _c_list:
     class _tmp(getattr(v, c), SepalWidget):
         pass
 
+    _tmp.__name__ = c
+    _tmp.__qualname__ = c
+
     locals()[c] = _tmp
 del _tmp
 

--- a/sepal_ui/sepalwidgets/sepalwidget.py
+++ b/sepal_ui/sepalwidgets/sepalwidget.py
@@ -1,3 +1,4 @@
+from ipyvue import VueWidget
 import ipyvuetify as v
 from traitlets import Unicode, Bool, observe
 
@@ -110,5 +111,62 @@ class SepalWidget(v.VuetifyWidget):
         """
 
         self.v_model = None
+
+        return self
+
+    def get_children(self, id_):
+        """Retrieve all children elements that matches with the given id_.
+
+        Args:
+            id_ (str, optional): attribute id to compare with.
+
+        Returns:
+            Will return a list with all mathing elements if there are more than one,
+            otherwise will return the mathing element.
+
+        """
+
+        elements = []
+
+        def search_children(parent):
+
+            if issubclass(parent.__class__, VueWidget):
+
+                if parent.attributes.get("id") == id_:
+                    elements.append(parent)
+
+                if len(parent.children):
+                    [search_children(chld) for chld in parent.children]
+
+        # Search in the self children elements
+        [search_children(chld) for chld in self.children]
+
+        return elements[0] if len(elements) == 1 else elements
+
+    def set_children(self, children, position="first"):
+        """Insert input children in self children within given position
+
+        Args:
+            children (str, DOMWidget, list(str, DOMWidget)):
+            position (str): whether to insert as first or last element. ["first", "last"]
+        """
+
+        if not isinstance(children, list):
+            children = [children]
+
+        new_childrens = self.children[:]
+
+        if position == "first":
+            new_childrens = children + new_childrens
+
+        elif position == "last":
+            new_childrens = new_childrens + children
+
+        else:
+            raise ValueError(
+                f"Position '{position}' is not a valid value. Use 'first' or 'last'"
+            )
+
+        self.children = new_childrens
 
         return self

--- a/tests/test_SepalWidget.py
+++ b/tests/test_SepalWidget.py
@@ -74,7 +74,7 @@ class TestSepalWidget:
         test_card.set_children("asdf", "last")
         assert test_card.children[-1] == "asdf"
 
-        # Test that new element is at the begining
+        # Test that new element is at the begining (default)
         test_card.set_children("asdf")
         assert test_card.children[0] == "asdf"
 
@@ -83,7 +83,7 @@ class TestSepalWidget:
         test_card.set_children(new_els)
         assert test_card.children[: len(new_els)] == new_els
 
-    def test_children_error(self):
+    def test_set_children_error(self):
         """Test when set_children methods throws an error"""
 
         with pytest.raises(ValueError):
@@ -105,6 +105,7 @@ class TestSepalWidget:
         # Arrange without any match
         test_card = sw.Card()
 
+        # The result will be an empty list
         assert not test_card.get_children(id_="asdf")
 
         # Arrange with a nested element

--- a/tests/test_SepalWidget.py
+++ b/tests/test_SepalWidget.py
@@ -66,6 +66,56 @@ class TestSepalWidget:
 
         return
 
+    def test_set_children(self):
+
+        test_card = sw.Card()
+
+        # Test that new element is at the end of the children
+        test_card.set_children("asdf", "last")
+        assert test_card.children[-1] == "asdf"
+
+        # Test that new element is at the begining
+        test_card.set_children("asdf")
+        assert test_card.children[0] == "asdf"
+
+        # Test we can add more than one element as a list
+        new_els = [sw.Icon(), "asdf"]
+        test_card.set_children(new_els)
+        assert test_card.children[: len(new_els)] == new_els
+
+    def test_children_error(self):
+        """Test when set_children methods throws an error"""
+
+        with pytest.raises(ValueError):
+            sw.Card().set_children("asdf", "middle")
+
+    def test_get_children(self):
+
+        # Arrange with multiple childrens with same id
+        test_card = sw.Card()
+        match_card = sw.Card(attributes={"id": "asdf"})
+
+        test_card.set_children([match_card] * 2, position="first")
+
+        expected_output = [match_card] * 2
+
+        assert isinstance(test_card.get_children(id_="asdf"), list)
+        assert test_card.get_children(id_="asdf") == expected_output
+
+        # Arrange without any match
+        test_card = sw.Card()
+
+        assert not test_card.get_children(id_="asdf")
+
+        # Arrange with a nested element
+        test_card = sw.Card()
+        test_card.set_children(sw.Card(children=[match_card]))
+
+        assert test_card.get_children(id_="asdf") == match_card
+
+        # Be sure we are only getting the element (not list) when there's only one match
+        assert type(test_card.get_children(id_="asdf")) == type(match_card)
+
     @pytest.fixture
     def widget(self):
         """return a sepalwidget"""


### PR DESCRIPTION
In relation to https://github.com/12rambau/sepal_ui/issues/443.

- Rename SepalWidget overwrote Vuetify Classes
- Two new methods created `set_children` and `get_children`:
  - I've only included `first` and `last` as available positions when setting new children, do you think is enough? or should we use the indexes instead?
- Tests
- Docs