### PR TITLE
refactor value inspector 

### DIFF
--- a/sepal_ui/mapping/__init__.py
+++ b/sepal_ui/mapping/__init__.py
@@ -19,6 +19,7 @@ Example:
 from .aoi_control import *
 from .draw_control import *
 from .fullscreen_control import *
+from .inspector_control import *
 from .layer import *
 from .layer_state_control import *
 from .layers_control import *
@@ -26,5 +27,4 @@ from .legend_control import *
 from .map_btn import *
 from .menu_control import *
 from .sepal_map import *
-from .value_inspector import *
 from .zoom_control import *

--- a/sepal_ui/mapping/inspector_control.py
+++ b/sepal_ui/mapping/inspector_control.py
@@ -15,6 +15,7 @@ from deprecated.sphinx import deprecated
 from ipyleaflet import GeoJSON, Map
 from rasterio.crs import CRS
 from shapely import geometry as sg
+from traitlets import Bool
 
 from sepal_ui import color
 from sepal_ui import sepalwidgets as sw
@@ -39,7 +40,10 @@ class InspectorControl(MenuControl):
     text: Optional[v.CardText] = None
     "The text element from the card that is edited when the user click on the map"
 
-    def __init__(self, m: Map, **kwargs) -> None:
+    open_tree: Bool = Bool(True).tag(sync=True)
+    "Either or not the tree should be opened automatically"
+
+    def __init__(self, m: Map, open_tree: bool = True, **kwargs) -> None:
         """
         Widget control displaying a btn on the map.
 
@@ -48,6 +52,9 @@ class InspectorControl(MenuControl):
         Args:
             m: the map on which he vinspector is displayed to interact with it's layers
         """
+        # set traits
+        self.open_tree = open_tree
+
         # set some default parameters
         kwargs.setdefault("position", "topleft")
         kwargs["m"] = m
@@ -123,7 +130,7 @@ class InspectorControl(MenuControl):
 
         # write the layers data
         items, layers = [], [lyr for lyr in self.m.layers if not lyr.base]
-        for lyr in layers:
+        for i, lyr in enumerate(layers):
 
             if isinstance(lyr, EELayer):
                 data = self._from_eelayer(lyr.ee_object, coords)
@@ -138,11 +145,13 @@ class InspectorControl(MenuControl):
 
             items.append(
                 {
+                    "id": str(i),
                     "name": lyr.name,
                     "children": [{"name": f"{k}: {v}"} for k, v in data.items()],
                 }
             )
         tree_view.items = items
+        tree_view.open_ = "0" if self.open_tree else ""
 
         # set them in the card
         self.text.children = children

--- a/sepal_ui/mapping/inspector_control.py
+++ b/sepal_ui/mapping/inspector_control.py
@@ -11,6 +11,7 @@ import geopandas as gpd
 import ipyvuetify as v
 import rasterio as rio
 import rioxarray
+from deprecated.sphinx import deprecated
 from ipyleaflet import GeoJSON, Map
 from rasterio.crs import CRS
 from shapely import geometry as sg
@@ -24,7 +25,7 @@ from sepal_ui.message import ms
 from sepal_ui.scripts import decorator as sd
 
 
-class ValueInspector(MenuControl):
+class InspectorControl(MenuControl):
 
     m: Optional[Map] = None
     "the map on which he vinspector is displayed to interact with it's layers"
@@ -61,8 +62,8 @@ class ValueInspector(MenuControl):
         )
 
         # set up the content
-        title = sw.CardTitle(children=[ms.v_inspector.title])
-        self.text = sw.CardText(children=[ms.v_inspector.landing])
+        title = sw.CardTitle(children=[ms.inspector_control.title])
+        self.text = sw.CardText(children=[ms.inspector_control.landing])
 
         # create the menu widget
         super().__init__("fa-solid fa-crosshairs", self.text, title, **kwargs)
@@ -111,13 +112,13 @@ class ValueInspector(MenuControl):
         lng, lat = coords = [c for c in reversed(kwargs.get("coordinates"))]
 
         # write the coordinates and the scale
