### PR TITLE
add a custom zoomControl

### DIFF
--- a/sepal_ui/frontend/css/custom.css
+++ b/sepal_ui/frontend/css/custom.css
@@ -64,3 +64,14 @@ nav.v-navigation-drawer {
 .leaflet-center.leaflet-middle {
   transform: translate(-50%, -50%);
 }
+
+/* add specific css for the map btn */
+.v-btn.v-zoom-plus {
+  border-bottom-left-radius: 0;
+  border-bottom-right-radius: 0;
+}
+
+.v-btn.v-zoom-minus {
+  border-top-left-radius: 0;
+  border-top-right-radius: 0;
+}

--- a/sepal_ui/frontend/css/custom.css
+++ b/sepal_ui/frontend/css/custom.css
@@ -65,7 +65,15 @@ nav.v-navigation-drawer {
   transform: translate(-50%, -50%);
 }
 
-/* add specific css for the map btn */
+/* specific css for the btn placed on maps */
+.v-btn.v-size--default.v-map-btn:not(.v-btn--round) {
+  padding: 0px;
+  min-width: 0px;
+  width: 30px;
+  height: 30px;
+}
+
+/* add specific css for the zoom btn of the map */
 .v-btn.v-zoom-plus {
   border-bottom-left-radius: 0;
   border-bottom-right-radius: 0;

--- a/sepal_ui/frontend/css/custom.css
+++ b/sepal_ui/frontend/css/custom.css
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Customization of the provided css from the different libs used by sepal_ui 
+ * Customization of the provided css from the different libs used by sepal_ui
  */
 
 /* replace the map panel elements on top */
@@ -80,6 +80,7 @@ nav.v-navigation-drawer {
 }
 
 .v-btn.v-zoom-minus {
+  margin-top: -1px;
   border-top-left-radius: 0;
   border-top-right-radius: 0;
 }

--- a/sepal_ui/frontend/json/map_btn.json
+++ b/sepal_ui/frontend/json/map_btn.json
@@ -1,6 +1,0 @@
-{
-  "padding": "0px",
-  "min-width": "0px",
-  "width": "30px",
-  "height": "30px"
-}

--- a/sepal_ui/mapping/__init__.py
+++ b/sepal_ui/mapping/__init__.py
@@ -26,3 +26,4 @@ from .map_btn import *
 from .menu_control import *
 from .sepal_map import *
 from .value_inspector import *
+from .zoom_control import *

--- a/sepal_ui/mapping/map_btn.py
+++ b/sepal_ui/mapping/map_btn.py
@@ -2,13 +2,10 @@
 Based ``SepalMap`` Btn.
 """
 
-import json
-
 import ipyvuetify as v
 
 from sepal_ui import color
 from sepal_ui import sepalwidgets as sw
-from sepal_ui.frontend import styles as ss
 
 
 class MapBtn(v.Btn, sw.SepalWidget):
@@ -29,15 +26,12 @@ class MapBtn(v.Btn, sw.SepalWidget):
         else:
             content = content[: min(3, len(content))].upper()
 
-        # create the style from default
-        style = json.loads((ss.JSON_DIR / "map_btn.json").read_text())
-        style.update(background=color.bg)
-
         # some parameters are overloaded to match the map requirements
         kwargs["color"] = "text-color"
         kwargs["outlined"] = True
-        kwargs["style_"] = " ".join([f"{k}: {v};" for k, v in style.items()])
+        kwargs["style_"] = f"background: {color.bg};"
         kwargs["children"] = [content]
         kwargs["icon"] = False
+        kwargs.setdefault("class_", "v-map-btn")
 
         super().__init__(**kwargs)

--- a/sepal_ui/mapping/sepal_map.py
+++ b/sepal_ui/mapping/sepal_map.py
@@ -41,6 +41,7 @@ from sepal_ui.mapping.layer import EELayer
 from sepal_ui.mapping.layer_state_control import LayerStateControl
 from sepal_ui.mapping.legend_control import LegendControl
 from sepal_ui.mapping.value_inspector import ValueInspector
+from sepal_ui.mapping.zoom_control import ZoomControl
 from sepal_ui.message import ms
 from sepal_ui.scripts import decorator as sd
 from sepal_ui.scripts import utils as su
@@ -121,7 +122,7 @@ class SepalMap(ipl.Map):
         [self.add_basemap(basemap) for basemap in set(basemaps)]
 
         # add the base controls
-        self.add(ipl.ZoomControl(position="topright"))
+        self.add(ZoomControl(self))
         self.add(ipl.LayersControl(position="topright"))
         self.add(ipl.AttributionControl(position="bottomleft", prefix="SEPAL"))
         self.add(ipl.ScaleControl(position="bottomleft", imperial=False))

--- a/sepal_ui/mapping/zoom_control.py
+++ b/sepal_ui/mapping/zoom_control.py
@@ -57,7 +57,7 @@ class ZoomControl(WidgetControl):
     def zoom(self, widget: MapBtn, *args) -> None:
         """update the zoom according to the clicked btn."""
         # read min and max zoom
-        max_zoom = self.m.max_zoom or 20
+        max_zoom = self.m.max_zoom or 24
         min_zoom = self.m.min_zoom or 0
 
         # computed zoom

--- a/sepal_ui/mapping/zoom_control.py
+++ b/sepal_ui/mapping/zoom_control.py
@@ -1,0 +1,69 @@
+"""
+Customized ``Control`` to zoom in and out on the map.
+"""
+from typing import Optional
+
+from ipyleaflet import Map, WidgetControl
+
+from sepal_ui import sepalwidgets as sw
+from sepal_ui.mapping.map_btn import MapBtn
+
+
+class ZoomControl(WidgetControl):
+
+    plus: Optional[MapBtn] = None
+    "The plus btn"
+
+    minus: Optional[MapBtn] = None
+    "the minus btn"
+
+    m: Optional[Map] = None
+    "the map to manipulate"
+
+    def __init__(self, m: Map, **kwargs) -> None:
+        """
+        Customized ``Control`` to zoom in and out on the map.
+
+        Replace the built-in zoom control of ipyleaflet to match the theme of sepal-ui based applications. It is by default positioned in the top-right corner
+
+        Args:
+            m: the map to manipulate
+            kwargs: any ``ipyleaflet.widgetControl`` arguments
+        """
+        # init the map
+        self.m = m
+
+        # create the 2 btns
+        self.plus = MapBtn("fa-solid fa-plus", _metadata={"step": 1})
+        self.minus = MapBtn("fa-solid fa-minus", _metadata={"step": -1})
+
+        # customize their layout by removing the bottom radius
+        self.plus.class_list.add("v-zoom-plus")
+        self.minus.class_list.add("v-zoom-minus")
+
+        # agregate them in a layout
+        content = sw.Layout(column=True, children=[self.plus, self.minus])
+
+        # by default Zoomcontrols will be displayed in the topright corner
+        kwargs.setdefault("position", "topright")
+        kwargs["widget"] = content
+
+        super().__init__(**kwargs)
+
+        # add js behaviour
+        self.plus.on_event("click", self.zoom)
+        self.minus.on_event("click", self.zoom)
+
+    def zoom(self, widget: MapBtn, *args) -> None:
+        """update the zoom according to the clicked btn."""
+        # read min and max zoom
+        max_zoom = self.m.max_zoom or 20
+        min_zoom = self.m.min_zoom or 0
+
+        # computed zoom
+        zoom = self.m.zoom + widget._metadata["step"]
+
+        # adapt to the limitations of the map
+        self.m.zoom = max(min(zoom, max_zoom), min_zoom)
+
+        return

--- a/tests/test_ZoomControl.py
+++ b/tests/test_ZoomControl.py
@@ -1,0 +1,50 @@
+from sepal_ui import mapping as sm
+
+
+class TestZoomControl:
+    def test_init(self):
+
+        m = sm.SepalMap()
+        m.clear()
+        zoom_control = sm.ZoomControl(m)
+        m.add(zoom_control)
+
+        assert isinstance(zoom_control, sm.ZoomControl)
+        assert zoom_control in m.controls
+
+        return
+
+    def test_change_zoom(self):
+
+        m = sm.SepalMap()
+        zoom_control = next(c for c in m.controls if isinstance(c, sm.ZoomControl))
+        m.zoom = 10
+
+        zoom_control.zoom(zoom_control.plus)
+        assert m.zoom == 11
+
+        zoom_control.zoom(zoom_control.minus)
+        assert m.zoom == 10
+
+        return
+
+    def test_min_max_zoom(self):
+
+        m = sm.SepalMap()
+        zoom_control = next(c for c in m.controls if isinstance(c, sm.ZoomControl))
+
+        # click 40 times on plus and then 40 times on minus
+        [zoom_control.zoom(zoom_control.plus) for i in range(40)]
+        assert m.zoom == 20
+        [zoom_control.zoom(zoom_control.minus) for i in range(40)]
+        assert m.zoom == 0
+
+        # ssame but with a min-max zoom on the map
+        m.min_zoom = 5
+        m.max_zoom = 18
+        [zoom_control.zoom(zoom_control.plus) for i in range(40)]
+        assert m.zoom == m.max_zoom
+        [zoom_control.zoom(zoom_control.minus) for i in range(40)]
+        assert m.zoom == m.min_zoom
+
+        return

--- a/tests/test_ZoomControl.py
+++ b/tests/test_ZoomControl.py
@@ -35,7 +35,7 @@ class TestZoomControl:
 
         # click 40 times on plus and then 40 times on minus
         [zoom_control.zoom(zoom_control.plus) for i in range(40)]
-        assert m.zoom == 20
+        assert m.zoom == 24
         [zoom_control.zoom(zoom_control.minus) for i in range(40)]
         assert m.zoom == 0
 


### PR DESCRIPTION
In the current implementation, the zoom control is a normal ipyleaflet widget so its display is kinda tricky: 
- transparent or not depending on the execution 
- use the voila background 
- don't respect theming 
- don't use the theme colors

This is a custom implementation of a python zooming widget. It is using the same look & feel as the other buttons (Vuetify material) and respect the themes. 

I think I cover all the potential situations.

<img width="895" alt="Capture d’écran 2023-01-23 à 12 14 33" src="https://user-images.githubusercontent.com/12596392/214026289-9a6d0725-5919-4039-981c-fdfc2553f826.png">

