### PR TITLE
build: use anyascii instead of unidecode for licence compatibility

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -37,3 +37,9 @@ repos:
     hooks:
       - id: doc8
         stages: [commit]
+
+  - repo: https://github.com/FHPythonUtils/LicenseCheck
+    rev: "2023.1.1"
+    hooks:
+      - id: licensecheck
+        stages: [commit]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ dependencies = [
     "python-box",
     "tqdm",
     "Deprecated",
-    "Unidecode",  # to decode international names with non latin characters
+    "anyascii",  # to decode international names with non latin characters
     "natsort",
     "typing-extensions",
     "nest-asyncio", # planet API interaction
@@ -168,3 +168,6 @@ omit = [
 [tool.doc8]
 ignore = ["D001"] # we follow a 1 line = 1 paragraph style
 ignore-path-errors = ["docs/source/index.rst;D000"]
+
+[tool.licensecheck]
+using = "PEP631:test;dev;doc"

--- a/sepal_ui/scripts/utils.py
+++ b/sepal_ui/scripts/utils.py
@@ -13,9 +13,9 @@ from urllib.parse import urlparse
 import ee
 import httplib2
 import ipyvuetify as v
+from anyascii import anyascii
 from deprecated.sphinx import deprecated, versionadded
 from matplotlib import colors as c
-from unidecode import unidecode
 
 import sepal_ui
 from sepal_ui.conf import config, config_file
@@ -162,7 +162,7 @@ def normalize_str(msg: str, folder: bool = True) -> str:
     """
     regex = "[^a-zA-Z\d\-\_]" if folder else "[^a-zA-Z\d\-\_\ ']"
 
-    return re.sub(regex, "_", unidecode(msg))
+    return re.sub(regex, "_", anyascii(msg))
 
 
 def to_colors(


### PR DESCRIPTION
Fix #799 