-        txt = ms.v_inspector.coords.format(round(self.m.get_scale()))
+        txt = ms.inspector_control.coords.format(round(self.m.get_scale()))
         children.append(sw.Html(tag="h4", children=[txt]))
         children.append(sw.Html(tag="p", children=[f"[{lng:.3f}, {lat:.3f}]"]))
 
         # wrap layer data in a treeview widget
         tree_view = sw.Treeview(hoverable=True, dense=True, open_on_click=True)
-        children.append(sw.Html(tag="h4", children=["Layers"]))
+        children.append(sw.Html(tag="h4", children=[ms.inspector_control.layers]))
         children.append(tree_view)
 
         # write the layers data
@@ -131,7 +132,9 @@ class ValueInspector(MenuControl):
             elif type(lyr).__name__ == "BoundTileLayer":
                 data = self._from_raster(lyr.raster, coords)
             else:
-                data = {ms.v_inspector.info.header: ms.v_inspector.info.text}
+                data = {
+                    ms.inspector_control.info.header: ms.inspector_control.info.text
+                }
 
             items.append(
                 {
@@ -261,13 +264,21 @@ class ValueInspector(MenuControl):
             da_filtered = da.rio.isel_window(window)
             means = da_filtered.mean(axis=(1, 2)).to_numpy()
             pixel_values = {
-                ms.v_inspector.band.format(i + 1): v for i, v in enumerate(means)
+                ms.inspector_control.band.format(i + 1): v for i, v in enumerate(means)
             }
 
         # if the point is out of the image display None
         else:
             pixel_values = {
-                ms.v_inspector.band.format(i + 1): None for i in range(da.rio.count)
+                ms.inspector_control.band.format(i + 1): None
+                for i in range(da.rio.count)
             }
 
         return pixel_values
+
+
+@deprecated(
+    version="2.15.1", reason="ValueInspector class is now renamed InspectorControl"
+)
+class ValueInspector(InspectorControl):
+    pass

--- a/sepal_ui/mapping/sepal_map.py
+++ b/sepal_ui/mapping/sepal_map.py
@@ -37,11 +37,11 @@ from sepal_ui import sepalwidgets as sw
 from sepal_ui.frontend import styles as ss
 from sepal_ui.mapping.basemaps import basemap_tiles
 from sepal_ui.mapping.draw_control import DrawControl
+from sepal_ui.mapping.inspector_control import InspectorControl
 from sepal_ui.mapping.layer import EELayer
 from sepal_ui.mapping.layer_state_control import LayerStateControl
 from sepal_ui.mapping.layers_control import LayersControl
 from sepal_ui.mapping.legend_control import LegendControl
-from sepal_ui.mapping.value_inspector import ValueInspector
 from sepal_ui.mapping.zoom_control import ZoomControl
 from sepal_ui.message import ms
 from sepal_ui.scripts import decorator as sd
@@ -60,7 +60,7 @@ class SepalMap(ipl.Map):
     gee: bool = True
     "Either the map will use ee binding or not"
 
-    v_inspector: Optional[ValueInspector] = None
+    v_inspector: Optional[InspectorControl] = None
     "The value inspector of the map"
 
     dc: Optional[DrawControl] = None
@@ -137,7 +137,7 @@ class SepalMap(ipl.Map):
         not dc or self.add(self.dc)
 
         # specific v_inspector
-        self.v_inspector = ValueInspector(self)
+        self.v_inspector = InspectorControl(self)
         not vinspector or self.add(self.v_inspector)
 
         # specific statebar

--- a/sepal_ui/mapping/value_inspector.py
+++ b/sepal_ui/mapping/value_inspector.py
@@ -115,11 +115,14 @@ class ValueInspector(MenuControl):
         children.append(sw.Html(tag="h4", children=[txt]))
         children.append(sw.Html(tag="p", children=[f"[{lng:.3f}, {lat:.3f}]"]))
 
-        # write the layers data
+        # wrap layer data in a treeview widget
+        tree_view = sw.Treeview(hoverable=True, dense=True, open_on_click=True)
         children.append(sw.Html(tag="h4", children=["Layers"]))
-        layers = [lyr for lyr in self.m.layers if not lyr.base]
+        children.append(tree_view)
+
+        # write the layers data
+        items, layers = [], [lyr for lyr in self.m.layers if not lyr.base]
         for lyr in layers:
-            children.append(sw.Html(tag="h5", children=[lyr.name]))
 
             if isinstance(lyr, EELayer):
                 data = self._from_eelayer(lyr.ee_object, coords)
@@ -130,9 +133,13 @@ class ValueInspector(MenuControl):
             else:
                 data = {ms.v_inspector.info.header: ms.v_inspector.info.text}
 
-            for k, val in data.items():
-                children.append(sw.Html(tag="span", children=[f"{k}: {val}"]))
-                children.append(sw.Html(tag="br", children=[]))
+            items.append(
+                {
+                    "name": lyr.name,
+                    "children": [{"name": f"{k}: {v}"} for k, v in data.items()],
+                }
+            )
+        tree_view.items = items
 
         # set them in the card
         self.text.children = children
@@ -143,8 +150,8 @@ class ValueInspector(MenuControl):
 
         # one last flicker to replace the menu next to the btn
         # if not it goes below the map
-        # i've try playing with the styles but it didn't worked out well
-        # lost hours on this issue : 1h
+        # I've try playing with the styles but it didn't worked out well
+        # lost hours on this issue : 2h
         self.menu.v_model = False
         self.menu.v_model = True
 

--- a/sepal_ui/message/en/inspector_control.json
+++ b/sepal_ui/message/en/inspector_control.json
@@ -1,5 +1,5 @@
 {
-  "v_inspector": {
+  "inspector_control": {
     "title": "Inspector",
     "landing": "select a point",
     "info": {
@@ -7,6 +7,7 @@
       "text": "data reading method not yet ready"
     },
     "band": "band {}",
-    "coords": "Coordinates (lng, lat) at {} m/px"
+    "coords": "Coordinates (lng, lat) at {} m/px",
+    "layers": "Layers"
   }
 }

--- a/tests/test_InspectorControl.py
+++ b/tests/test_InspectorControl.py
@@ -9,27 +9,36 @@ import pytest
 from sepal_ui import mapping as sm
 
 
-class TestValueInspector:
+class TestInspectorControl:
     def test_init(self):
 
         m = sm.SepalMap()
-        value_inspector = sm.ValueInspector(m)
-        m.add(value_inspector)
+        inspector_control = sm.InspectorControl(m)
+        m.add(inspector_control)
 
-        assert isinstance(value_inspector, sm.ValueInspector)
+        assert isinstance(inspector_control, sm.InspectorControl)
+
+    def test_deprecated(self):
+
+        m = sm.SepalMap()
+        with pytest.deprecated_call():
+            inspector_control = sm.ValueInspector(m)
+        m.add(inspector_control)
+
+        assert isinstance(inspector_control, sm.InspectorControl)
 
     def test_toogle_cursor(self):
 
         m = sm.SepalMap()
-        value_inspector = sm.ValueInspector(m)
-        m.add(value_inspector)
+        inspector_control = sm.InspectorControl(m)
+        m.add(inspector_control)
 
         # activate the window
-        value_inspector.menu.v_model = True
+        inspector_control.menu.v_model = True
         assert m.default_style.cursor == "crosshair"
 
         # close with the menu
-        value_inspector.menu.v_model = False
+        inspector_control.menu.v_model = False
         assert m.default_style.cursor == "grab"
 
         return
@@ -38,17 +47,17 @@ class TestValueInspector:
 
         # not testing the display of anything here just the interaction
         m = sm.SepalMap()
-        value_inspector = sm.ValueInspector(m)
-        m.add(value_inspector)
+        inspector_control = sm.InspectorControl(m)
+        m.add(inspector_control)
 
         # click anywhere without activation
-        value_inspector.read_data(type="click", coordinates=[0, 0])
-        assert len(value_inspector.text.children) == 1
+        inspector_control.read_data(type="click", coordinates=[0, 0])
+        assert len(inspector_control.text.children) == 1
 
         # click when activated
-        value_inspector.menu.v_model = True
-        value_inspector.read_data(type="click", coordinates=[0, 0])
-        assert len(value_inspector.text.children) == 3
+        inspector_control.menu.v_model = True
+        inspector_control.read_data(type="click", coordinates=[0, 0])
+        assert len(inspector_control.text.children) == 4
 
         return
 
@@ -57,22 +66,22 @@ class TestValueInspector:
 
         # create a map with a value inspector
         m = sm.SepalMap()
-        value_inspector = sm.ValueInspector(m)
+        inspector_control = sm.InspectorControl(m)
 
         # check a nodata place on Image
-        data = value_inspector._from_eelayer(world_temp.mosaic(), [0, 0])
+        data = inspector_control._from_eelayer(world_temp.mosaic(), [0, 0])
         assert data == {"temperature_2m": None}
 
         # check vatican city
-        data = value_inspector._from_eelayer(world_temp.mosaic(), [12.457, 41.902])
+        data = inspector_control._from_eelayer(world_temp.mosaic(), [12.457, 41.902])
         assert data == {"temperature_2m": 296.00286865234375}
 
         # check a featurecollection on nodata place
-        data = value_inspector._from_eelayer(ee_adm2, [0, 0])
+        data = inspector_control._from_eelayer(ee_adm2, [0, 0])
         assert data == {"ADM2_CODE": None}
 
         # check the featurecollection on vatican city
-        data = value_inspector._from_eelayer(ee_adm2, [12.457, 41.902])
+        data = inspector_control._from_eelayer(ee_adm2, [12.457, 41.902])
         assert data == {"ADM2_CODE": 18350}
 
         return
@@ -81,14 +90,14 @@ class TestValueInspector:
 
         # create a map with a value inspector
         m = sm.SepalMap()
-        value_inspector = sm.ValueInspector(m)
+        inspector_control = sm.InspectorControl(m)
 
         # check a featurecollection on nodata place
-        data = value_inspector._from_geojson(adm0_vatican, [0, 0])
+        data = inspector_control._from_geojson(adm0_vatican, [0, 0])
         assert data == {"GID_0": None, "NAME_0": None}
 
         # check the featurecollection on vatican city
-        data = value_inspector._from_geojson(adm0_vatican, [12.457, 41.902])
+        data = inspector_control._from_geojson(adm0_vatican, [12.457, 41.902])
         assert data == {"GID_0": "VAT", "NAME_0": "Vatican City"}
 
         return
@@ -97,14 +106,14 @@ class TestValueInspector:
 
         # create a map with a value inspector
         m = sm.SepalMap()
-        value_inspector = sm.ValueInspector(m)
+        inspector_control = sm.InspectorControl(m)
 
         # check a featurecollection on nodata place
-        data = value_inspector._from_raster(raster_bahamas, [0, 0])
+        data = inspector_control._from_raster(raster_bahamas, [0, 0])
         assert data == {"band 1": None, "band 2": None, "band 3": None}
 
         # check the featurecollection on vatican city
-        data = value_inspector._from_raster(raster_bahamas, [-78.072, 24.769])
+        data = inspector_control._from_raster(raster_bahamas, [-78.072, 24.769])
         assert math.isclose(data["band 1"], 70.46553, rel_tol=1e-5)
         assert math.isclose(data["band 2"], 91.41595, rel_tol=1e-5)
         assert math.isclose(data["band 3"], 93.08673, rel_tol=1e-5)


### PR DESCRIPTION
Fix #731 

- Change the inspector rendering using a `tree_view`. It makes it easier to read data with many different bands/layers
- Change the name: We are more or less following a convention for the controls of the map: XXXControl. ValueInspector was the only one not respecting it. I renamed the class "InspectorControl" and created a "deprecated" one to avoid regression.
- complete messages: there was one key still hard coded in the .py file  


![Enregistrement de l’écran 2023-02-07 à 13 57 22](https://user-images.githubusercontent.com/12596392/217263707-29b33786-04df-4b20-a362-92a8d1dfd305.gif)

 