### PR TITLE
make the aoi style customizable

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -1,5 +1,5 @@
 """
-All the process that can be run using nox. 
+All the process that can be run using nox.
 
 The nox run are build in isolated environment that will be stored in .nox. to force the venv update, remove the .nox/xxx folder.
 """
@@ -39,7 +39,8 @@ def bin(session):
 def docs(session):
     """Build the documentation."""
     session.install(".[doc]")
-    session.run("rm", "-rf", "docs/build/", external=True)
+    session.run("rm", "-rf", "docs/source/modules", external=True)
+    session.run("rm", "-rf", "docs/build/html", external=True)
     session.run(
         "sphinx-apidoc",
         "--force",
@@ -50,7 +51,14 @@ def docs(session):
         "./sepal_ui",
     )
     session.run(
-        "sphinx-build", "-v", "-b", "html", "docs/source", "build", "-w", "warnings.txt"
+        "sphinx-build",
+        "-v",
+        "-b",
+        "html",
+        "docs/source",
+        "docs/build/html",
+        "-w",
+        "warnings.txt",
     )
     session.run("python", "tests/check_warnings.py")
 
@@ -68,7 +76,7 @@ def docs_live(session):
         "docs/source/modules",
         "./sepal_ui",
     )
-    session.run("sphinx-autobuild", "-b", "html", "docs/source", "build")
+    session.run("sphinx-autobuild", "-b", "html", "docs/source", "docs/build/html")
 
 
 @nox.session(name="mypy", reuse_venv=True)

--- a/sepal_ui/aoi/aoi_model.py
+++ b/sepal_ui/aoi/aoi_model.py
@@ -599,9 +599,12 @@ class AoiModel(Model):
 
         return self
 
-    def get_ipygeojson(self) -> GeoJSON:
+    def get_ipygeojson(self, style: Optional[dict] = None) -> GeoJSON:
         """
         Converts current geopandas object into ipyleaflet GeoJSON.
+
+        Args:
+            style: the predifined style of the aoi. It's by default using a "success" ``sepal_ui.color`` with 0.5 transparent fill color. It can be completly replace by a fully qualified `style dictionnary <https://ipyleaflet.readthedocs.io/en/latest/layers/geo_json.html>`__. Use the ``sepal_ui.color`` object to define any color to remain compatible with light and dark theme.
 
         Returns:
             The geojson layer of the aoi gdf, ready to use in a Map
@@ -616,8 +619,9 @@ class AoiModel(Model):
             f["properties"]["name"] = self.name
 
         # adapt the style to the theme
-        style = json.loads((ss.JSON_DIR / "aoi.json").read_text())
-        style.update(color=color.success, fillColor=color.success)
+        if style is None:
+            style = json.loads((ss.JSON_DIR / "aoi.json").read_text())
+            style.update(color=color.success, fillColor=color.success)
 
         # create a GeoJSON object
         # attribution="SEPAL(c)" is not recognized yet

--- a/sepal_ui/aoi/aoi_tile.py
+++ b/sepal_ui/aoi/aoi_tile.py
@@ -31,6 +31,7 @@ class AoiTile(sw.Tile):
         admin: Union[int, str] = "",
         asset: Union[str, Path] = "",
         folder: Union[str, Path] = "",
+        map_style: Optional[dict] = None,
         **kwargs
     ) -> None:
         """
@@ -42,6 +43,7 @@ class AoiTile(sw.Tile):
             vector: the path to the default vector object
             admin: the administrative code of the default selection. Need to be GADM if ee==False and GAUL 2015 if ee==True.
             asset: the default asset. Can only work if :code:`ee==True`.
