### PR TITLE
make sure the Fullscreen btn widden the appropriate map

### DIFF
--- a/docs/source/modules/sepal_ui.mapping.SepalMap.rst
+++ b/docs/source/modules/sepal_ui.mapping.SepalMap.rst
@@ -10,6 +10,7 @@ sepal\_ui.mapping.SepalMap
         ~SepalMap.ee
         ~SepalMap.dc
         ~SepalMap.v_inspector
+        ~SepalMap._id
         
     .. rubric:: Methods
     

--- a/sepal_ui/mapping/fullscreen_control.py
+++ b/sepal_ui/mapping/fullscreen_control.py
@@ -33,7 +33,7 @@ class FullScreenControl(WidgetControl):
     template = None
     "ipyvuetify.VuetifyTemplate: embeds the 2 javascripts methods to change the rendering of the map"
 
-    def __init__(self, **kwargs):
+    def __init__(self, m, **kwargs):
 
         # create a btn
         self.w_btn = MapBtn(logo=self.ICONS[self.zoomed])
@@ -59,7 +59,7 @@ class FullScreenControl(WidgetControl):
         <script>
             {methods: {
                 jupyter_fullscreen() {
-                    var element = document.getElementsByClassName("leaflet-container")[0];
+                    var element = document.querySelector(".%s .leaflet-container");
                     element.style.position = "fixed";
                     element.style.width = "100vw";
                     element.style.height = "100vh";
@@ -69,7 +69,7 @@ class FullScreenControl(WidgetControl):
                     window.dispatchEvent(new Event('resize'));
                 },
                 jupyter_embed() {
-                    var element = document.getElementsByClassName("leaflet-container")[0];
+                    var element = document.querySelector(".%s .leaflet-container");
                     element.style.position = "";
                     element.style.width = "";
                     element.style.height = "";
@@ -81,6 +81,7 @@ class FullScreenControl(WidgetControl):
             }}
         </script>
         """
+            % (m._id, m._id)
         )
         display(self.template)
 

--- a/sepal_ui/mapping/fullscreen_control.py
+++ b/sepal_ui/mapping/fullscreen_control.py
@@ -15,6 +15,7 @@ class FullScreenControl(WidgetControl):
     .. versionadded:: 2.7.0
 
     Args:
+        m (SepalMap): the map on which the mutated CSS will be applied (Only work with SepalMap as we are querying the _id)
         kwargs (optional): any available arguments from a ipyleaflet WidgetControl
     """
 

--- a/sepal_ui/mapping/sepal_map.py
+++ b/sepal_ui/mapping/sepal_map.py
@@ -10,6 +10,8 @@ from pathlib import Path
 from distutils.util import strtobool
 import warnings
 import math
+import string
+import random
 
 from haversine import haversine
 import numpy as np
@@ -74,6 +76,9 @@ class SepalMap(ipl.Map):
     dc = None
     "ipyleaflet.DrawingControl: the drawing control of the map"
 
+    _id = None
+    "str: a unique 6 letters str to identify the map in the DOM"
+
     def __init__(self, basemaps=[], dc=False, vinspector=False, gee=True, **kwargs):
 
         # set the default parameters
@@ -113,6 +118,11 @@ class SepalMap(ipl.Map):
         # specific v_inspector
         self.v_inspector = ValueInspector(self)
         not vinspector or self.add_control(self.v_inspector)
+
+        # create a proxy ID to the element
+        # this id should be unique and will be used by mutators to identify this map
+        self._id = "".join(random.choice(string.ascii_lowercase) for i in range(6))
+        self.add_class(self._id)
 
     @deprecated(version="2.8.0", reason="the local_layer stored list has been dropped")
     def _remove_local_raster(self, local_layer):

--- a/sepal_ui/scripts/utils.py
+++ b/sepal_ui/scripts/utils.py
@@ -115,7 +115,6 @@ def random_string(string_length=3):
         (str): A random string
     """
 
-    # random.seed(1001)
     letters = string.ascii_lowercase
 
     return "".join(random.choice(letters) for i in range(string_length))

--- a/tests/test_FullScreenControl.py
+++ b/tests/test_FullScreenControl.py
@@ -8,7 +8,7 @@ class TestFullScreenControl:
         map_ = sm.SepalMap()
 
         # add a fullscreenControl
-        control = sm.FullScreenControl()
+        control = sm.FullScreenControl(map_)
         map_.add_control(control)
 
         assert isinstance(control, sm.FullScreenControl)
@@ -21,7 +21,7 @@ class TestFullScreenControl:
     def test_toggle_fullscreen(self):
 
         map_ = sm.SepalMap()
-        control = sm.FullScreenControl()
+        control = sm.FullScreenControl(map_)
         map_.add_control(control)
 
         # trigger the click

--- a/tests/test_SepalMap.py
+++ b/tests/test_SepalMap.py
@@ -11,7 +11,7 @@ from sepal_ui import mapping as sm
 import sepal_ui.frontend.styles as styles
 
 # create a seed so that we can check values
-random.seed(10)
+random.seed(42)
 
 
 class TestSepalMap:
@@ -19,6 +19,7 @@ class TestSepalMap:
 
         # check that the map start with no info
         m = sm.SepalMap()
+        id1 = m._id  # to check that the next map has another ID
 
         assert isinstance(m, sm.SepalMap)
         assert m._id == "sbnpsa"
@@ -36,12 +37,11 @@ class TestSepalMap:
 
         # check that the map start with a DC
         m = sm.SepalMap(dc=True)
-        assert m._id == "fbqpkc"
+        assert m._id != id1
         assert m.dc in m.controls
 
         # check that the map starts with a vinspector
         m = sm.SepalMap(vinspector=True)
-        assert m._id == "hxlbne"
         assert m.v_inspector in m.controls
 
         # check that a wrong layer raise an error if it's not part of the leaflet basemap list
@@ -59,8 +59,8 @@ class TestSepalMap:
         zoom = random.randint(0, 22)
         m.set_center(lng, lat, zoom)
 
-        assert m.zoom == 5.0
-        assert m.center == [-23, 53]
+        assert m.zoom == zoom
+        assert m.center == [lat, lng]
 
         return
 

--- a/tests/test_SepalMap.py
+++ b/tests/test_SepalMap.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from random import randint
+import random
 from urllib.request import urlretrieve
 import math
 
@@ -10,6 +10,9 @@ from ipyleaflet import GeoJSON, LocalTileLayer
 from sepal_ui import mapping as sm
 import sepal_ui.frontend.styles as styles
 
+# create a seed so that we can check values
+random.seed(10)
+
 
 class TestSepalMap:
     def test_init(self):
@@ -18,6 +21,7 @@ class TestSepalMap:
         m = sm.SepalMap()
 
         assert isinstance(m, sm.SepalMap)
+        assert m._id == "sbnpsa"
         assert m.center == [0, 0]
         assert m.zoom == 2
         assert len(m.layers) == 1
@@ -32,10 +36,12 @@ class TestSepalMap:
 
         # check that the map start with a DC
         m = sm.SepalMap(dc=True)
+        assert m._id == "fbqpkc"
         assert m.dc in m.controls
 
         # check that the map starts with a vinspector
         m = sm.SepalMap(vinspector=True)
+        assert m._id == "hxlbne"
         assert m.v_inspector in m.controls
 
         # check that a wrong layer raise an error if it's not part of the leaflet basemap list
@@ -48,13 +54,13 @@ class TestSepalMap:
 
         m = sm.SepalMap()
 
-        lat = randint(-90, 90)
-        lng = randint(-180, 180)
-        zoom = randint(0, 22)
+        lat = random.randint(-90, 90)
+        lng = random.randint(-180, 180)
+        zoom = random.randint(0, 22)
         m.set_center(lng, lat, zoom)
 
-        assert m.zoom == zoom
-        assert m.center == [lat, lng]
+        assert m.zoom == 5.0
+        assert m.center == [-23, 53]
 
         return
 

--- a/tests/test_SepalMap.py
+++ b/tests/test_SepalMap.py
@@ -22,7 +22,6 @@ class TestSepalMap:
         id1 = m._id  # to check that the next map has another ID
 
         assert isinstance(m, sm.SepalMap)
-        assert m._id == "sbnpsa"
         assert m.center == [0, 0]
         assert m.zoom == 2
         assert len(m.layers) == 1


### PR DESCRIPTION
Fix #479 

## description

I set an automatic 6 letters `_id` to the maps. The `_id` is set as the class of the higher level DOM element of the widget.
I needed to add the `m` parameter to the `FullscreenControl` to let him access this value. 
I then slightly modified the JS template using a querySelector (css classic selection) to select the first map with the same class id. 

## notes

- As JS is using "{" I was unabled to use f-string or format (cannot escape this charater in any ways). As a last resort I used `%s` a,d it seems to work.
- I decided not to let the developer name the id as nobody will should use this variable outside of JS.
- When the kernel starts a seed is automatically chosen for the "random" module so it's impossible that 2 maps get the same ID. 

## demo 

copy paste the following code in a voila dashboard 

```python
from sepal_ui import mapping as sm 

map1 = sm.SepalMap(["HYBRID"], zoom=5)
map1.add_control(sm.FullScreenControl(map1))
display(map1)

map2 = sm.SepalMap(zoom=5)
map2.add_control(sm.FullScreenControl(map2))
display(map2)
```
