### PR TITLE
test: add pytest missing plugins

### DIFF
--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -72,7 +72,7 @@ jobs:
           assert len(unexpected) == 0
       
       - name: test with pytest
-        run: coverage run -m pytest --color=yes --instafail tests
+        run: pytest --color=yes --cov --cov-report=xml --instafail tests
         
       - name: assess dead fixtures
         if: matrix.python-version == '3.8'

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -74,15 +74,17 @@ jobs:
       - name: test with pytest
         run: coverage run -m pytest --color=yes --instafail tests
         
+      - name: assess dead fixtures
+        if: matrix.python-version == '3.8'
+        run: pytest --dead-fixtures
+        
       - name: build the template panel application 
         if: matrix.python-version == '3.8'
-        run: |
-          pytest --nbmake sepal_ui/templates/panel_app/ui.ipynb
+        run: pytest --nbmake sepal_ui/templates/panel_app/ui.ipynb
           
       - name: build the template map application 
         if: matrix.python-version == '3.8'
-        run: |
-          pytest --nbmake sepal_ui/templates/map_app/ui.ipynb
+        run: pytest --nbmake sepal_ui/templates/map_app/ui.ipynb
         
       - name: coverage
         run: coverage xml

--- a/setup.py
+++ b/setup.py
@@ -84,6 +84,7 @@ setup_params = {
             "pytest-icdiff",
             "pytest-instafail",
             "pytest-deadfixtures",
+            "pytest-cov",
             "nbmake ",
         ],
         "doc": [

--- a/setup.py
+++ b/setup.py
@@ -83,6 +83,7 @@ setup_params = {
             "pytest-sugar",
             "pytest-icdiff",
             "pytest-instafail",
+            "pytest-deadfixtures",
             "nbmake ",
         ],
         "doc": [

--- a/tests/test_PlanetModel.py
+++ b/tests/test_PlanetModel.py
@@ -9,11 +9,17 @@ from sepal_ui.planetapi import PlanetModel
 
 @pytest.mark.skipif("PLANET_API_KEY" not in os.environ, reason="requires Planet")
 class TestPlanetModel:
-    @pytest.mark.parametrize("credentials", ["planet_key", "cred"])
-    def test_init(self, credentials, request):
+    def test_init(self, planet_key, cred, request):
 
-        # Test with a valid api key and login credentials
-        planet_model = PlanetModel(request.getfixturevalue(credentials))
+        # Test with a valid api key
+        planet_model = PlanetModel(planet_key)
+
+        assert isinstance(planet_model, PlanetModel)
+        assert isinstance(planet_model.session, planet.http.Session)
+        assert planet_model.active is True
+
+        # Test with a valid login credentials
+        planet_model = PlanetModel(cred)
 
         assert isinstance(planet_model, PlanetModel)
         assert isinstance(planet_model.session, planet.http.Session)
@@ -56,10 +62,7 @@ class TestPlanetModel:
 
         return
 
-    def test_is_active(self, planet_key):
-
-        # We only need to test with a key.
-        planet_model = PlanetModel(planet_key)
+    def test_is_active(self, planet_model):
 
         planet_model._is_active()
         assert planet_model.active is True
@@ -69,9 +72,8 @@ class TestPlanetModel:
 
         return
 
-    def test_get_subscriptions(self, planet_key):
+    def test_get_subscriptions(self, planet_model):
 
-        planet_model = PlanetModel(planet_key)
         subs = planet_model.get_subscriptions()
 
         # Check object has length, because there is no way to check a value
@@ -80,10 +82,7 @@ class TestPlanetModel:
 
         return
 
-    def test_get_planet_items(self, planet_key):
-
-        # Arrange
-        planet_model = PlanetModel(planet_key)
+    def test_get_planet_items(self, planet_model):
 
         aoi = {  # Yasuni national park in Ecuador
             "type": "Polygon",
@@ -119,3 +118,11 @@ class TestPlanetModel:
         credentials = json.loads(os.getenv("PLANET_API_CREDENTIALS"))
 
         return list(credentials.values())
+
+    @pytest.fixture
+    def planet_model(self):
+        """Start a planet model using the API key"""
+
+        key = os.getenv("PLANET_API_KEY")
+
+        return PlanetModel(key)


### PR DESCRIPTION
Final touch to the pytest plugins: Fix #630 

## pytest-deadfixture

- install `pytest-deadfixture` in `setup.py `
- use it the unit test suit against python 3.8 (example of failure: https://github.com/12rambau/sepal_ui/actions/runs/3571282698/jobs/6003017612)
- tune test_PlanetModel to expose the use of `cred` and `planet_api`

## pytest-cov

- install `pytest-cov` in `setup.py`
- use it in our unit test suit to generate the xml coverage file