### PR TITLE
fix: create a specific aoi_dc on the map

### DIFF
--- a/sepal_ui/mapping/draw_control.py
+++ b/sepal_ui/mapping/draw_control.py
@@ -2,8 +2,9 @@ from copy import deepcopy
 
 import geopandas as gpd
 from ipyleaflet import DrawControl
-from sepal_ui import color
 from shapely import geometry as sg
+
+from sepal_ui import color
 
 
 class DrawControl(DrawControl):
@@ -29,7 +30,7 @@ class DrawControl(DrawControl):
         kwargs["circle"] = kwargs.pop("circle", options)
         kwargs["polygon"] = kwargs.pop("polygon", options)
 
-        # save the map in the memeber of the objects
+        # save the map in the member of the objects
         self.m = m
 
         super().__init__(**kwargs)


### PR DESCRIPTION
Fix #595

Create a aoi_dc on the fly if a map is specified. This create a duplicate but ensure that if 2 dcs are added to the map, AoiVeiw abject will only manipulate this one.