### PR TITLE
fix: add checks for bin content 

### DIFF
--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -46,6 +46,17 @@ jobs:
       - name: Install dependencies
         run: pip install .[test]
 
+      - name: test the entrypoints
+        if: matrix.python-version == '3.9'
+        run: |
+          module_deploy --help
+          module_factory --help
+          module_l10n --help
+          module_theme --help
+          module_venv --help
+          activate_venv --help
+          sepal_ipyvuetify --help
+
       - name: build the documentation
         if: matrix.python-version == '3.8'
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -57,6 +57,7 @@ coverage.xml
 *.py,cover
 .hypothesis/
 .pytest_cache/
+.ruff_cache/
 
 # Translations
 *.mo

--- a/noxfile.py
+++ b/noxfile.py
@@ -23,6 +23,19 @@ def test(session):
 
 
 @nox.session(reuse_venv=True)
+def bin(session):
+    """Run all the bin methods to validate the conda recipe."""
+    session.install(".")
+    session.run("module_deploy", "--help")
+    session.run("module_factory", "--help")
+    session.run("module_l10n", "--help")
+    session.run("module_theme", "--help")
+    session.run("module_venv", "--help")
+    session.run("activate_venv", "--help")
+    session.run("sepal_ipyvuetify", "--help")
+
+
+@nox.session(reuse_venv=True)
 def docs(session):
     """Build the documentation."""
     session.install(".[doc]")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -95,7 +95,7 @@ module_l10n = "sepal_ui.bin.module_l10n:main"
 module_theme = "sepal_ui.bin.module_theme:main"
 module_venv = "sepal_ui.bin.module_venv:main"
 activate_venv = "sepal_ui.bin.activate_venv:main"
-sepal_ipyvuetify = "sepal_ui.bin.ipyvuetify:main"
+sepal_ipyvuetify = "sepal_ui.bin.sepal_ipyvuetify:main"
 
 [tool.setuptools]
 include-package-data = true

--- a/sepal_ui/bin/sepal_ipyvuetify.py
+++ b/sepal_ui/bin/sepal_ipyvuetify.py
@@ -12,7 +12,7 @@ from pathlib import Path
 
 import ipyvuetify as v
 
-parser = argparse.ArgumentParser(description=__doc__, usage="override_ipyvuetify")
+parser = argparse.ArgumentParser(description=__doc__, usage="sepal_ipyvuetify")
 
 
 def disclaimer() -> str:


### PR DESCRIPTION
The build of v2.14.0 is blocked on conda-forge because the latest bin entry_point cannot work.
This PR add the appropiate tests and modify the name of the scripts to make it work.