### PR TITLE
improve zoom management

### DIFF
--- a/docs/source/modules/sepal_ui.mapping.SepalMap.rst
+++ b/docs/source/modules/sepal_ui.mapping.SepalMap.rst
@@ -37,6 +37,7 @@ sepal\_ui.mapping.SepalMap
         ~SepalMap.getScale
         ~SepalMap.addLayer
         ~SepalMap.centerObject
+        ~SepalLap.zoom_raster
         
 .. automethod:: sepal_ui.mapping.SepalMap.remove_last_layer
 
@@ -79,3 +80,5 @@ sepal\_ui.mapping.SepalMap
 .. automethod:: sepal_ui.mapping.SepalMap.getScale
 
 .. automethod:: sepal_ui.mapping.SepalMap.centerObject
+
+.. automethod:: sepal_ui.mapping.SepalMap.zoom_raster

--- a/sepal_ui/mapping/sepal_map.py
+++ b/sepal_ui/mapping/sepal_map.py
@@ -179,18 +179,10 @@ class SepalMap(ipl.Map):
         ee_geometry = item if isinstance(item, ee.Geometry) else item.geometry()
 
         # extract bounds from ee_object
-        ee_bounds = ee_geometry.bounds().coordinates()
-        coords = ee_bounds.get(0).getInfo()
-
-        # Get (x, y) of the 4 cardinal points
-        bl, br, tr, tl, _ = coords
-
-        # Get (x, y) of the 4 cardinal points
-        min_lon, min_lat = bl
-        max_lon, max_lat = tr
+        coords = ee_geometry.bounds().coordinates().get(0).getInfo()
 
         # zoom on these bounds
-        self.zoom_bounds([min_lon, min_lat, max_lon, max_lat], zoom_out)
+        self.zoom_bounds((*coords[0], *coords[2]), zoom_out)
 
         return self
 

--- a/sepal_ui/mapping/sepal_map.py
+++ b/sepal_ui/mapping/sepal_map.py
@@ -10,8 +10,6 @@ from pathlib import Path
 from distutils.util import strtobool
 import warnings
 import math
-import string
-import random
 
 from haversine import haversine
 import numpy as np
@@ -76,9 +74,6 @@ class SepalMap(ipl.Map):
     dc = None
     "ipyleaflet.DrawingControl: the drawing control of the map"
 
-    _id = None
-    "str: a unique 6 letters str to identify the map in the DOM"
-
     def __init__(self, basemaps=[], dc=False, vinspector=False, gee=True, **kwargs):
 
         # set the default parameters
@@ -118,11 +113,6 @@ class SepalMap(ipl.Map):
         # specific v_inspector
         self.v_inspector = ValueInspector(self)
         not vinspector or self.add_control(self.v_inspector)
-
-        # create a proxy ID to the element
-        # this id should be unique and will be used by mutators to identify this map
-        self._id = "".join(random.choice(string.ascii_lowercase) for i in range(6))
-        self.add_class(self._id)
 
     @deprecated(version="2.8.0", reason="the local_layer stored list has been dropped")
     def _remove_local_raster(self, local_layer):
@@ -173,17 +163,20 @@ class SepalMap(ipl.Map):
         return
 
     @su.need_ee
-    def zoom_ee_object(self, ee_geometry, zoom_out=1):
+    def zoom_ee_object(self, item, zoom_out=1):
         """
         Get the proper zoom to the given ee geometry.
 
         Args:
-            ee_geometry (ee.Geometry): the geometry to zoom on
+            item (ee.ComputedObject): the geometry to zoom on
             zoom_out (int) (optional): Zoom out the bounding zoom
 
         Return:
             self
         """
+
+        # type check the given object
+        ee_geometry = item if isinstance(item, ee.Geometry) else item.geometry()
 
         # extract bounds from ee_object
         ee_bounds = ee_geometry.bounds().coordinates()

--- a/sepal_ui/mapping/sepal_map.py
+++ b/sepal_ui/mapping/sepal_map.py
@@ -203,21 +203,16 @@ class SepalMap(ipl.Map):
         # Center map to the centroid of the layer(s)
         self.center = [(maxy - miny) / 2 + miny, (maxx - minx) / 2 + minx]
 
-        tl = (minx, maxy)
-        bl = (minx, miny)
-        tr = (maxx, maxy)
-        br = (maxx, miny)
+        # create the tuples for each corner
+        tl, br, bl, tr = (minx, maxy), (maxx, miny), (minx, miny), (maxx, maxy)
 
+        # find zoom level to display the biggest diagonal (in km)
+        lg, zoom = 40075, 1  # number of displayed km at zoom 1
         maxsize = max(haversine(tl, br), haversine(bl, tr))
-
-        lg = 40075  # number of displayed km at zoom 1
-        zoom = 1
         while lg > maxsize:
-            zoom += 1
-            lg /= 2
+            (zoom, lg) = (zoom + 1, lg / 2)
 
-        if zoom_out > zoom:
-            zoom_out = zoom - 1
+        zoom_out = (zoom - 1) if zoom_out > zoom else zoom_out
 
         self.zoom = zoom - zoom_out
 

--- a/tests/test_SepalMap.py
+++ b/tests/test_SepalMap.py
@@ -360,6 +360,17 @@ class TestSepalMap:
 
         return
 
+    def test_zoom_raster(self, byte):
+
+        m = sm.SepalMap()
+        layer = m.add_raster(byte, fit_bounds=False)
+        m.zoom_raster(layer)
+
+        assert m.center == [33.89703655465772, -117.63458938969723]
+        assert m.zoom == 15.0
+
+        return
+
     @pytest.fixture
     def rgb(self):
         """add a raster file of the bahamas coming from rasterio test suit"""

--- a/tests/test_SepalMap.py
+++ b/tests/test_SepalMap.py
@@ -366,7 +366,8 @@ class TestSepalMap:
         layer = m.add_raster(byte, fit_bounds=False)
         m.zoom_raster(layer)
 
-        assert m.center == [33.89703655465772, -117.63458938969723]
+        center = [33.89703655465772, -117.63458938969723]
+        assert all([math.isclose(s, t, rel_tol=0.2) for s, t in zip(m.center, center)])
         assert m.zoom == 15.0
 
         return


### PR DESCRIPTION
attempt to fix #480 

- `zoom_ee_object` now behaves exactly like `CenterObject` as it's accepting `Image`, `Feature` etc...)
- `zoom_raster` allows zooming on a specific raster layer. the layer need to be added to the map first and the layer object in now an output of the `add_raster` method.
- small refactoring of the zoom methods