### PR TITLE
feat(MapApp): responsive bottom panel + fixes

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -86,6 +86,7 @@ test = [
     "pytest-icdiff",
     "pytest-cov",
     "pytest-deadfixtures",
+    "pytest-rerunfailures",
     "Flake8-pyproject",
     "nbmake",
     "pytest-regressions",

--- a/pysepal/aoi/aoi_model.py
+++ b/pysepal/aoi/aoi_model.py
@@ -177,7 +177,7 @@ class AoiModel(Model):
                 self.gee_interface = gee_interface
             else:
                 self.gee_interface = GEEInterface(gee_session)
-            self.folder = str(folder) or self.gee_interface.get_folder()
+            self.folder = str(folder) if folder else self.gee_interface.get_folder()
 
         # set default values
         self.set_default(vector, admin, asset)

--- a/pysepal/mapping/sepal_map.py
+++ b/pysepal/mapping/sepal_map.py
@@ -97,6 +97,9 @@ class SepalMap(ipl.Map):
     viewport_inset_right = _TInt(0)
     "Right overlay width in px. Set by the parent shell (e.g. MapApp) so fit_bounds targets the visible region."
 
+    viewport_inset_bottom = _TInt(0)
+    "Bottom overlay height in px. Set by the parent shell (e.g. MapApp narrow-mode bottom panel) so fit_bounds targets the visible region."
+
     canvas_width_px = _TInt(0)
     "Canvas width in px, pushed from the frontend."
 
@@ -883,16 +886,19 @@ class SepalMap(ipl.Map):
         canvas_w = int(self.canvas_width_px) or derived_w or DEFAULT_MAP_WIDTH_PX
         canvas_h = int(self.canvas_height_px) or derived_h or (canvas_w * 9 / 16)
 
-        # Subtract overlay panels (nav drawer, right panel) from the *width*;
-        # MapApp has no top/bottom overlays, so height is the full canvas.
+        # Subtract overlay panels (nav drawer, right panel) from the *width*
+        # and the narrow-mode bottom panel from the *height* so fit_bounds
+        # targets the truly visible region.
         left = max(int(self.viewport_inset_left), 0)
         right = max(int(self.viewport_inset_right), 0)
+        bottom = max(int(self.viewport_inset_bottom), 0)
         visible_w = max(canvas_w - left - right, 1)
-        visible_h = canvas_h
+        visible_h = max(canvas_h - bottom, 1)
 
         log.debug(
             f"canvas=({canvas_w:.0f},{canvas_h:.0f}) "
-            f"visible=({visible_w:.0f},{visible_h:.0f}) insets=({left},{right})"
+            f"visible=({visible_w:.0f},{visible_h:.0f}) "
+            f"insets=({left},{right},{bottom})"
         )
 
         zoom = (

--- a/pysepal/mapping/sepal_map.py
+++ b/pysepal/mapping/sepal_map.py
@@ -914,12 +914,20 @@ class SepalMap(ipl.Map):
         self.zoom = zoom
 
         # Shift the map center so the target's geographic center lands at the
-        # *visible* center (drawer_left + visible/2), not the canvas center.
-        # In Web Mercator, longitude is linear in pixels: 360° / (256 * 2**zoom).
+        # *visible* center, not the canvas center.
+        # X (longitude) is linear in Web Mercator pixels: 360° / (256 * 2**zoom).
+        # Y (latitude) scale near lat_c is the X scale * cos(lat_c).
         lat_c, lon_c = compute_center(bounds)
-        px_offset = (left - right) / 2  # +ve when left panel dominates
-        lon_shift = px_offset * 360.0 / (256 * (2**zoom))
-        self.center = (lat_c, lon_c - lon_shift)
+        deg_per_px_x = 360.0 / (256 * (2**zoom))
+        deg_per_px_y = deg_per_px_x * math.cos(math.radians(lat_c))
+
+        px_offset_x = (left - right) / 2  # +ve when left panel dominates
+        # bottom panel pushes the visible region upward → canvas center is
+        # below visible center → map center must shift south (lower lat).
+        px_offset_y = bottom / 2
+        lon_shift = px_offset_x * deg_per_px_x
+        lat_shift = px_offset_y * deg_per_px_y
+        self.center = (lat_c - lat_shift, lon_c - lon_shift)
 
     def add_legend(
         self,

--- a/pysepal/scripts/gee.py
+++ b/pysepal/scripts/gee.py
@@ -206,7 +206,7 @@ def _get_assets(folder: Union[str, Path] = "", async_=True) -> List[dict]:
         the asset list. each asset is a dict with 3 keys: 'type', 'name' and 'id'
 
     """
-    folder = str(folder) or f"projects/{get_ee_project()}/assets/"
+    folder = str(folder) if folder else f"projects/{get_ee_project()}/assets/"
 
     return _get_assets_sync(folder)
 
@@ -269,7 +269,7 @@ def is_asset(asset_name: str = None, folder: Union[str, Path] = "", asset_id: st
             asset_id = asset_name
         else:
             # Construct asset_id from legacy parameters
-            folder = str(folder)
+            folder = str(folder) if folder else ""
             if folder and not folder.startswith("projects/"):
                 # If folder doesn't start with 'projects/', assume it's a relative path
                 folder = f"projects/{get_ee_project()}/assets/{folder}"

--- a/pysepal/sepalwidgets/inputs.py
+++ b/pysepal/sepalwidgets/inputs.py
@@ -723,7 +723,7 @@ class AssetSelect(v.Combobox, SepalWidget):
         # self.asset_info = {}
 
         # if folder is not set use the root one
-        self.folder = str(folder) or self.gee_interface.get_folder()
+        self.folder = str(folder) if folder else self.gee_interface.get_folder()
         self.types = types
 
         # load the default assets

--- a/pysepal/sepalwidgets/vue/MapApp.vue
+++ b/pysepal/sepalwidgets/vue/MapApp.vue
@@ -1107,60 +1107,17 @@ export default {
   pointer-events: none !important;
 }
 
-/* Narrow-mode rules that only target this component's own DOM
-   (#map-container, .step-content-container, .sidebar-controls, .left-drawer)
-   stay scoped. */
-.narrow-mode #map-container.map-background {
-  transition: bottom 0.3s ease;
-}
-.narrow-bottom-panel #map-container.map-background {
-  bottom: var(--bottom-panel-height) !important;
-}
-
-.narrow-bottom-panel #map-container .leaflet-right {
-  right: 0 !important;
-  transition: none !important;
-}
-.narrow-bottom-panel #map-container .leaflet-left {
-  transition: none !important;
-}
-
-/* Left drawer should only span the visible map area, not run behind the
-   bottom panel. */
-.narrow-mode .left-drawer.v-navigation-drawer {
-  transition: height 0.3s ease, bottom 0.3s ease,
-    transform 0.2s cubic-bezier(0.25, 0.8, 0.5, 1) !important;
-}
-.narrow-bottom-panel .left-drawer.v-navigation-drawer {
-  height: calc(100vh - var(--bottom-panel-height)) !important;
-  bottom: var(--bottom-panel-height) !important;
-}
-
-/* Step-type content (when used instead of the map) must also leave room
-   for the bottom panel. */
-.narrow-bottom-panel .step-content-container {
-  bottom: var(--bottom-panel-height);
-}
-
-/* Re-center the sidebar collapse/expand arrow on the visible map area. */
-.narrow-bottom-panel .sidebar-controls {
-  top: calc((100vh - var(--bottom-panel-height)) / 2);
-}
-</style>
-
-<style>
-/* Non-scoped: these rules target DOM rendered inside sibling components
-   (RightPanel.vue mounted via jupyter-widget). Vue 2 scoped CSS appends
-   the parent's data-v-* attribute to the rightmost selector, which would
-   not match elements outside this component's template — !important does
-   not fix that. Keep them as plain global CSS, gated by the .narrow-mode
-   / .narrow-bottom-panel classes set on this component's <v-app> root.
+/* Narrow viewports: dock the right panel to the bottom and shrink the map
+   above it. Despite the right-panel widget being mounted via a separate
+   jupyter-widget, these scoped rules still apply in the ipyvue runtime —
+   moving them to a non-scoped block was tried and broke the layout, so
+   they stay here. The panel height is read from --narrow-panel-height so
+   it cannot drift from the JS value used elsewhere for layout offsets.
 
    `narrow-mode` (always when narrow) reshapes the right-panel into a bottom
-   sheet so its open/close transition slides vertically. `narrow-bottom-panel`
-   (narrow + open) drives layout shifts for siblings. The panel height is
-   read from --narrow-panel-height so it cannot drift from the JS value
-   used elsewhere for layout offsets. */
+   sheet so its open/close transition slides vertically instead of from the
+   right edge. `narrow-bottom-panel` (narrow + open) drives the layout shift
+   for siblings: map shrinks upward, left drawer height shrinks, etc. */
 .narrow-mode .right-panel.v-navigation-drawer {
   top: auto !important;
   left: 0 !important;
@@ -1180,8 +1137,50 @@ export default {
   transform: translateY(0) !important;
 }
 
-/* Right-panel toggle tab: dock to bottom-center when narrow, rotate the
-   chevron 90° so it points up, round the top corners. */
+/* Match the right-panel's 0.3s slide so the map shrinks in sync with the
+   bottom sheet rising into place — without this they desync (drawer/map
+   snap instantly while the panel still slides up). */
+.narrow-mode #map-container.map-background {
+  transition: bottom 0.3s ease;
+}
+.narrow-bottom-panel #map-container.map-background {
+  bottom: var(--bottom-panel-height) !important;
+}
+
+.narrow-bottom-panel #map-container .leaflet-right {
+  right: 0 !important;
+  transition: none !important;
+}
+.narrow-bottom-panel #map-container .leaflet-left {
+  transition: none !important;
+}
+
+/* Left drawer should only span the visible map area, not run behind the
+   bottom panel. Vuetify positions the drawer with top:0 + height:100%; we
+   shrink height (and pin bottom) so it stops at the panel's top edge. */
+.narrow-mode .left-drawer.v-navigation-drawer {
+  transition: height 0.3s ease, bottom 0.3s ease,
+    transform 0.2s cubic-bezier(0.25, 0.8, 0.5, 1) !important;
+}
+.narrow-bottom-panel .left-drawer.v-navigation-drawer {
+  height: calc(100vh - var(--bottom-panel-height)) !important;
+  bottom: var(--bottom-panel-height) !important;
+}
+
+/* Step-type content (when used instead of the map) must also leave room
+   for the bottom panel. */
+.narrow-bottom-panel .step-content-container {
+  bottom: var(--bottom-panel-height);
+}
+
+/* Re-center the sidebar collapse/expand arrow on the visible map area. */
+.narrow-bottom-panel .sidebar-controls {
+  top: calc((100vh - var(--bottom-panel-height)) / 2);
+}
+
+/* Right-panel toggle tab: when narrow, dock it to the bottom-center so the
+   panel slides up from below it. Rotate the chevron-left icon 90° so it
+   points up, and round the top corners instead of the left corners. */
 .narrow-mode .right-panel-tab {
   top: auto !important;
   right: auto !important;

--- a/pysepal/sepalwidgets/vue/MapApp.vue
+++ b/pysepal/sepalwidgets/vue/MapApp.vue
@@ -1178,9 +1178,11 @@ export default {
   top: calc((100vh - var(--bottom-panel-height)) / 2);
 }
 
-/* Right-panel toggle tab: when narrow, dock it to the bottom-center so the
-   panel slides up from below it. Rotate the chevron-left icon 90° so it
-   points up, and round the top corners instead of the left corners. */
+/* Right-panel toggle tab: when narrow, dock it flush to the bottom-center
+   so the panel slides up from below it. The button flips orientation —
+   on the right edge it is a vertical tab (25px short axis = width); at
+   the bottom it becomes a horizontal tab (25px short axis = height) so
+   the visible "thickness" matches in both layouts. */
 .narrow-mode .right-panel-tab {
   top: auto !important;
   right: auto !important;
@@ -1189,6 +1191,10 @@ export default {
   transform: translateX(-50%) !important;
 }
 .narrow-mode .right-panel-tab .control-btn {
+  min-width: 64px !important;
+  height: 25px !important;
+  padding: 0 !important;
+  margin-bottom: 0 !important;
   border-radius: 3px 3px 0 0 !important;
   box-shadow: 0 -2px 6px rgba(0, 0, 0, 0.12) !important;
 }

--- a/pysepal/sepalwidgets/vue/MapApp.vue
+++ b/pysepal/sepalwidgets/vue/MapApp.vue
@@ -5,7 +5,8 @@
       '--drawer-width': sidebarOffset,
       '--right-panel-width': rightPanelOffset,
       '--right-panel-open': rightPanelOpen ? '1' : '0',
-      '--bottom-panel-height': narrowBottom ? bottomPanelHeight : '0px',
+      '--narrow-panel-height': NARROW_PANEL_HEIGHT,
+      '--bottom-panel-height': narrowBottom ? NARROW_PANEL_HEIGHT : '0px',
     }"
   >
     <div
@@ -399,7 +400,11 @@ export default {
     windowWidth: window.innerWidth,
     windowHeight: window.innerHeight,
     narrowBreakpoint: 960,
-    bottomPanelHeight: "45vh",
+    // Single source of truth for the narrow-mode bottom-panel height,
+    // shared between inline style bindings and the global layout vars
+    // synced to the document root. The CSS rule that sizes the panel
+    // reads this via `var(--narrow-panel-height)` so they can't drift.
+    NARROW_PANEL_HEIGHT: "45vh",
   }),
 
   computed: {
@@ -664,7 +669,7 @@ export default {
       // when narrow + closed, else 0.
       const hasRightPanel = this.right_panel && this.right_panel.length > 0;
       let bottomReserved = "0px";
-      if (this.narrowBottom) bottomReserved = this.bottomPanelHeight;
+      if (this.narrowBottom) bottomReserved = this.NARROW_PANEL_HEIGHT;
       else if (this.isNarrow && hasRightPanel) bottomReserved = "48px";
       root.style.setProperty("--sepal-bottom-reserved", bottomReserved);
     },
@@ -1102,37 +1107,9 @@ export default {
   pointer-events: none !important;
 }
 
-/* Narrow viewports: dock the right panel to the bottom and shrink the map
-   above it. The right-panel widget is mounted via a separate jupyter-widget
-   so scoped data-v-* attributes don't reach it; the !important overrides
-   target Vuetify's right-side navigation drawer regardless.
-
-   `narrow-mode` (always when narrow) reshapes the right-panel into a bottom
-   sheet so its open/close transition slides vertically instead of from the
-   right edge. `narrow-bottom-panel` (narrow + open) drives the layout shift
-   for siblings: map shrinks upward, left drawer height shrinks, etc. */
-.narrow-mode .right-panel.v-navigation-drawer {
-  top: auto !important;
-  left: 0 !important;
-  right: 0 !important;
-  bottom: 0 !important;
-  width: 100vw !important;
-  max-width: 100vw !important;
-  height: 45vh !important;
-  box-shadow: 0 -2px 18px rgba(0, 0, 0, 0.12) !important;
-  transition: transform 0.3s ease !important;
-}
-.narrow-mode .right-panel.v-navigation-drawer--close,
-.narrow-mode .right-panel.v-navigation-drawer:not(.v-navigation-drawer--open) {
-  transform: translateY(100%) !important;
-}
-.narrow-mode .right-panel.v-navigation-drawer--open {
-  transform: translateY(0) !important;
-}
-
-/* Match the right-panel's 0.3s slide so the map shrinks in sync with the
-   bottom sheet rising into place — without this they desync (drawer/map
-   snap instantly while the panel still slides up). */
+/* Narrow-mode rules that only target this component's own DOM
+   (#map-container, .step-content-container, .sidebar-controls, .left-drawer)
+   stay scoped. */
 .narrow-mode #map-container.map-background {
   transition: bottom 0.3s ease;
 }
@@ -1149,8 +1126,7 @@ export default {
 }
 
 /* Left drawer should only span the visible map area, not run behind the
-   bottom panel. Vuetify positions the drawer with top:0 + height:100%; we
-   shrink height (and pin bottom) so it stops at the panel's top edge. */
+   bottom panel. */
 .narrow-mode .left-drawer.v-navigation-drawer {
   transition: height 0.3s ease, bottom 0.3s ease,
     transform 0.2s cubic-bezier(0.25, 0.8, 0.5, 1) !important;
@@ -1170,10 +1146,42 @@ export default {
 .narrow-bottom-panel .sidebar-controls {
   top: calc((100vh - var(--bottom-panel-height)) / 2);
 }
+</style>
 
-/* Right-panel toggle tab: when narrow, dock it to the bottom-center so the
-   panel slides up from below it. Rotate the chevron-left icon 90° so it
-   points up, and round the top corners instead of the left corners. */
+<style>
+/* Non-scoped: these rules target DOM rendered inside sibling components
+   (RightPanel.vue mounted via jupyter-widget). Vue 2 scoped CSS appends
+   the parent's data-v-* attribute to the rightmost selector, which would
+   not match elements outside this component's template — !important does
+   not fix that. Keep them as plain global CSS, gated by the .narrow-mode
+   / .narrow-bottom-panel classes set on this component's <v-app> root.
+
+   `narrow-mode` (always when narrow) reshapes the right-panel into a bottom
+   sheet so its open/close transition slides vertically. `narrow-bottom-panel`
+   (narrow + open) drives layout shifts for siblings. The panel height is
+   read from --narrow-panel-height so it cannot drift from the JS value
+   used elsewhere for layout offsets. */
+.narrow-mode .right-panel.v-navigation-drawer {
+  top: auto !important;
+  left: 0 !important;
+  right: 0 !important;
+  bottom: 0 !important;
+  width: 100vw !important;
+  max-width: 100vw !important;
+  height: var(--narrow-panel-height, 45vh) !important;
+  box-shadow: 0 -2px 18px rgba(0, 0, 0, 0.12) !important;
+  transition: transform 0.3s ease !important;
+}
+.narrow-mode .right-panel.v-navigation-drawer--close,
+.narrow-mode .right-panel.v-navigation-drawer:not(.v-navigation-drawer--open) {
+  transform: translateY(100%) !important;
+}
+.narrow-mode .right-panel.v-navigation-drawer--open {
+  transform: translateY(0) !important;
+}
+
+/* Right-panel toggle tab: dock to bottom-center when narrow, rotate the
+   chevron 90° so it points up, round the top corners. */
 .narrow-mode .right-panel-tab {
   top: auto !important;
   right: auto !important;

--- a/pysepal/sepalwidgets/vue/MapApp.vue
+++ b/pysepal/sepalwidgets/vue/MapApp.vue
@@ -1137,21 +1137,21 @@ export default {
   transform: translateY(0) !important;
 }
 
-/* Match the right-panel's 0.3s slide so the map shrinks in sync with the
-   bottom sheet rising into place — without this they desync (drawer/map
-   snap instantly while the panel still slides up). */
+/* In narrow mode the map ALWAYS reserves the bottom-panel height, even
+   when the panel is closed. This keeps the visible map area stable so
+   downstream calculations (e.g. image centering against the map size)
+   don't shift every time the panel toggles. The closed-panel state shows
+   an empty band below the map where the panel tab sits; the open panel
+   slides in on top of that band. */
 .narrow-mode #map-container.map-background {
-  transition: bottom 0.3s ease;
-}
-.narrow-bottom-panel #map-container.map-background {
-  bottom: var(--bottom-panel-height) !important;
+  bottom: var(--narrow-panel-height, 45vh) !important;
 }
 
-.narrow-bottom-panel #map-container .leaflet-right {
+.narrow-mode #map-container .leaflet-right {
   right: 0 !important;
   transition: none !important;
 }
-.narrow-bottom-panel #map-container .leaflet-left {
+.narrow-mode #map-container .leaflet-left {
   transition: none !important;
 }
 

--- a/pysepal/sepalwidgets/vue/MapApp.vue
+++ b/pysepal/sepalwidgets/vue/MapApp.vue
@@ -1,9 +1,11 @@
 <template>
   <v-app
+    :class="{ 'narrow-mode': isNarrow, 'narrow-bottom-panel': narrowBottom }"
     :style="{
       '--drawer-width': sidebarOffset,
       '--right-panel-width': rightPanelOffset,
       '--right-panel-open': rightPanelOpen ? '1' : '0',
+      '--bottom-panel-height': narrowBottom ? bottomPanelHeight : '0px',
     }"
   >
     <div
@@ -28,7 +30,7 @@
       :mini-variant="mini"
       :mini-variant-width="collapsedWidth"
       :width="expandedWidth"
-      :class="{ 'drawer-disabled': drawerDisabled }"
+      :class="['left-drawer', { 'drawer-disabled': drawerDisabled }]"
       app
       permanent
       stateless
@@ -396,6 +398,8 @@ export default {
     open_dialog: false,
     windowWidth: window.innerWidth,
     windowHeight: window.innerHeight,
+    narrowBreakpoint: 960,
+    bottomPanelHeight: "45vh",
   }),
 
   computed: {
@@ -497,6 +501,14 @@ export default {
     drawerDisabled() {
       return this.open_dialog;
     },
+
+    isNarrow() {
+      return this.windowWidth < this.narrowBreakpoint;
+    },
+
+    narrowBottom() {
+      return this.isNarrow && this.rightPanelOpen;
+    },
   },
 
   watch: {
@@ -568,6 +580,42 @@ export default {
     mini() {
       this._pushDrawerWidth();
     },
+
+    // Toggle a body-level class while a step dialog is open so siblings
+    // mounted outside the v-app stacking context (e.g. Legend, mounted via
+    // its own jupyter-widget) can hide themselves cleanly.
+    open_dialog: {
+      immediate: true,
+      handler(open) {
+        document.body.classList.toggle("sepal-modal-open", !!open);
+      },
+    },
+
+    // Nudge leaflet to recompute its canvas when the bottom-panel layout
+    // toggles — the map-container's height changes via CSS, but leaflet
+    // only listens to window resize. Also re-sync global layout vars so
+    // Legend / NotificationUI stop tracking a right edge that no longer
+    // exists in narrow-bottom mode.
+    narrowBottom() {
+      this._syncGlobalLayoutVars();
+      this.$nextTick(() => {
+        window.dispatchEvent(new Event("resize"));
+      });
+    },
+
+    // Auto-collapse the drawer on narrow viewports regardless of pin state,
+    // and restore the pinned-open state when the viewport grows back.
+    isNarrow: {
+      immediate: true,
+      handler(narrow) {
+        if (narrow) {
+          if (!this.mini) this.mini = true;
+        } else if (this.is_pinned && this.mini) {
+          this.mini = false;
+        }
+        this._syncGlobalLayoutVars();
+      },
+    },
   },
 
   mounted() {
@@ -584,6 +632,7 @@ export default {
   beforeDestroy() {
     window.removeEventListener("resize", this.handleResize);
     this._clearGlobalLayoutVars();
+    document.body.classList.remove("sepal-modal-open");
   },
 
   methods: {
@@ -598,16 +647,26 @@ export default {
     _syncGlobalLayoutVars() {
       const root = document.documentElement;
       const offset = this.actualRightOffset;
-      root.style.setProperty("--sepal-right-panel-width", offset + "px");
-      root.style.setProperty(
-        "--sepal-right-panel-open",
-        offset > 0 ? "1" : "0"
-      );
+      // In narrow-bottom mode the right panel is docked at the bottom, so
+      // downstream consumers (Legend, notifications) should treat the right
+      // edge as flush and instead leave room at the bottom.
+      const rightOffset = this.narrowBottom ? 0 : offset;
+      const isOpen = this.narrowBottom ? false : offset > 0;
+      root.style.setProperty("--sepal-right-panel-width", rightOffset + "px");
+      root.style.setProperty("--sepal-right-panel-open", isOpen ? "1" : "0");
       root.style.setProperty(
         "--sepal-notification-right-offset",
-        offset + "px"
+        rightOffset + "px"
       );
       root.style.setProperty("--sepal-drawer-width", this.sidebarOffset);
+      // Reserved space at the bottom edge for floating components (Legend,
+      // toasts) — equals the panel height when open, the toggle-tab height
+      // when narrow + closed, else 0.
+      const hasRightPanel = this.right_panel && this.right_panel.length > 0;
+      let bottomReserved = "0px";
+      if (this.narrowBottom) bottomReserved = this.bottomPanelHeight;
+      else if (this.isNarrow && hasRightPanel) bottomReserved = "48px";
+      root.style.setProperty("--sepal-bottom-reserved", bottomReserved);
     },
     _clearGlobalLayoutVars() {
       const root = document.documentElement;
@@ -615,6 +674,7 @@ export default {
       root.style.removeProperty("--sepal-right-panel-open");
       root.style.removeProperty("--sepal-notification-right-offset");
       root.style.removeProperty("--sepal-drawer-width");
+      root.style.removeProperty("--sepal-bottom-reserved");
     },
     handleResize() {
       // Update reactive window dimensions
@@ -1012,12 +1072,12 @@ export default {
   z-index: 1001 !important;
 }
 
-.leaflet-left {
+#map-container .leaflet-left {
   transition: left 0.3s ease;
   left: var(--drawer-width) !important;
 }
 
-.leaflet-right {
+#map-container .leaflet-right {
   transition: right 0.3s ease;
   right: calc(var(--right-panel-width) * var(--right-panel-open)) !important;
 }
@@ -1040,5 +1100,92 @@ export default {
 
 .drawer-disabled .v-list-item {
   pointer-events: none !important;
+}
+
+/* Narrow viewports: dock the right panel to the bottom and shrink the map
+   above it. The right-panel widget is mounted via a separate jupyter-widget
+   so scoped data-v-* attributes don't reach it; the !important overrides
+   target Vuetify's right-side navigation drawer regardless.
+
+   `narrow-mode` (always when narrow) reshapes the right-panel into a bottom
+   sheet so its open/close transition slides vertically instead of from the
+   right edge. `narrow-bottom-panel` (narrow + open) drives the layout shift
+   for siblings: map shrinks upward, left drawer height shrinks, etc. */
+.narrow-mode .right-panel.v-navigation-drawer {
+  top: auto !important;
+  left: 0 !important;
+  right: 0 !important;
+  bottom: 0 !important;
+  width: 100vw !important;
+  max-width: 100vw !important;
+  height: 45vh !important;
+  box-shadow: 0 -2px 18px rgba(0, 0, 0, 0.12) !important;
+  transition: transform 0.3s ease !important;
+}
+.narrow-mode .right-panel.v-navigation-drawer--close,
+.narrow-mode .right-panel.v-navigation-drawer:not(.v-navigation-drawer--open) {
+  transform: translateY(100%) !important;
+}
+.narrow-mode .right-panel.v-navigation-drawer--open {
+  transform: translateY(0) !important;
+}
+
+/* Match the right-panel's 0.3s slide so the map shrinks in sync with the
+   bottom sheet rising into place — without this they desync (drawer/map
+   snap instantly while the panel still slides up). */
+.narrow-mode #map-container.map-background {
+  transition: bottom 0.3s ease;
+}
+.narrow-bottom-panel #map-container.map-background {
+  bottom: var(--bottom-panel-height) !important;
+}
+
+.narrow-bottom-panel #map-container .leaflet-right {
+  right: 0 !important;
+  transition: none !important;
+}
+.narrow-bottom-panel #map-container .leaflet-left {
+  transition: none !important;
+}
+
+/* Left drawer should only span the visible map area, not run behind the
+   bottom panel. Vuetify positions the drawer with top:0 + height:100%; we
+   shrink height (and pin bottom) so it stops at the panel's top edge. */
+.narrow-mode .left-drawer.v-navigation-drawer {
+  transition: height 0.3s ease, bottom 0.3s ease,
+    transform 0.2s cubic-bezier(0.25, 0.8, 0.5, 1) !important;
+}
+.narrow-bottom-panel .left-drawer.v-navigation-drawer {
+  height: calc(100vh - var(--bottom-panel-height)) !important;
+  bottom: var(--bottom-panel-height) !important;
+}
+
+/* Step-type content (when used instead of the map) must also leave room
+   for the bottom panel. */
+.narrow-bottom-panel .step-content-container {
+  bottom: var(--bottom-panel-height);
+}
+
+/* Re-center the sidebar collapse/expand arrow on the visible map area. */
+.narrow-bottom-panel .sidebar-controls {
+  top: calc((100vh - var(--bottom-panel-height)) / 2);
+}
+
+/* Right-panel toggle tab: when narrow, dock it to the bottom-center so the
+   panel slides up from below it. Rotate the chevron-left icon 90° so it
+   points up, and round the top corners instead of the left corners. */
+.narrow-mode .right-panel-tab {
+  top: auto !important;
+  right: auto !important;
+  bottom: 0 !important;
+  left: 50% !important;
+  transform: translateX(-50%) !important;
+}
+.narrow-mode .right-panel-tab .control-btn {
+  border-radius: 3px 3px 0 0 !important;
+  box-shadow: 0 -2px 6px rgba(0, 0, 0, 0.12) !important;
+}
+.narrow-mode .right-panel-tab .v-icon {
+  transform: rotate(90deg);
 }
 </style>

--- a/pysepal/sepalwidgets/vue/TaskButton.vue
+++ b/pysepal/sepalwidgets/vue/TaskButton.vue
@@ -1,7 +1,7 @@
 <template>
   <v-btn
     :color="currentColor"
-    :disabled="false"
+    :disabled="disabled"
     @click="on_click_python()"
     :style="{ minWidth: buttonWidth }"
     :small="small"

--- a/pysepal/sepalwidgets/vue_app.py
+++ b/pysepal/sepalwidgets/vue_app.py
@@ -193,6 +193,12 @@ class MapApp(v.VuetifyTemplate):
 
         return [ThemeToggle(theme_state=theme_state)]
 
+    # Mirror of MapApp.vue: viewports below this width dock the right
+    # panel as a bottom sheet sized at NARROW_PANEL_HEIGHT_VH of the
+    # window height. Both values must stay in sync with the .vue file.
+    _NARROW_BREAKPOINT_PX = 960
+    _NARROW_PANEL_HEIGHT_VH = 0.45
+
     def _sync_map_insets(self, *args):
         """Push drawer / right-panel pixel widths + window size onto the map."""
         if not self.main_map:
@@ -200,10 +206,21 @@ class MapApp(v.VuetifyTemplate):
         map_widget = self.main_map[0]
         if not hasattr(map_widget, "viewport_inset_left"):
             return
+        is_narrow = 0 < self.window_width < self._NARROW_BREAKPOINT_PX
+        has_right_panel = bool(self.right_panel)
         map_widget.viewport_inset_left = int(self.drawer_width)
+        # In narrow mode the right panel is docked at the bottom, so it
+        # consumes height (mirrored below) rather than width.
         map_widget.viewport_inset_right = (
-            int(self.right_panel_width) if self.right_panel_open else 0
+            int(self.right_panel_width) if self.right_panel_open and not is_narrow else 0
         )
+        if hasattr(map_widget, "viewport_inset_bottom"):
+            bottom = (
+                int(self.window_height * self._NARROW_PANEL_HEIGHT_VH)
+                if is_narrow and has_right_panel
+                else 0
+            )
+            map_widget.viewport_inset_bottom = bottom
         if self.window_width > 0 and hasattr(map_widget, "canvas_width_px"):
             map_widget.canvas_width_px = int(self.window_width)
         if self.window_height > 0 and hasattr(map_widget, "canvas_height_px"):

--- a/pysepal/solara/components/Legend.vue
+++ b/pysepal/solara/components/Legend.vue
@@ -141,7 +141,7 @@ module.exports = {
 <style scoped>
 .sepal-legend {
   position: fixed;
-  bottom: 16px;
+  bottom: calc(var(--sepal-bottom-reserved, 0px) + 16px);
   left: calc(
     var(--sepal-drawer-width, 0px) +
       (
@@ -153,7 +153,14 @@ module.exports = {
   z-index: 1000;
   pointer-events: auto;
   font-family: Roboto, sans-serif;
-  transition: left 0.3s ease;
+  transition: left 0.3s ease, bottom 0.3s ease;
+}
+
+/* Hide while a step dialog/modal is open — the legend's stacking context
+   sits above the modal scrim due to the jupyter-widget z-index, so simply
+   removing it from the layer is the cleanest fix. */
+body.sepal-modal-open .sepal-legend {
+  display: none;
 }
 
 .sepal-legend__pill,

--- a/pysepal/solara/components/Legend.vue
+++ b/pysepal/solara/components/Legend.vue
@@ -156,13 +156,6 @@ module.exports = {
   transition: left 0.3s ease, bottom 0.3s ease;
 }
 
-/* Hide while a step dialog/modal is open — the legend's stacking context
-   sits above the modal scrim due to the jupyter-widget z-index, so simply
-   removing it from the layer is the cleanest fix. */
-body.sepal-modal-open .sepal-legend {
-  display: none;
-}
-
 .sepal-legend__pill,
 .sepal-legend__body {
   backdrop-filter: blur(4px);
@@ -277,5 +270,15 @@ body.sepal-modal-open .sepal-legend {
 
 .sepal-legend__toggle:hover {
   opacity: 1;
+}
+</style>
+
+<style>
+/* Non-scoped: `body` is outside this component's scope attribute, so the
+   selector must run as plain global CSS. Hides the legend while a step
+   dialog/modal is open — its stacking context sits above the modal scrim
+   due to the jupyter-widget z-index. */
+body.sepal-modal-open .sepal-legend {
+  display: none;
 }
 </style>

--- a/pysepal/solara/components/Legend.vue
+++ b/pysepal/solara/components/Legend.vue
@@ -153,7 +153,6 @@ module.exports = {
   z-index: 1000;
   pointer-events: auto;
   font-family: Roboto, sans-serif;
-  transition: left 0.3s ease, bottom 0.3s ease;
 }
 
 .sepal-legend__pill,

--- a/tests/test_planetapi/conftest.py
+++ b/tests/test_planetapi/conftest.py
@@ -8,12 +8,15 @@ assertion failures and other exceptions still fail fast on the first run.
 import pytest
 
 _RERUN_ON = (
-    # Planet's own rate-limit exception
-    "planet.exceptions.TooManyRequests",
-    # Generic transient network errors
-    "httpx.ConnectError",
-    "httpx.ReadTimeout",
-    "httpx.RemoteProtocolError",
+    # pytest-rerunfailures regex-matches these against the failure repr
+    # (e.g. "TooManyRequests(...)"), so use bare class names.
+    "TooManyRequests",
+    "TooManyRedirects",
+    "ConnectError",
+    "ReadTimeout",
+    "RemoteProtocolError",
+    "ConnectionError",
+    "ServerError",
 )
 
 

--- a/tests/test_planetapi/conftest.py
+++ b/tests/test_planetapi/conftest.py
@@ -1,0 +1,29 @@
+"""Auto-retry transient failures from Planet's live API.
+
+Tests in this directory hit api.planet.com and are subject to rate-limiting
+(HTTP 429) and transient connection errors. We retry only those — real
+assertion failures and other exceptions still fail fast on the first run.
+"""
+
+import pytest
+
+_RERUN_ON = (
+    # Planet's own rate-limit exception
+    "planet.exceptions.TooManyRequests",
+    # Generic transient network errors
+    "httpx.ConnectError",
+    "httpx.ReadTimeout",
+    "httpx.RemoteProtocolError",
+)
+
+
+def pytest_collection_modifyitems(config, items):
+    """Attach a flaky marker to every test under tests/test_planetapi/."""
+    marker = pytest.mark.flaky(
+        reruns=3,
+        reruns_delay=15,
+        only_rerun=list(_RERUN_ON),
+    )
+    for item in items:
+        if "test_planetapi" in item.nodeid:
+            item.add_marker(marker)


### PR DESCRIPTION
## Summary
- Responsive bottom-panel layout for narrow viewports in `MapApp`.
- Legend now lifts above the bottom panel and hides during step dialogs.
- AOI/asset helpers fall back to the GEE root when `folder` is `None` instead of producing the literal string `"None"` in asset paths (e.g. `None/aoi_drawn_…`). Affects legacy `AoiView` draw-with-gee, `AssetSelect`, and the deprecated `gee.get_assets` / `gee.is_asset` helpers.

## Test plan
- [x] Resize viewport: confirm bottom panel reflows and Legend stays visible above it.
- [x] Open a step dialog: Legend hides; closes restore it.
- [x] Legacy `AoiView(gee=True)` with no `folder` arg: draw a polygon and confirm the export targets the user's GEE asset root, not `None/...`.
- [ ] `nox -s test` passes.