+            map_style: the predifined style of the aoi. It's by default using a "success" ``sepal_ui.color`` with 0.5 transparent fill color. It can be completly replace by a fully qualified `style dictionnary <https://ipyleaflet.readthedocs.io/en/latest/layers/geo_json.html>`__. Use the ``sepal_ui.color`` object to define any color to remain compatible with light and dark theme.
         """
         # create the map
         self.map = sm.SepalMap(dc=True, gee=gee)
@@ -57,6 +59,7 @@ class AoiTile(sw.Tile):
             admin=admin,
             asset=asset,
             folder=folder,
+            map_style=map_style,
             **kwargs
         )
         self.view.elevation = 0

--- a/sepal_ui/aoi/aoi_view.py
+++ b/sepal_ui/aoi/aoi_view.py
@@ -208,6 +208,9 @@ class AoiView(sw.Card):
     model: Optional[AoiModel] = None
     "The model to create the AOI from the selected parameters"
 
+    map_style: Optional[dict] = None
+    "The predifined style of the aoi on the map"
+
     # ##########################################################################
     # ###                            the embeded widgets                     ###
     # ##########################################################################
@@ -262,6 +265,7 @@ class AoiView(sw.Card):
         gee: bool = True,
         folder: Union[str, Path] = "",
         model: Optional[AoiModel] = None,
+        map_style: Optional[dict] = None,
         **kwargs,
     ) -> None:
         r"""
@@ -274,6 +278,7 @@ class AoiView(sw.Card):
             vector: the path to the default vector object
             admin: the administrative code of the default selection. Need to be GADM if :code:`ee==False` and GAUL 2015 if :code:`ee==True`.
             asset: the default asset. Can only work if :code:`ee==True`
+            map_style: the predifined style of the aoi. It's by default using a "success" ``sepal_ui.color`` with 0.5 transparent fill color. It can be completly replace by a fully qualified `style dictionnary <https://ipyleaflet.readthedocs.io/en/latest/layers/geo_json.html>`__. Use the ``sepal_ui.color`` object to define any color to remain compatible with light and dark theme.
         """
         # set ee dependencie
         self.gee = gee
@@ -286,6 +291,9 @@ class AoiView(sw.Card):
 
         # get the map if filled
         self.map_ = map_
+
+        # get the aoi geoJSON style
+        self.map_style = map_style
 
         # create the method widget
         self.w_method = MethodSelect(methods, gee=gee, map_=map_)
@@ -373,7 +381,7 @@ class AoiView(sw.Card):
         if self.map_:
             self.map_.remove_layer("aoi", none_ok=True)
             self.map_.zoom_bounds(self.model.total_bounds())
-            self.map_.add_layer(self.model.get_ipygeojson())
+            self.map_.add_layer(self.model.get_ipygeojson(self.map_style))
 
             self.aoi_dc.hide()
 

--- a/sepal_ui/aoi/aoi_view.py
+++ b/sepal_ui/aoi/aoi_view.py
@@ -118,9 +118,9 @@ class AdminField(sw.Select):
         It is binded to ee (GAUL 2015) or not (GADM 2021). allows to select administrative codes taking into account the administrative parent code and displaying humanly readable administrative names.
 
         Args:
-            level (int): The administrative level of the field
-            parent (AdminField): the adminField that deal with the parent admin level of the current selector. used to narrow down the possible options
-            ee (bool, optional): wether to use ee or not (default to True)
+            level: The administrative level of the field
+            parent: the adminField that deal with the parent admin level of the current selector. used to narrow down the possible options
+            ee: wether to use ee or not (default to True)
         """
         # save ee state
         self.gee = gee
@@ -373,11 +373,7 @@ class AoiView(sw.Card):
         if self.map_:
             self.map_.remove_layer("aoi", none_ok=True)
             self.map_.zoom_bounds(self.model.total_bounds())
-
-            if self.gee:
-                self.map_.add_ee_layer(self.model.feature_collection, {}, name="aoi")
-            else:
-                self.map_.add_layer(self.model.get_ipygeojson())
+            self.map_.add_layer(self.model.get_ipygeojson())
 
             self.aoi_dc.hide()
 


### PR DESCRIPTION
Fix #706 

As we now use the AOIView more often in custom map style application it became critical to modify the rendering of the AOI on the map natively. 

With this PR, the developer can change the AOI display directly when he creates the AOIView/Tile. as in the following example: 

```python
from sepal_ui import aoi 

aoi.AoiTile(map_style = {'opacity': 1, 'dashArray': '9', 'fillOpacity': 0.1, 'weight': 1})
```
<img width="1095" alt="Capture d’écran 2023-01-31 à 14 43 35" src="https://user-images.githubusercontent.com/12596392/215776702-d7975c7c-f9d8-4feb-8e8d-854f1eafb7f1.png">


