### PR TITLE
build(ipyleaflet): aims to close #901

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ dependencies = [
     "ipykernel",
     "ipyvuetify",
     "markdown",
-    "ipyleaflet @ git+https://github.com/cdanielw/ipyleaflet.git#egg=ipyleaflet",  # jupyter lab == 4 supported
+    "ipyleaflet @ https://github.com/cdanielw/ipyleaflet/releases/download/0.17.4/ipyleaflet-0.17.4-py3-none-any.whl",  # jupyter lab == 4 supported
     # earthengine management
     "earthengine-api",
     # to create a module

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ dependencies = [
     "ipykernel",
     "ipyvuetify",
     "markdown",
-    "ipyleaflet>=0.14.0",  # to have access to data member in edition
+    "ipyleaflet @ git+https://github.com/cdanielw/ipyleaflet.git#egg=ipyleaflet",  # jupyter lab == 4 supported
     # earthengine management
     "earthengine-api",
     # to create a module


### PR DESCRIPTION
- I have changed the `ipyleaflet` requirements to https://github.com/cdanielw/ipyleaflet.git.
- I tried to use just the repo but I got an error on the `ipyleaflet` build in the documentation test since that environment doesn't have `yarn` which is required to compile and build the wheel, so I opted to use the compiled wheel that is already in the forked project.
- I have tested it on different environments and it works but Windows.

@12rambau let me know what do you think about this.