### PR TITLE
build: build archive and wheel when publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,5 +20,5 @@ jobs:
         TWINE_USERNAME: __token__
         TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
       run: |
-        python setup.py sdist
+        python -m build
         twine upload dist/*


### PR DESCRIPTION
To have the wheel file available on pipy (useful for jupyterlite and faster way of installing the lib in general) 

#470 
