### PR TITLE
fix: build the coverage analysis with nox as well

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -19,7 +19,7 @@ def test(session):
     """Run all the test using the environment varialbe of the running machine."""
     session.install(".[test]")
     test_files = session.posargs or ["tests"]
-    session.run("pytest", "--color=yes", *test_files)
+    session.run("pytest", "--color=yes", "--cov", "--cov-report=html", *test_files)
 
 
 @nox.session(reuse_venv=True)


### PR DESCRIPTION
I decided to build the coverage as well when running the tests locally. Only they are build in HTML, longer to compute but it can be analysed in a normal browser. 