### PR TITLE
fix: update datepicker

### DIFF
--- a/sepal_ui/aoi/aoi_view.py
+++ b/sepal_ui/aoi/aoi_view.py
@@ -350,7 +350,7 @@ class AoiView(sw.Card):
             self.aoi_dc.hide()
 
         # add a validation btn
-        self.btn = sw.Btn(ms.aoi_sel.btn)
+        self.btn = sw.Btn(msg=ms.aoi_sel.btn)
 
         # create the widget
         self.children = (

--- a/sepal_ui/sepalwidgets/btn.py
+++ b/sepal_ui/sepalwidgets/btn.py
@@ -6,9 +6,9 @@ All the content of this modules is included in the parent ``sepal_ui.sepalwidget
 
 Example:
     .. jupyter-execute::
-    
+
         from sepal_ui import sepalwidgets as sw
-        
+
         sw.Btn()
 """
 
@@ -74,8 +74,9 @@ class Btn(v.Btn, SepalWidget):
                     DeprecationWarning,
                 )
 
-        # create the default v_icon
-        self.v_icon = v.Icon(children=[""])
+        # create the default v_icon (hidden)
+        self.v_icon = v.Icon(children=[""], left=True)
+        self.v_icon.hide()
 
         # set the default parameters
         kwargs.setdefault("color", "primary")
@@ -84,22 +85,17 @@ class Btn(v.Btn, SepalWidget):
         # call the constructor
         super().__init__(**kwargs)
 
-        self.gliph = gliph
+        # set msg and gliph to trigger the rendering
         self.msg = msg
+        self.gliph = gliph
 
     @observe("gliph")
     def _set_gliph(self, change: dict) -> Self:
         """
         Set a new icon. If the icon is set to "", then it's hidden.
         """
-        new_gliph = change["new"]
-        self.v_icon.children = [new_gliph]
-
-        # hide the component to avoid the right padding
-        if not new_gliph:
-            su.hide_component(self.v_icon)
-        else:
-            su.show_component(self.v_icon)
+        self.v_icon.children = [self.gliph]
+        self.v_icon.hide() if self.gliph == "" else self.v_icon.show()
 
         return self
 
@@ -108,8 +104,8 @@ class Btn(v.Btn, SepalWidget):
         """
         Set the text of the btn.
         """
-        self.v_icon.left = bool(change["new"])
-        self.children = [self.v_icon, change["new"]]
+        self.v_icon.left = bool(self.msg)
+        self.children = [self.v_icon, self.msg]
 
         return self
 

--- a/sepal_ui/sepalwidgets/inputs.py
+++ b/sepal_ui/sepalwidgets/inputs.py
@@ -64,7 +64,9 @@ class DatePicker(v.Layout, SepalWidget):
     disabled: t.Bool = t.Bool(False).tag(sync=True)
     "the disabled status of the Datepicker object"
 
-    def __init__(self, label: str = "Date", layout_kwargs: dict = {}, **kwargs) -> None:
+    def __init__(
+        self, label: str = "Date", layout_kwargs: Optional[dict] = None, **kwargs
+    ) -> None:
         """
         Custom input widget to provide a reusable DatePicker.
 
@@ -106,6 +108,7 @@ class DatePicker(v.Layout, SepalWidget):
         )
 
         # set the default parameter
+        layout_kwargs = layout_kwargs or {}
         layout_kwargs.setdefault("row", True)
         layout_kwargs.setdefault("class_", "pa-5")
         layout_kwargs.setdefault("align_center", True)

--- a/sepal_ui/sepalwidgets/inputs.py
+++ b/sepal_ui/sepalwidgets/inputs.py
@@ -6,9 +6,9 @@ All the content of this modules is included in the parent ``sepal_ui.sepalwidget
 
 Example:
     .. jupyter-execute::
-    
+
         from sepal_ui import sepalwidgets as sw
-        
+
         sw.DatePicker()
 """
 
@@ -162,13 +162,12 @@ class DatePicker(v.Layout, SepalWidget):
             date: the date to test in YYYY-MM-DD format
 
         Returns:
-            the date to test
+            The validity of the date with respect to the datepicker format
         """
+        valid = True
         try:
             datetime.strptime(date, "%Y-%m-%d")
-            valid = True
-
-        except Exception:
+        except (ValueError, TypeError):
             valid = False
 
         return valid


### PR DESCRIPTION
Fix #730, Fix #746

The `layout_kwargs` was init to `{}` and then updated with `setdefaults` for all `DatePicker` without option. That's a mutable object rookie mistake, they were all sharing the same. I made it optional and if not present, it's inited in the `__init__` method. 

can be tested by running: 

```python 
from sepal_ui import sepalwidgets as sw 

toto = sw.DatePicker()
toto.v_model = "2022-06-15"
toto
```

or for the duplication issue: 
```python 
import sepal_ui.sepalwidgets as sw


class DateSelector(sw.Layout):
    
    def __init__(self, *args, **kwargs):
        
        super().__init__(*args, **kwargs)
        
        self.w_unique_date = sw.DatePicker(label="Date")
        self.w_ini_date = sw.DatePicker(label="Start date")

        self.children = [
            self.w_unique_date,
            self.w_ini_date
        ]

date_selector = DateSelector()
date_selector
```