### PR TITLE
fix: update_progress accept values >1

### DIFF
--- a/sepal_ui/sepalwidgets/alert.py
+++ b/sepal_ui/sepalwidgets/alert.py
@@ -94,9 +94,10 @@ class Alert(v.Alert, SepalWidget):
         self.show()
 
         # cast the progress to float
+        total = tqdm_args.get("total", 1)
         progress = float(progress)
-        if not (0 <= progress <= 1):
-            raise ValueError(f"progress should be in [0, 1], {progress} given")
+        if not (0 <= progress <= total):
+            raise ValueError(f"progress should be in [0, {total}], {progress} given")
 
         # Prevent adding multiple times
         if self.progress_output not in self.children:
@@ -107,7 +108,7 @@ class Alert(v.Alert, SepalWidget):
                 "bar_format", "{l_bar}{bar}{n_fmt}/{total_fmt}"
             )
             tqdm_args["dynamic_ncols"] = tqdm_args.pop("dynamic_ncols", tqdm_args)
-            tqdm_args["total"] = tqdm_args.pop("total", 100)
+            tqdm_args["total"] = tqdm_args.pop("total", 1)
             tqdm_args["desc"] = tqdm_args.pop("desc", msg)
             tqdm_args["colour"] = tqdm_args.pop("tqdm_args", getattr(color, self.type))
 
@@ -120,7 +121,7 @@ class Alert(v.Alert, SepalWidget):
                 # Initialize bar
                 self.progress_bar.update(0)
 
-        self.progress_bar.update(progress * 100 - self.progress_bar.n)
+        self.progress_bar.update(progress - self.progress_bar.n)
 
         if progress == 1:
             self.progress_bar.close()

--- a/tests/test_Alert.py
+++ b/tests/test_Alert.py
@@ -153,11 +153,18 @@ class TestAlert:
 
         # test a random update
         alert.update_progress(0.5)
-        assert alert.progress_bar.n == 50
+        assert alert.progress_bar.n == 0.5
         assert alert.viz is True
 
         # show that a value > 1 raise an error
         with pytest.raises(ValueError):
+            alert.reset()
             alert.update_progress(1.5)
+
+        # check that if total is set value can be more than 1
+        alert.reset()
+        alert.update_progress(50, total=100)
+        assert alert.progress_bar.n == 50
+        assert alert.viz is True
 
         return


### PR DESCRIPTION
- by default ùpdate_progress continues to refuse values >1 (no regression)
- the user can select a different `total` parameter for tqdm and then the value should only be <`total`

Fix #562 