### PR TITLE
fix: remove left when only icon is set

### DIFF
--- a/sepal_ui/sepalwidgets/btn.py
+++ b/sepal_ui/sepalwidgets/btn.py
@@ -25,6 +25,9 @@ class Btn(v.Btn, SepalWidget):
 
     .. deprecated:: 2.13
         ``text`` and ``icon`` will be replaced by ``msg`` and ``gliph`` to avoid duplicating ipyvuetify trait.
+
+    .. deprecated:: 2.14
+        Btn is not using a default ``msg`` anymor`.
     """
 
     v_icon = None
@@ -36,7 +39,7 @@ class Btn(v.Btn, SepalWidget):
     msg = Unicode("").tag(sync=True)
     "traitlet.Unicode: the text of the btn"
 
-    def __init__(self, msg="Click", gliph="", **kwargs):
+    def __init__(self, msg="", gliph="", **kwargs):
 
         # deprecation in 2.13 of text and icon
         # as they already exist in the ipyvuetify Btn traits (as booleans)
@@ -55,7 +58,7 @@ class Btn(v.Btn, SepalWidget):
                 )
 
         # create the default v_icon
-        self.v_icon = v.Icon(left=True, children=[""])
+        self.v_icon = v.Icon(children=[""])
 
         # set the default parameters
         kwargs["color"] = kwargs.pop("color", "primary")
@@ -88,8 +91,12 @@ class Btn(v.Btn, SepalWidget):
         """
         Set the text of the btn
         """
-
-        self.children = [self.v_icon, change["new"]]
+        if change["new"]:
+            self.v_icon.left = True
+            self.children = [self.v_icon, change["new"]]
+        else:
+            self.v_icon.left = False
+            self.children = [self.v_icon]
 
         return self
 

--- a/sepal_ui/sepalwidgets/btn.py
+++ b/sepal_ui/sepalwidgets/btn.py
@@ -91,12 +91,9 @@ class Btn(v.Btn, SepalWidget):
         """
         Set the text of the btn
         """
-        if change["new"]:
-            self.v_icon.left = True
-            self.children = [self.v_icon, change["new"]]
-        else:
-            self.v_icon.left = False
-            self.children = [self.v_icon]
+
+        self.v_icon.left = bool(change["new"])
+        self.children = [self.v_icon, change["new"]]
 
         return self
 

--- a/tests/test_Btn.py
+++ b/tests/test_Btn.py
@@ -11,6 +11,7 @@ class TestBtn:
         btn = sw.Btn()
         assert btn.color == "primary"
         assert btn.v_icon.children[0] == ""
+        assert btn.children[1] == ""
 
         # extensive btn
         btn = sw.Btn("toto", "fas fa-folder")
@@ -50,7 +51,7 @@ class TestBtn:
 
         # display only the gliph
         btn.msg = ""
-        assert len(btn.children) == 1
+        assert btn.children[1] == ""
         assert btn.v_icon.left is False
 
         # remove all gliph

--- a/tests/test_Btn.py
+++ b/tests/test_Btn.py
@@ -11,7 +11,6 @@ class TestBtn:
         btn = sw.Btn()
         assert btn.color == "primary"
         assert btn.v_icon.children[0] == ""
-        assert btn.children[1] == "Click"
 
         # extensive btn
         btn = sw.Btn("toto", "fas fa-folder")
@@ -42,11 +41,17 @@ class TestBtn:
 
         assert isinstance(btn.v_icon, v.Icon)
         assert btn.v_icon.children[0] == gliph
+        assert btn.v_icon.left is True
 
         # change existing icon
         gliph = "fas fa-file"
         btn.gliph = gliph
         assert btn.v_icon.children[0] == gliph
+
+        # display only the gliph
+        btn.msg = ""
+        assert len(btn.children) == 1
+        assert btn.v_icon.left is False
 
         # remove all gliph
         gliph = ""
@@ -79,4 +84,4 @@ class TestBtn:
     def btn(self):
         """Create a simple btn"""
 
-        return sw.Btn()
+        return sw.Btn("Click")


### PR DESCRIPTION
FIx #623 

- removed the default "click" parameter 
- remove the `left` trait of the `v_icon` when the text is not set