### PR TITLE
feat: introduce tqdm progress bar. related with #294

### DIFF
--- a/sepal_ui/frontend/styles.py
+++ b/sepal_ui/frontend/styles.py
@@ -128,6 +128,7 @@ class Styles(v.VuetifyTemplate):
     - remove shadow of widget-control
     - remove padding of the main content
     - load fontawsome as a resource
+    - ensure that tqdm bars are using a transparent background when displayed in an alert
     """
 
     template = Unicode(
@@ -138,6 +139,7 @@ class Styles(v.VuetifyTemplate):
             .leaflet-widgetcontrol {box-shadow: none}
             main.v-content {padding-top: 0px !important;}
             .leaflet-control-container .vuetify-styles .v-application {background: rgb(0,0,0,0);}
+            .v-alert__wrapper .progress {background-color: transparent;}
         </style>
         <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.4/css/all.min.css"/>
     """

--- a/sepal_ui/sepalwidgets/alert.py
+++ b/sepal_ui/sepalwidgets/alert.py
@@ -109,6 +109,11 @@ class Alert(v.Alert, SepalWidget):
             with self.progress_output:
                 self.progress_output.clear_output()
                 self.progress_bar = tqdm(**tqdm_args)
+                self.progress_bar.container.children[0].add_class(f"{self.type}--text")
+                self.progress_bar.container.children[2].add_class(f"{self.type}--text")
+                self.progress_bar.container.children[1].add_class("toto")
+
+                # style.bar_color = '#ffff00'
 
                 # Initialize bar
                 self.progress_bar.update(0)
@@ -118,7 +123,9 @@ class Alert(v.Alert, SepalWidget):
         if progress == 1:
 
             self.progress_bar.close()
-            self.progress_bar.colour = color.success
+            # self.progress_bar.colour = color.success
+
+        return
 
     def add_msg(self, msg, type_="info"):
         """

--- a/sepal_ui/sepalwidgets/alert.py
+++ b/sepal_ui/sepalwidgets/alert.py
@@ -1,5 +1,5 @@
 from datetime import datetime
-from tqdm.auto import tqdm
+from tqdm.notebook import tqdm
 from ipywidgets import jslink, Output
 import ipyvuetify as v
 from traitlets import Unicode, observe, directional_link, Bool
@@ -74,7 +74,7 @@ class Alert(v.Alert, SepalWidget):
         self.progress_output = Output()
         self.progress_bar = None
 
-    def update_progress(self, progress, msg="Progress", bar_length=30, **tqdm_args):
+    def update_progress(self, progress, msg="Progress", **tqdm_args):
         """
         Update the Alert message with a progress bar. This function will stay until we
         manage to use tqdm in the widgets
@@ -111,9 +111,6 @@ class Alert(v.Alert, SepalWidget):
                 self.progress_bar = tqdm(**tqdm_args)
                 self.progress_bar.container.children[0].add_class(f"{self.type}--text")
                 self.progress_bar.container.children[2].add_class(f"{self.type}--text")
-                self.progress_bar.container.children[1].add_class("toto")
-
-                # style.bar_color = '#ffff00'
 
                 # Initialize bar
                 self.progress_bar.update(0)
@@ -121,9 +118,7 @@ class Alert(v.Alert, SepalWidget):
         self.progress_bar.update(progress * 100 - self.progress_bar.n)
 
         if progress == 1:
-
             self.progress_bar.close()
-            # self.progress_bar.colour = color.success
 
         return
 

--- a/sepal_ui/sepalwidgets/alert.py
+++ b/sepal_ui/sepalwidgets/alert.py
@@ -1,12 +1,12 @@
 from datetime import datetime
-
-from ipywidgets import jslink
+from tqdm.auto import tqdm
+from ipywidgets import jslink, Output
 import ipyvuetify as v
 from traitlets import Unicode, observe, directional_link, Bool
 
 from sepal_ui.sepalwidgets.sepalwidget import SepalWidget
 from sepal_ui.scripts.utils import set_type
-from sepal_ui.frontend.styles import TYPES
+from sepal_ui.frontend.styles import TYPES, color
 from sepal_ui.message import ms
 
 __all__ = ["Divider", "Alert", "StateBar", "Banner"]
@@ -71,10 +71,13 @@ class Alert(v.Alert, SepalWidget):
         super().__init__(**kwargs)
 
         self.hide()
+        self.progress_output = Output()
+        self.progress_bar = None
 
