### PR TITLE
auto-merge main in release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,11 +10,14 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
+
       - uses: actions/setup-python@v2
+
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
           pip install setuptools wheel twine build
+
       - name: Build and publish
         env:
           TWINE_USERNAME: __token__
@@ -22,3 +25,12 @@ jobs:
         run: |
           python -m build
           twine upload dist/*
+
+      - name: merge in release
+        uses: devmasx/merge-branch@master
+        with:
+          type: now
+          label_name: ":rocket: ${{  github.ref_name }}"
+          from_branch: main
+          target_branch: release
+          github_token: ${{ github.token }}


### PR DESCRIPTION
when a new release is created the worklfow will:
- create a distrib 
- push it to pipy (which triggers conda-forge)
- push to the release branch

Fix #713 