### PR TITLE
fix: add a today method to datepickers

### DIFF
--- a/sepal_ui/sepalwidgets/inputs.py
+++ b/sepal_ui/sepalwidgets/inputs.py
@@ -156,6 +156,12 @@ class DatePicker(v.Layout, SepalWidget):
 
         return
 
+    def today(self) -> Self:
+        """Update the date to the current day."""
+        self.v_model = datetime.today().strftime("%Y-%m-%d")
+
+        return self
+
     @staticmethod
     def is_valid_date(date: str) -> bool:
         """

--- a/tests/test_DatePicker.py
+++ b/tests/test_DatePicker.py
@@ -1,3 +1,5 @@
+from datetime import datetime
+
 import pytest
 from traitlets import Any
 
@@ -93,6 +95,16 @@ class TestDatePicker:
         datepicker.v_model = test
         assert datepicker.v_model == test
         assert datepicker.date_text.error_messages is None
+
+        return
+
+    def test_today(self, datepicker) -> None:
+        """check that the date is updated to today"""
+
+        res = datepicker.today()
+
+        assert res == datepicker
+        assert res.v_model == datetime.today().strftime("%Y-%m-%d")
 
         return
 


### PR DESCRIPTION
Fix #752

you can now create a dateipker set to today and/or dinamically change its date after initilization: 

```python 
from sepal_ui import sepalwidgets as sw 

sw.DatePicker().today()

# or 
dt = sw.DatePicker()
dt.today()
```