### PR TITLE
build: add nest_asyncio deps

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,7 @@ dependencies = [
     "Unidecode",  # to decode international names with non latin characters
     "natsort",
     "typing-extensions",
+    "nest-asyncio", # planet API interaction
 ]
 
 [[project.authors]]


### PR DESCRIPTION
It seems to be missing and the doc build fails because of it. My guess is that it was silentely included in one of the other libs and it has been removed recently