### PR TITLE
fix: resolve session lifecycle bugs in Solara session management

### DIFF
--- a/pysepal/scripts/gee_interface.py
+++ b/pysepal/scripts/gee_interface.py
@@ -578,9 +578,9 @@ class GEEInterface:
         log.debug(f"Closing GEEInterface... {id(self)}")
 
         try:
-            if hasattr(self, "_sync_loop") and self._async_loop.is_running():
+            if hasattr(self, "_async_loop") and self._async_loop.is_running():
                 self._async_loop.call_soon_threadsafe(self._async_loop.stop)
-                if hasattr(self, "_sync_thread") and self._async_thread.is_alive():
+                if hasattr(self, "_async_thread") and self._async_thread.is_alive():
                     self._async_thread.join(timeout=5.0)
                     if self._async_thread.is_alive():
                         log.warning("Background thread did not stop within timeout")

--- a/pysepal/solara/session_manager.py
+++ b/pysepal/solara/session_manager.py
@@ -59,7 +59,7 @@ class SessionManager:
     def get_kernel_id(self) -> str:
         """Get the current kernel ID."""
         # Solara provides a way to get the current kernel context
-        return id(solara.server.kernel_context.get_current_context().kernel)
+        return str(id(solara.server.kernel_context.get_current_context().kernel))
 
     def create_session(self, module_name: str = "default") -> None:
         """Create a new session with all the interfaces for the given kernel ID.

--- a/pysepal/solara/session_manager.py
+++ b/pysepal/solara/session_manager.py
@@ -72,8 +72,14 @@ class SessionManager:
             EEClientError: For authentication-related errors.
             Exception: For other validation or connection errors.
         """
-        current_headers = headers.value
         kernel_id = self.get_kernel_id()
+
+        # Skip if a session already exists for this kernel (idempotent)
+        if kernel_id in self._sessions:
+            logger.debug(f"Session already exists for kernel {kernel_id}, skipping creation")
+            return
+
+        current_headers = headers.value
 
         if current_headers is None:
             logger.warning(f"Headers not available yet for kernel {kernel_id}")

--- a/pysepal/solara/utils.py
+++ b/pysepal/solara/utils.py
@@ -46,8 +46,12 @@ def _get_fallback_drive_interface() -> GDriveInterface:
 def get_current_gee_interface() -> GEEInterface:
     """Returns the GEE interface for the current kernel session.
 
-    If session manager is not initialized, returns a shared fallback GEEInterface
-    with an EESession without headers.
+    If session manager is not initialized (e.g. running in a notebook),
+    returns a shared fallback GEEInterface with an EESession without headers.
+
+    Raises:
+        RuntimeError: If session manager is initialized but no session exists
+            for the current kernel (indicates a missing @with_sepal_sessions decorator).
     """
     if SessionManager.is_initialized():
         session_manager = SessionManager()
@@ -55,7 +59,12 @@ def get_current_gee_interface() -> GEEInterface:
         if interface is not None:
             return interface
 
-    # Fallback: return shared GEEInterface with EESession without headers
+        raise RuntimeError(
+            "Session manager is active but no session exists for the current kernel. "
+            "Ensure your Page component is decorated with @with_sepal_sessions."
+        )
+
+    # Fallback only for non-Solara contexts (notebooks, scripts)
     return _get_fallback_gee_interface()
 
 
@@ -76,8 +85,12 @@ def get_current_sepal_client() -> Optional[SepalClient]:
 def get_current_drive_interface() -> GDriveInterface:
     """Returns Drive interface for the current kernel session.
 
-    If session manager is not initialized, returns a shared fallback GDriveInterface
-    without headers.
+    If session manager is not initialized (e.g. running in a notebook),
+    returns a shared fallback GDriveInterface without headers.
+
+    Raises:
+        RuntimeError: If session manager is initialized but no session exists
+            for the current kernel (indicates a missing @with_sepal_sessions decorator).
     """
     if SessionManager.is_initialized():
         session_manager = SessionManager()
@@ -85,7 +98,12 @@ def get_current_drive_interface() -> GDriveInterface:
         if interface is not None:
             return interface
 
-    # Fallback: return shared GDriveInterface without headers
+        raise RuntimeError(
+            "Session manager is active but no session exists for the current kernel. "
+            "Ensure your Page component is decorated with @with_sepal_sessions."
+        )
+
+    # Fallback only for non-Solara contexts (notebooks, scripts)
     return _get_fallback_drive_interface()
 
 

--- a/tests/test_scripts/test_gee_interface.py
+++ b/tests/test_scripts/test_gee_interface.py
@@ -194,10 +194,14 @@ def test_close(gee_interface: GEEInterface) -> None:
     # Create a new interface for this test
     interface = GEEInterface()
     assert not interface._closed
+    assert interface._async_thread.is_alive()
+    assert interface._async_loop.is_running()
 
     # Close it
     interface.close()
     assert interface._closed
+    assert not interface._async_thread.is_alive()
+    assert interface._async_loop.is_closed()
 
     # Calling close again should be safe
     interface.close()


### PR DESCRIPTION
## Summary

- **Make `create_session` idempotent** — skip creation if a session already exists for the kernel, preventing leaked `GEEInterface` threads/event loops on every Solara re-render
- **Fix `GEEInterface.close()`** — the `hasattr` guards checked `_sync_loop`/`_sync_thread` but the constructor creates `_async_loop`/`_async_thread`, so cleanup never actually stopped the background loop or joined the thread
- **Fail loud in multi-user context** — `get_current_gee_interface()` and `get_current_drive_interface()` now raise `RuntimeError` when `SessionManager` is active but no session exists for the current kernel, instead of silently falling back to shared process-level credentials. The fallback is preserved for non-Solara contexts (notebooks, scripts).

## Test plan
- [ ] Deploy a Solara app with `@with_sepal_sessions` and verify session is created once per kernel (check logs for "skipping creation" on re-renders)
- [ ] Verify `GEEInterface.close()` stops the background thread on kernel shutdown (no lingering threads)
- [ ] Confirm that calling `get_current_gee_interface()` without `@with_sepal_sessions` in a Solara app raises `RuntimeError`
- [ ] Confirm notebook/script usage still gets the fallback `GEEInterface` without error