### PR TITLE
fix: closes 838. By using wrapper comments

### DIFF
--- a/sepal_ui/frontend/js/fontawesome.js
+++ b/sepal_ui/frontend/js/fontawesome.js
@@ -1,7 +1,7 @@
 /*******************************************************************************
  * remove any links from fontawesome 5 created by jupyter in favor of
  * fontawesome 6. to be removed when Jupyter updates it
- */
+*/
 
 function remove_fa5() {
   links = document.querySelectorAll(

--- a/sepal_ui/frontend/js/jupyter_embed.js
+++ b/sepal_ui/frontend/js/jupyter_embed.js
@@ -1,4 +1,4 @@
-// set a selected map to embed mode (i.e. default display)
+/* set a selected map to embed mode (i.e. default display) */
 var i = 0;
 const wait_unitl_element_appear = setInterval(() => {
   var element = document.querySelector(".%s .leaflet-container");

--- a/sepal_ui/frontend/js/jupyter_fullscreen.js
+++ b/sepal_ui/frontend/js/jupyter_fullscreen.js
@@ -1,4 +1,4 @@
-// set a selected map to fullscreen
+/* set a selected map to fullscreen */
 var i = 0;
 const wait_unitl_element_appear = setInterval(() => {
   var element = document.querySelector(".%s .leaflet-container");

--- a/sepal_ui/frontend/js/jupyter_resize.js
+++ b/sepal_ui/frontend/js/jupyter_resize.js
@@ -1,2 +1,2 @@
-// force the resize event. usefull for drawer clicks
+/* force the resize event. usefull for drawer clicks*/
 window.dispatchEvent(new Event("resize"));


### PR DESCRIPTION
The problem here (after many wasted hours) was that we're reading the `js` files as text and so, apparently, the inline comments had a conflict with the `js` script, I have wrapped the comments with `/* ...*/` and apparently it works now.