### PR TITLE
fix: add root parameters in FileInput

### DIFF
--- a/sepal_ui/sepalwidgets/inputs.py
+++ b/sepal_ui/sepalwidgets/inputs.py
@@ -470,7 +470,7 @@ class FileInput(v.Flex, SepalWidget):
         root_folder = Path(self.root)
         if self.root == "":
             folder_list.insert(0, parent_item)
-        elif folder.is_relative_to(root_folder) and not folder == root_folder:
+        elif root_folder in folder.parents:
             folder_list.insert(0, parent_item)
 
         return folder_list

--- a/sepal_ui/sepalwidgets/sepalwidget.py
+++ b/sepal_ui/sepalwidgets/sepalwidget.py
@@ -13,7 +13,7 @@ Example:
 """
 
 import warnings
-from typing import Optional, Union
+from typing import List, Optional, Union
 
 import ipyvuetify as v
 import traitlets as t
@@ -125,7 +125,7 @@ class SepalWidget(v.VuetifyWidget):
         value: str = "",
         id_: str = "",
         elements: Optional[list] = None,
-    ) -> list:
+    ) -> List[v.VuetifyWidget]:
         r"""
         Recursively search for every element matching the specifications.
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,7 @@
 import uuid
 from itertools import product
 from pathlib import Path
+from typing import Optional
 
 import ee
 import geopandas as gpd
@@ -20,7 +21,7 @@ except Exception:
 
 
 @pytest.fixture(scope="session")
-def root_dir():
+def root_dir() -> Path:
     """
     Path to the root dir of the librairy.
     """
@@ -28,7 +29,7 @@ def root_dir():
 
 
 @pytest.fixture(scope="session")
-def tmp_dir():
+def tmp_dir() -> Path:
     """
     Creates a temporary local directory to store data.
     """
@@ -39,7 +40,7 @@ def tmp_dir():
 
 
 @pytest.fixture(scope="session")
-def _hash():
+def _hash() -> str:
     """
     Create a hash for each test instance.
     """
@@ -47,7 +48,7 @@ def _hash():
 
 
 @pytest.fixture(scope="session")
-def gee_dir(_hash):
+def gee_dir(_hash: str) -> Optional[Path]:
     """
     Create a test dir based on earthengine initialization
     populate it with fake super small assets:
@@ -131,6 +132,6 @@ def gee_dir(_hash):
 
 
 @pytest.fixture
-def alert():
+def alert() -> sw.Alert:
     """return a dummy alert that can be used everywhere to display informations."""
     return sw.Alert()

--- a/tests/test_FileInput.py
+++ b/tests/test_FileInput.py
@@ -1,3 +1,7 @@
+from pathlib import Path
+from typing import List
+
+import ipyvuetify as v
 import pytest
 from traitlets import Any
 
@@ -119,20 +123,32 @@ class TestFileInput:
 
         return
 
+    def test_root(self, file_input: sw.FileInput, root_dir: Path) -> None:
+        """Add a root folder to a file_input and check that you can't go higher"""
+
+        # set the root to the current folder and reload
+        file_input.root = str(root_dir)
+        file_input._on_reload()
+        first_title_item = file_input.get_children(klass=v.ListItemTitle)[0]
+
+        assert ".. /" not in first_title_item.children[0]
+
+        return
+
     @pytest.fixture
-    def file_input(self, root_dir):
+    def file_input(self, root_dir: Path) -> sw.FileInput:
         """create a default file_input in the root_dir."""
         return sw.FileInput(folder=root_dir)
 
     @pytest.fixture
-    def readme(self, root_dir):
+    def readme(self, root_dir: Path) -> Path:
         """return the readme file path."""
         return root_dir / "README.rst"
 
     @staticmethod
-    def get_names(widget):
+    def get_names(file_input: sw.FileInput) -> List[str]:
         """get the list name of a fileinput object."""
-        item_list = widget.file_list.children[0].children
+        item_list = file_input.file_list.children[0].children
 
         def get_name(item):
             return item.children[1].children[0].children[0]


### PR DESCRIPTION
Fix #769 

- FileInput now embed a `root` traits that is piloting how high you can go up in the hierarchy. 
- It can be set at init or while computing. 
- if the current `v_model` is higher, reload will make the parent node disapear, but you'll still be able to go deeper

```python 
from sepal_ui import sepalwidgets as sw 
from pathlib import Path

fi = sw.FileInput(root=Path.home())
fi
```