### PR TITLE
Legend suggestion

### DIFF
--- a/sepal_ui/mapping/__init__.py
+++ b/sepal_ui/mapping/__init__.py
@@ -3,7 +3,7 @@ from .draw_control import *
 from .fullscreen_control import *
 from .layer import *
 from .layer_state_control import *
-from .legend import *
+from .legend_control import *
 from .map_btn import *
 from .menu_control import *
 from .sepal_map import *

--- a/sepal_ui/mapping/legend_control.py
+++ b/sepal_ui/mapping/legend_control.py
@@ -45,7 +45,7 @@ class LegendControl(WidgetControl):
         self._html_title = sw.Html(tag="h4", children=[f"{self.title}"])
         self._html_table = sw.Html(tag="table", children=[])
 
-        # create a card insode the widget
+        # create a card inside the widget
         # Be sure that the scroll bar will be shown up when legend horizontal
         card = sw.Card(
             style_="overflow-x:auto; white-space: nowrap;",

--- a/sepal_ui/mapping/sepal_map.py
+++ b/sepal_ui/mapping/sepal_map.py
@@ -33,7 +33,7 @@ from sepal_ui.mapping.basemaps import basemap_tiles
 from sepal_ui.mapping.draw_control import DrawControl
 from sepal_ui.mapping.layer import EELayer
 from sepal_ui.mapping.layer_state_control import LayerStateControl
-from sepal_ui.mapping.legend import Legend
+from sepal_ui.mapping.legend_control import LegendControl
 from sepal_ui.mapping.value_inspector import ValueInspector
 from sepal_ui.message import ms
 from sepal_ui.scripts import utils as su
@@ -867,7 +867,8 @@ class SepalMap(ipl.Map):
         position="bottomright",
         vertical=True,
     ):
-        """Creates and adds a custom legend as widget control to the map
+        """
+        Creates and adds a custom legend as widget control to the map
 
         Args:
             title (str, optional): Title of the legend. Defaults to 'Legend'.
@@ -875,11 +876,11 @@ class SepalMap(ipl.Map):
         """
 
         # Define as class member so it can be accessed from outside.
-        self.legend = Legend(legend_dict, title=title, vertical=vertical)
+        self.legend = LegendControl(
+            legend_dict, title=title, vertical=vertical, position=position
+        )
 
-        legend_control = ipl.WidgetControl(widget=self.legend, position=position)
-
-        self.add_control(legend_control)
+        return self.add_control(self.legend)
 
     # ##########################################################################
     # ###                overwrite geemap calls                              ###

--- a/tests/test_LegendControl.py
+++ b/tests/test_LegendControl.py
@@ -1,6 +1,6 @@
 import re
 
-from sepal_ui.mapping import Legend
+from sepal_ui.mapping import LegendControl
 
 
 class TestLegend:
@@ -25,11 +25,11 @@ class TestLegend:
             "Warning",
         ]
 
-        legend = Legend(legend_dict, title="Legend")
+        legend = LegendControl(legend_dict, title="Legend")
 
         # Check all the default values
         assert legend.title == "Legend"
-        assert legend.html_title.children[0] == "Legend"
+        assert legend._html_title.children[0] == "Legend"
         assert legend.legend_dict == legend_dict
 
         # check all the labels and colors are present in the html
@@ -37,8 +37,9 @@ class TestLegend:
         assert all([color in str(legend._html_table) for color in legend_dict.values()])
 
         # Check the lenght
-
         assert len(legend) == 6
+
+        return
 
     def test_set_legend(self):
 
@@ -47,7 +48,7 @@ class TestLegend:
             "info": "#79b1c9",
         }
 
-        legend = Legend(legend_dict)
+        legend = LegendControl(legend_dict)
 
         new_legend = {
             "forest": "#b3842e",
@@ -78,6 +79,8 @@ class TestLegend:
         legend.vertical = False
         assert str(legend._html_table).count("'tr'") == 0
 
+        return
+
     def test_update_title(self):
 
         legend_dict = {
@@ -85,13 +88,15 @@ class TestLegend:
             "info": "#79b1c9",
         }
 
-        legend = Legend(legend_dict)
+        legend = LegendControl(legend_dict)
 
         legend.title = "leyenda"
 
         # Check all the default values
         assert legend.title == "leyenda"
-        assert legend.html_title.children[0] == "leyenda"
+        assert legend._html_title.children[0] == "leyenda"
+
+        return
 
     def test_color_box(self):
 
@@ -99,9 +104,11 @@ class TestLegend:
             "forest": "#b3842e",
             "info": "#79b1c9",
         }
-        legend = Legend(legend_dict)
+        legend = LegendControl(legend_dict)
         str_box = re.sub("[ ]+", "", str(legend.color_box("blue", 50)[0]))
 
         assert "fill:#0000ff" in str_box
         assert "width='50'" in str_box
         assert "'height='25.0'" in str_box
+
+        return

--- a/tests/test_SepalMap.py
+++ b/tests/test_SepalMap.py
@@ -11,7 +11,7 @@ from ipyleaflet import GeoJSON
 from sepal_ui import get_theme
 from sepal_ui import mapping as sm
 from sepal_ui.frontend import styles as ss
-from sepal_ui.mapping.legend import Legend
+from sepal_ui.mapping.legend_control import LegendControl
 
 # create a seed so that we can check values
 random.seed(42)
@@ -402,8 +402,10 @@ class TestSepalMap:
         ee_map_with_layers.add_legend(legend_dict=legend_dict)
 
         # just test that is a Legend, the rest is tested by Legend
-        assert isinstance(ee_map_with_layers.legend, Legend)
+        assert isinstance(ee_map_with_layers.legend, LegendControl)
         assert ee_map_with_layers.legend.legend_dict == legend_dict
+
+        return
 
     @pytest.fixture
     def rgb(self):


### PR DESCRIPTION
small implementation change: 

`Lengend` is now not a `Card` but a `WidgetControl`. It allows more flexibility to add it to the map: 

people that are used to ipyleaflet: 
```python 
legend = sm.LengendControl({})
map = SepalMap()
map.add_control(legend)
```

people that know the lib very well 
```python 
map = SepalMap()
map.add_legend({}, position="topleft")
```

I think the implementation you did pave the way for all the controls in general: 
- the ipyleaflet way (created outside used outside) 
- the semi auto (created with a specific method, added to the member)
- the lazy one (create at init state, added to the members)

This will of course be handled in another PR and another issue


