### PR TITLE
fix: align the checkbox on the layer states

### DIFF
--- a/sepal_ui/mapping/layers_control.py
+++ b/sepal_ui/mapping/layers_control.py
@@ -100,9 +100,9 @@ class LayerRow(sw.Html):
         super().__init__(tag="tr", children=[label_cell, slider_cell, checkbox_cell])
 
         # add js behavior
-        link((layer, "opacity"), (self.w_slider, "v_model"))
-        link((self.w_checkbox, "v_model"), (layer, "visible"))
         self.w_checkbox.observe(self._toggle_slider, "v_model")
+        link((layer, "opacity"), (self.w_slider, "v_model"))
+        link((layer, "visible"), (self.w_checkbox, "v_model"))
 
     def _toggle_slider(self, *args) -> None:
         """Toggle the modification of the slider."""
@@ -145,7 +145,7 @@ class VectorRow(sw.Html):
         super().__init__(tag="tr", children=[label_cell, empty_cell, checkbox_cell])
 
         # add js behavior
-        link((self.w_checkbox, "v_model"), (layer, "visible"))
+        link((layer, "visible"), (self.w_checkbox, "v_model"))
 
 
 class LayersControl(MenuControl):


### PR DESCRIPTION
Fix #818 

- set the listener first (to change both slider and checkbox if necessary)
- set the layer as pilot of the link so if layer visibility is set to False, it stays as it is. 

```python
from ipyleaflet import Map, basemaps, basemap_to_tiles
from sepal_ui import mapping as sm

m = sm.SepalMap(center=(52.204793, 360.121558), zoom=9)

dark_matter_layer = basemap_to_tiles(basemaps.CartoDB.Positron)
dark_matter_layer.visible = False
m.add_layer(dark_matter_layer)
m
```
