### PR TITLE
fix: set the drawer on top of the appbar

### DIFF
--- a/sepal_ui/frontend/css/custom.css
+++ b/sepal_ui/frontend/css/custom.css
@@ -5,3 +5,4 @@ main.v-content {padding-top: 0px !important;}
 .leaflet-control-container .vuetify-styles .v-application {background: rgb(0,0,0,0);}
 .v-alert__wrapper .progress {background-color: transparent;}
 header.v-app-bar {z-index: 800 !important}
+nav.v-navigation-drawer {z-index: 900 !important}


### PR DESCRIPTION
Fix #568 

The app bar as set with a higher z-inex to be on top of the fullscreen app, here I make sure that the drawer is even higher. 
