### PR TITLE
test: use sugar-pytest to have more test outputs

### DIFF
--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -67,7 +67,7 @@ jobs:
           assert len(unexpected) == 0
       
       - name: test with pytest
-        run: coverage run -m pytest --color=yes tests
+        run: coverage run -m pytest --color=yes --force-sugar tests
         
       - name: build the template panel application 
         if: matrix.python-version == '3.8'

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -67,7 +67,7 @@ jobs:
           assert len(unexpected) == 0
       
       - name: test with pytest
-        run: coverage run -m pytest --color=yes --force-sugar tests
+        run: coverage run -m pytest --color=yes tests
         
       - name: build the template panel application 
         if: matrix.python-version == '3.8'

--- a/setup.py
+++ b/setup.py
@@ -80,6 +80,7 @@ setup_params = {
         "test": [
             "coverage",
             "pytest",
+            "pytest-sugar",
             "nbmake ",
         ],
         "doc": [


### PR DESCRIPTION
I wanted more information specifically: 
- the total execution time
- the error directly where they appear
- In github actions we still use the default one as it's a non interactive shell