### PR TITLE
fix: display meaningfull message if the folder list is empty

### DIFF
--- a/sepal_ui/message/en/utils.json
+++ b/sepal_ui/message/en/utils.json
@@ -2,6 +2,9 @@
   "utils": {
     "check_input": {
       "error": "The value has not been initialized"
+    },
+    "ee": {
+      "no_asset_root": "No asset folder is available with this credentials. Please check your account and try again."
     }
   }
 }

--- a/sepal_ui/scripts/decorator.py
+++ b/sepal_ui/scripts/decorator.py
@@ -54,6 +54,7 @@ def init_ee() -> None:
         # if the user is in local development the authentication should
         # already be available
         ee.Initialize(http_transport=httplib2.Http())
+        assert len(ee.data.getAssetRoots()) > 0, ms.utils.ee.no_asset_root
 
     return
 

--- a/sepal_ui/scripts/utils.py
+++ b/sepal_ui/scripts/utils.py
@@ -142,6 +142,7 @@ def init_ee() -> None:
         # if the user is in local development the authentication should
         # already be available
         ee.Initialize(http_transport=httplib2.Http())
+        assert len(ee.data.getAssetRoots()) > 0, ms.utils.ee.no_asset_root
 
     return
 


### PR DESCRIPTION
fix: #826 

Normally all the conection to GEE should be done using either the need_ee method or the need_ee decorator. So in both cases I decided to simply assert if at least one root exist. If not I raise an error. As this will be triggered before the widgets are displayed, it will be visible on the screen.