### PR TITLE
fix: change default branch on docs. closes #846

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -121,7 +121,7 @@ html_theme_options = {
 html_context = {
     "github_user": "12rambau",
     "github_repo": "sepal_ui",
-    "github_version": "master",
+    "github_version": "main",
     "doc_path": "docs/source",
 }
 


### PR DESCRIPTION
by changing this context parameter, the `edit on github` link will point to the default branch