### PR TITLE
fix: replace jslink by link

### DIFF
--- a/sepal_ui/sepalwidgets/alert.py
+++ b/sepal_ui/sepalwidgets/alert.py
@@ -17,9 +17,9 @@ from typing import Any, Optional
 import ipyvuetify as v
 import traitlets as t
 from deprecated.sphinx import deprecated
-from ipywidgets import Output, jslink
+from ipywidgets import Output
 from tqdm.notebook import tqdm
-from traitlets import directional_link, observe
+from traitlets import directional_link, link, observe
 from typing_extensions import Self
 
 from sepal_ui import color
@@ -282,7 +282,7 @@ class StateBar(v.SystemBar, SepalWidget):
         # call the constructor
         super().__init__(**kwargs)
 
-        jslink((self, "loading"), (self.progress, "indeterminate"))
+        link((self, "loading"), (self.progress, "indeterminate"))
 
     @observe("loading")
     def _change_loading(self, *args) -> None:

--- a/sepal_ui/sepalwidgets/inputs.py
+++ b/sepal_ui/sepalwidgets/inputs.py
@@ -22,7 +22,6 @@ import ipyvuetify as v
 import pandas as pd
 import traitlets as t
 from deprecated.sphinx import versionadded
-from ipywidgets import jslink
 from natsort import humansorted
 from traitlets import link, observe
 from typing_extensions import Self
@@ -551,8 +550,8 @@ class LoadTableField(v.Col, SepalWidget):
         super().__init__(**kwargs)
 
         # link the dropdowns
-        jslink((self.IdSelect, "items"), (self.LngSelect, "items"))
-        jslink((self.IdSelect, "items"), (self.LatSelect, "items"))
+        link((self.IdSelect, "items"), (self.LngSelect, "items"))
+        link((self.IdSelect, "items"), (self.LatSelect, "items"))
 
         # link the widget with v_model
         self.fileInput.observe(self._on_file_input_change, "v_model")


### PR DESCRIPTION
Fix #828 
As suggested by @dfguerrerom I moved from using the frontend only ipywidgets `jslink` to the traitlets `link`. 
Nothing specific to talk about it's straight forward. I think the planet errors are related to #825.