### PR TITLE
fix: remove empty string from the translation dict

### DIFF
--- a/docs/source/modules/sepal_ui.translator.Translator.rst
+++ b/docs/source/modules/sepal_ui.translator.Translator.rst
@@ -27,6 +27,7 @@ sepal\_ui.translator.Translator
         ~Translator.find_target
         ~Translator.available_locales
         ~Translator.merge_dict
+        ~Translator.delete_empty
         
 .. automethod:: sepal_ui.translator.Translator.missing_keys
 
@@ -37,6 +38,8 @@ sepal\_ui.translator.Translator
 .. automethod:: sepal_ui.translator.Translator.available_locales
 
 .. automethod:: sepal_ui.translator.Translator.merge_dict
+
+.. automethod:: sepal_ui.translator.Translator.delete_empty
 
 .. autofunction:: sepal_ui.translator.Translator.find_target
    

--- a/tests/test_Translator.py
+++ b/tests/test_Translator.py
@@ -49,24 +49,28 @@ class TestTranslator:
         # a test dict with many embeded numbered list
         # but also an already existing list
         test = {
-            "foo1": {"0": "foo2", "1": "foo3"},
-            "foo4": {
-                "foo5": {"0": "foo6", "1": "foo7"},
-                "foo8": "foo9",
-            },
-            "foo10": ["foo11", "foo12"],
+            "a": {"0": "b", "1": "c"},
+            "d": {"e": {"0": "f", "1": "g"}, "h": "i"},
+            "j": ["k", "l"],
         }
 
         # the sanitize version of this
         result = {
-            "foo1": ["foo2", "foo3"],
-            "foo4": {"foo5": ["foo6", "foo7"], "foo8": "foo9"},
-            "foo10": ["foo11", "foo12"],
+            "a": ["b", "c"],
+            "d": {"e": ["f", "g"], "h": "i"},
+            "j": ["k", "l"],
         }
 
         assert Translator.sanitize(test) == result
 
         return
+
+    def test_delete_empty(self):
+
+        test = {"a": "", "b": 1, "c": {"d": ""}, "e": {"f": "", "g": 2}}
+        result = {"b": 1, "c": {}, "e": {"g": 2}}
+
+        assert Translator.delete_empty(test) == result
 
     def test_missing_keys(self, translation_folder):
 


### PR DESCRIPTION
Fix #449