### PR TITLE
fix: freeze back layers_control width

### DIFF
--- a/sepal_ui/mapping/layers_control.py
+++ b/sepal_ui/mapping/layers_control.py
@@ -191,8 +191,8 @@ class LayersControl(MenuControl):
         self.menu.open_on_hover = True
         self.menu.close_delay = 200
 
-        # set the ize according to the content
-        self.set_size(None, None, None, None)
+        # set the height according to the content
+        self.set_size(min_height=None, max_height=None)
 
         # update the table at instance creation
         self.update_table({})


### PR DESCRIPTION
if the titles are too small, the width reduces to the bare minimum and it gets impossible to move the slider. In this PR I simply rollback to previous implementation: 
- height is free
- width is 400px whatever content