### PR TITLE
fix: display a message at the top of the notebook while loading

### DIFF
--- a/sepal_ui/frontend/css/custom.css
+++ b/sepal_ui/frontend/css/custom.css
@@ -104,3 +104,9 @@ nav.v-navigation-drawer {
   width: calc(100vw - 80px);
   height: calc(100vh - 20px);
 }
+
+/* hide the disclaimer message placed on top of the ui notebook
+ * the message will be displayed until the css is loaded */
+#loading-app {
+  display: none !important;
+}

--- a/sepal_ui/templates/map_app/ui.ipynb
+++ b/sepal_ui/templates/map_app/ui.ipynb
@@ -1,6 +1,13 @@
 {
  "cells": [
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<center><h1 class=\"text-center h3\" id=\"loading-app\">Setting things up for you... Thanks for waiting!</h1></center>"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},

--- a/sepal_ui/templates/panel_app/ui.ipynb
+++ b/sepal_ui/templates/panel_app/ui.ipynb
@@ -1,6 +1,13 @@
 {
  "cells": [
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<center><h1 class=\"text-center h3\" id=\"loading-app\">Setting things up for you... Thanks for waiting!</h1></center>"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},


### PR DESCRIPTION
The message is manually placed at the top of the ui notebook in both template.
it uses the `loading-app` ID 
it's removed from the screen when loading of the widgets ends. 

Question: 
As we place apps in an overlay do we even need to extra CSS ? It seems to me that the markdown will simply go under it isn't it ? 