### PR TITLE
fix: remove pin on dialog and menu z-index

### DIFF
--- a/sepal_ui/frontend/css/custom.css
+++ b/sepal_ui/frontend/css/custom.css
@@ -34,13 +34,7 @@ header.v-app-bar {
 
 /* set the menu_content on top of the map when it's set to fullscreen */
 .v-menu__content {
-  z-index: 802 !important;
   max-width: 100% !important;
-}
-
-/* make sure the dialog remain on top of the bars (header and footer) */
-.v-dialog__content {
-  z-index: 802 !important;
 }
 
 /* make sure navigation drawers are always visibles when they exist */


### PR DESCRIPTION
By playing with the fullaplication map I relized we may overdid it by fixing the z-index of all theses components.
`Dialog` and `Menu` are 2 components that are added to the DOM by Javascript i.e. they are not just "under" their parent but somwhere else in the tree. Their positioning and z-index is therefore computed via JS. 

-  `Dialog` create a grey filler to avoid clicking outside at +1 z-index and a dialog div at +2 z-index
- `Menu` creates a div at +1 z-index from the activator

Initially we built these tricks to prevent issues when using the "real" fullscreen where menu and dialog were stuck behind the map. 
Now that the fullscreen mode is a css trick itself I think we should drop these css as it works well without it. 

**How did I noticed ?** 

I created a `Select` (which uses a `Menu` to show the items) on top o a `Dialog` and the list was stuck behind the Dialog. once I remove everything it works like a charm. 

**note**

I use this branch in se.plan to make the new interface work, let me know before deleting it