-    def update_progress(self, progress, msg="Progress", bar_length=30):
+    def update_progress(self, progress, msg="Progress", bar_length=30, **tqdm_args):
         """
-        Update the Alert message with a progress bar. This function will stay until we manage to use tqdm in the widgets
+        Update the Alert message with a progress bar. This function will stay until we
+        manage to use tqdm in the widgets
 
         Args:
             progress (float): the progress status in float [0, 1]
@@ -85,38 +88,37 @@ class Alert(v.Alert, SepalWidget):
             self
         """
 
-        # define the characters to use in the progress bar
-        plain_char = "█"
-        empty_char = " "
-
         # cast the progress to float
         progress = float(progress)
         if not (0 <= progress <= 1):
             raise ValueError(f"progress should be in [0, 1], {progress} given")
 
-        # set the length parameter
-        block = int(round(bar_length * progress))
+        # Prevent adding multiple times
+        if self.progress_output not in self.children:
 
-        # construct the message content
-        text = f"|{plain_char * block + empty_char * (bar_length - block)}|"
+            self.children = [self.progress_output]
 
-        # add the message to the output
-        self.add_live_msg(
-            v.Html(
-                tag="span",
-                children=[
-                    v.Html(tag="span", children=[f"{msg}: "], class_="d-inline"),
-                    v.Html(tag="pre", class_="info--text d-inline", children=[text]),
-                    v.Html(
-                        tag="span",
-                        children=[f" {progress *100:.1f}%"],
-                        class_="d-inline",
-                    ),
-                ],
+            tqdm_args["bar_format"] = tqdm_args.pop(
+                "bar_format", "{l_bar}{bar}{n_fmt}/{total_fmt}"
             )
-        )
+            tqdm_args["dynamic_ncols"] = tqdm_args.pop("dynamic_ncols", tqdm_args)
+            tqdm_args["total"] = tqdm_args.pop("total", 100)
+            tqdm_args["desc"] = tqdm_args.pop("desc", msg)
+            tqdm_args["colour"] = tqdm_args.pop("tqdm_args", getattr(color, self.type))
 
-        return self
+            with self.progress_output:
+                self.progress_output.clear_output()
+                self.progress_bar = tqdm(**tqdm_args)
+
+                # Initialize bar
+                self.progress_bar.update(0)
+
+        self.progress_bar.update(progress * 100 - self.progress_bar.n)
+
+        if progress == 1:
+
+            self.progress_bar.close()
+            self.progress_bar.colour = color.success
 
     def add_msg(self, msg, type_="info"):
         """

--- a/setup.py
+++ b/setup.py
@@ -51,6 +51,7 @@ setup_params = {
         "planet",
         "pyyaml",
         "dask",
+        "tqdm",
     ],
     "extras_require": {
         "dev": [

--- a/tests/test_Alert.py
+++ b/tests/test_Alert.py
@@ -183,8 +183,8 @@ class TestAlert:
 
         # test a random update
         alert.update_progress(0.5)
-        assert alert.children[1].children[0].children[2].children[0] == " 50.0%"
+        assert alert.progress_bar.n == 50
 
         # show that a value > 1 raise an error
-        with pytest.raises(Exception):
+        with pytest.raises(ValueError):
             alert.update_progress(1.5)


### PR DESCRIPTION
This PR aims to introduce the tqdm alert progress bar referenced by the (quite old)  #294 issue. 

- Even though it's doing what's expected, I can't manage to let the `tqdm` container `HBox` inherit the ipyvuetify styles, causing the text within the progress bar to be totally different. @12rambau would you like to give a check?
- In relation to the time, it does totally faster than the previous implementation.
- I've marked it as draft until we can manage the styles, and then I'll proceed with documentation and styles.



## Testing code:

```Python
import sepal_ui.sepalwidgets as sw
import urllib
from pathlib import Path
alert = sw.Alert().show()
url = 'https://firms.modaps.eosdis.nasa.gov/data/country/zips/modis_2000_all_countries.zip'
display(alert)

progress = 0
def update_progress(b, bsize, tsize):
    alert.update_progress(min(int(b*bsize*100/tsize), 100)/100)
urllib.request.urlretrieve(url, Path('~').expanduser()/'tmp/dum.zip', update_progress)

````

## Preview

![Proyecto sin título](https://user-images.githubusercontent.com/12363250/171906116-cca3cdd9-a91d-401f-b91a-cd3833902e2a.gif)

