### PR TITLE
docs: add prettier badge

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -11,6 +11,10 @@ Sepal_ui
    :target: https://github.com/psf/black
    :alt: Black badge
    
+.. image:: https://img.shields.io/badge/code_style-prettier-ff69b4.svg
+   :target: https://github.com/prettier/prettier
+   :alt: prettier badge
+   
 .. image:: https://img.shields.io/badge/Conventional%20Commits-1.0.0-yellow.svg
    :target: https://conventionalcommits.org
    :alt: conventional commit


### PR DESCRIPTION
everything is in the title. 
It is suggested by the main repository: https://github.com/prettier/prettier