### PR TITLE
speed up aoi method change

### DIFF
--- a/sepal_ui/aoi/aoi_view.py
+++ b/sepal_ui/aoi/aoi_view.py
@@ -361,28 +361,26 @@ class AoiView(sw.Card):
     def reset(self):
         """clear the aoi_model from input and remove the layer from the map (if existing)"""
 
-        # clear the map
-        self.map_ is None or self.map_.remove_layer("aoi", none_ok=True)
-
-        # clear the inputs
-        [w.reset() for w in self.components.values()]
-
-        # clear the model
-        self.model.clear_attributes()
-
-        # reset the alert
-        self.alert.reset()
-
         # reset the view of the widgets
         self.w_method.v_model = None
 
+        # clear the map
+        self.map_ is None or self.map_.remove_layer("aoi", none_ok=True)
+
         return self
 
+    @su.switch("loading", on_widgets=["w_method"])
     def _activate(self, change):
         """activate the adapted widgets"""
 
         # clear and hide the alert
         self.alert.reset()
+
+        # hide the widget so that the user doens't see status changes
+        [w.hide() for w in self.components.values()]
+
+        # clear the inputs in a second step as reseting a FileInput can be long
+        [w.reset() for w in self.components.values()]
 
         # deactivate or activate the dc
         # clear the geo_json saved features to start from scratch
@@ -392,17 +390,12 @@ class AoiView(sw.Card):
             else:
                 self.map_.dc.hide()
 
-        # clear the inputs
-        [w.reset() for w in self.components.values()]
-
-        # activate the widget
-        [
-            w.show() if change["new"] == k else w.hide()
-            for k, w in self.components.items()
-        ]
+        # activate the correct widget
+        w = next((w for k, w in self.components.items() if k == change["new"]), None)
+        w is None or w.show()
 
         # init the name to the current value
         now = dt.now().strftime("%Y-%m-%d_%H-%M-%S")
         self.w_draw.v_model = None if change["new"] is None else f"Manual_aoi_{now}"
 
-        return self
+        return

--- a/sepal_ui/aoi/aoi_view.py
+++ b/sepal_ui/aoi/aoi_view.py
@@ -366,19 +366,15 @@ class AoiView(sw.Card):
 
         # clear the inputs
         [w.reset() for w in self.components.values()]
-        print(self.w_draw.v_model)
 
         # clear the model
         self.model.clear_attributes()
-        print(self.w_draw.v_model)
 
         # reset the alert
         self.alert.reset()
-        print(self.w_draw.v_model)
 
         # reset the view of the widgets
         self.w_method.v_model = None
-        print(self.w_draw.v_model)
 
         return self
 

--- a/sepal_ui/sepalwidgets/inputs.py
+++ b/sepal_ui/sepalwidgets/inputs.py
@@ -296,11 +296,15 @@ class FileInput(v.Flex, SepalWidget):
         # note: The args arguments are useless here but need to be kept so that
         # the function is natively compatible with the clear btn
 
-        # move to root
-        self._on_file_select({"new": Path.home()})
+        # do nothing if nothing is set to avoids extremelly long waiting
+        # time when multiple fileInput are reset at the same time as in the aoiView
+        if self.v_model is not None:
 
-        # remove v_model
-        self.v_model = None
+            # move to root
+            self._on_file_select({"new": Path.home()})
+
+            # remove v_model
+            self.v_model = None
 
         return self
 
@@ -1015,12 +1019,16 @@ class VectorField(v.Col, SepalWidget):
     def _update_column(self, change):
         """Update the column name and empty the value list"""
 
+        # set the value
+        self._set_v_model("column", change["new"])
+
+        # exit if nothing as the only way to set this value to None is the reset
+        if not change["new"]:
+            return self
+
         # reset value widget
         self.w_value.items = []
         self.w_value.v_model = None
-
-        # set the value
-        self._set_v_model("column", change["new"])
 
         # hide value if "ALL" or none
         if change["new"] in ["ALL", None]:


### PR DESCRIPTION
I removed the None test in fileinput in 2.9.0 thinking I was optimizing the code. 
This test is to prevent to reload the root folder if the file input is already set to `None`. It's super useful in AoiView where you always reset 3 FileInput when changing from 1 method to another. 

- Vastly speed up AoiView
- remove legacy prints
- add the loading state when method is being loaded

Fix #554 