### PR TITLE
docs: update icons

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -111,12 +111,12 @@ html_theme_options = {
         {
             "name": "GitHub",
             "url": "https://github.com/12rambau/sepal_ui",
-            "icon": "fab fa-github",
+            "icon": "fa-brands fa-github",
         },
         {
             "name": "Pypi",
             "url": "https://pypi.org/project/sepal-ui/",
-            "icon": "fab fa-python",
+            "icon": "fa-brands fa-python",
         },
     ],
 }


### PR DESCRIPTION
Fix #613 

<img width="168" alt="Capture d’écran 2022-11-22 à 00 12 57" src="https://user-images.githubusercontent.com/12596392/203176662-d0eee9a7-f892-4abb-8f48-e8f4ffa8dc49.png">
