### PR TITLE
fix: close tqdm when total is reached

### DIFF
--- a/sepal_ui/sepalwidgets/alert.py
+++ b/sepal_ui/sepalwidgets/alert.py
@@ -146,7 +146,7 @@ class Alert(v.Alert, SepalWidget):
 
         self.progress_bar.update(progress - self.progress_bar.n)
 
-        if progress == 1:
+        if progress == total:
             self.progress_bar.close()
 
         return


### PR DESCRIPTION
if you use an int total, the progress was closed on the second item (1) and reopen on the 3rd (2)