### PR TITLE
feat(solara): carry SEPAL visualization onto exported images

### DIFF
--- a/pysepal/mapping/__init__.py
+++ b/pysepal/mapping/__init__.py
@@ -28,4 +28,5 @@ from .map_btn import *
 from .marker_cluster import *
 from .menu_control import *
 from .sepal_map import *
+from .visualization import *
 from .zoom_control import *

--- a/pysepal/mapping/visualization.py
+++ b/pysepal/mapping/visualization.py
@@ -3,7 +3,7 @@
 import json
 import logging
 import warnings
-from typing import Optional
+from typing import Mapping, Optional, Sequence, Union
 
 import ee
 
@@ -13,6 +13,17 @@ from pysepal.scripts.gee_interface import GEEInterface
 from pysepal.scripts.warning import SepalWarning
 
 log = logging.getLogger("sepalui.mapping.visualization")
+
+VIZ_LIST_KEYS = ("bands", "palette", "labels")
+VIZ_NUMERIC_LIST_KEYS = ("min", "max", "values")
+VIZ_BOOL_LIST_KEYS = ("inverted",)
+VIZ_SCALAR_KEYS = ("name", "type")
+VIZ_ALL_KEYS = (
+    *VIZ_LIST_KEYS,
+    *VIZ_NUMERIC_LIST_KEYS,
+    *VIZ_BOOL_LIST_KEYS,
+    *VIZ_SCALAR_KEYS,
+)
 
 
 def _strtobool(val: str) -> bool:
@@ -382,3 +393,129 @@ def validate_ee_object(ee_object: ee.ComputedObject) -> None:
             "\n\nThe image argument in 'addLayer' function must be an instance of "
             "one of ee.Image, ee.Geometry, ee.Feature or ee.FeatureCollection."
         )
+
+
+def _serialize_viz_value(key: str, value: object) -> str:
+    """Serialize a single visualization parameter value to the SEPAL property format.
+
+    SEPAL stores visualization parameters as flat image properties prefixed with
+    ``visualization_<index>_<key>``. List-valued keys (``bands``, ``palette``,
+    ``labels``, ``min``, ``max``, ``values``, ``inverted``) are stored as
+    comma-separated strings; scalar keys (``name``, ``type``) as plain strings.
+    """
+    if key in VIZ_SCALAR_KEYS:
+        return str(value)
+
+    if key in VIZ_BOOL_LIST_KEYS:
+        sequence = value if isinstance(value, (list, tuple)) else [value]
+        return ",".join("true" if bool(item) else "false" for item in sequence)
+
+    if isinstance(value, str):
+        # Allow callers to pass a pre-serialized comma-separated string.
+        return value
+    if isinstance(value, (list, tuple)):
+        return ",".join(str(item) for item in value)
+    return str(value)
+
+
+def set_viz_params(
+    image: ee.Image,
+    *,
+    name: str = "default",
+    type: Optional[str] = None,
+    bands: Optional[Sequence[str]] = None,
+    min: Union[float, Sequence[float], None] = None,
+    max: Union[float, Sequence[float], None] = None,
+    palette: Union[str, Sequence[str], None] = None,
+    values: Optional[Sequence[Union[int, float]]] = None,
+    labels: Optional[Sequence[str]] = None,
+    inverted: Optional[Sequence[bool]] = None,
+    index: int = 0,
+) -> ee.Image:
+    """Embed SEPAL-convention visualization parameters as image properties.
+
+    This is the inverse of :func:`get_viz_params`. SEPAL stores per-image
+    visualization as flat properties ``visualization_<index>_<key>``; SepalMap
+    reads them on display, and Earth Engine asset exports preserve them, so
+    callers downstream (other SEPAL recipes, the Code Editor) see the styling
+    automatically.
+
+    Args:
+        image: The :class:`ee.Image` to annotate. A new image is returned;
+            the original is not mutated.
+        name: Logical name of the visualization (e.g. ``"default"``). Stored
+            as ``visualization_<index>_name``.
+        type: Visualization type — one of ``"continuous"``, ``"categorical"``,
+            ``"rgb"``, ``"hsv"``. Inferred by SepalMap when omitted, based on
+            the number of bands.
+        bands: Band names targeted by the visualization. Single-band for
+            ``continuous``/``categorical``, three bands for ``rgb``/``hsv``.
+        min: Per-band minimum value(s). Scalar or sequence; both stored as
+            a comma-separated string.
+        max: Per-band maximum value(s). Same rules as ``min``.
+        palette: Hex color palette. Sequence of ``#RRGGBB`` or a
+            pre-comma-joined string.
+        values: For ``categorical`` only — the discrete pixel values that the
+            palette maps to. Preserves non-consecutive class codes.
+        labels: Per-value human-readable labels (used in legends).
+        inverted: Per-band inversion flags.
+        index: Slot index in the property name. Use distinct indices when
+            attaching multiple named visualizations to the same image.
+
+    Returns:
+        A new :class:`ee.Image` carrying the visualization properties.
+
+    Example:
+        >>> styled = set_viz_params(
+        ...     classified,
+        ...     name="loss_year",
+        ...     type="categorical",
+        ...     bands=["classification"],
+        ...     palette=["#ffff00", "#8b0000", "#d3d3d3"],
+        ...     values=[1, 25, 30],
+        ...     labels=["loss 2001", "loss 2025", "non forest"],
+        ... )
+    """
+    if not isinstance(image, ee.Image):
+        actual = image.__class__.__name__ if image is not None else "None"
+        raise TypeError(f"set_viz_params requires an ee.Image; got {actual}")
+
+    fields: dict[str, object] = {
+        "name": name,
+        "type": type,
+        "bands": bands,
+        "min": min,
+        "max": max,
+        "palette": palette,
+        "values": values,
+        "labels": labels,
+        "inverted": inverted,
+    }
+
+    properties: dict[str, str] = {}
+    for key, value in fields.items():
+        if value is None:
+            continue
+        properties[f"visualization_{index}_{key}"] = _serialize_viz_value(key, value)
+
+    if not properties:
+        return image
+
+    return image.set(properties)
+
+
+def merge_viz_params(*params_list: Mapping[str, object]) -> dict:
+    """Merge several visualization parameter dicts, later entries taking precedence.
+
+    Useful when an app exposes a base palette (e.g. a shared common module)
+    and a per-instance override (e.g. user-tuned min/max).
+    """
+    merged: dict = {}
+    for params in params_list:
+        if not params:
+            continue
+        for key, value in params.items():
+            if value is None:
+                continue
+            merged[key] = value
+    return merged

--- a/pysepal/sepalwidgets/vue/MapAppShell.vue
+++ b/pysepal/sepalwidgets/vue/MapAppShell.vue
@@ -1,0 +1,1308 @@
+<template>
+  <v-app
+    :class="{ 'narrow-mode': isNarrow, 'narrow-bottom-panel': narrowBottom }"
+    :style="{
+      '--drawer-width': sidebarOffset,
+      '--right-panel-width': rightPanelOffset,
+      '--right-panel-open': rightPanelOpen ? '1' : '0',
+      '--narrow-panel-height': NARROW_PANEL_HEIGHT,
+      '--bottom-panel-height': narrowBottom ? NARROW_PANEL_HEIGHT : '0px',
+    }"
+  >
+    <div
+      v-if="main_map && main_map.length > 0"
+      id="map-container"
+      class="map-background"
+      @click="handleMapClick"
+    >
+      <jupyter-widget :widget="main_map[0]"></jupyter-widget>
+    </div>
+
+    <div
+      v-if="activeStep && activeStep.display === 'step' && active_step_content"
+      class="step-content-container"
+      :class="{ 'right-panel-open': rightPanelOpen }"
+    >
+      <jupyter-widget :widget="active_step_content"></jupyter-widget>
+    </div>
+
+    <!-- Children slot: hosts widgets passed via `with MapAppComponent(): ...` -->
+    <div v-if="children_slot" class="mapapp-children-slot">
+      <jupyter-widget :widget="children_slot"></jupyter-widget>
+    </div>
+
+    <v-navigation-drawer
+      v-model="drawer"
+      :mini-variant="mini"
+      :mini-variant-width="collapsedWidth"
+      :width="expandedWidth"
+      :class="['left-drawer', { 'drawer-disabled': drawerDisabled }]"
+      app
+      permanent
+      stateless
+    >
+      <div style="display: flex; flex-direction: column; height: 100%">
+        <div class="drawer-header">
+          <div class="app-title">
+            <v-icon class="mr-2">{{
+              app_icon ? app_icon : "mdi-earth"
+            }}</v-icon>
+            <span class="title font-weight-medium">{{ app_title }}</span>
+          </div>
+
+          <v-spacer></v-spacer>
+          <v-btn
+            v-if="!mini"
+            icon
+            @click="togglePin"
+            class="pin-btn"
+            :title="is_pinned ? 'Unpin sidebar' : 'Pin sidebar'"
+          >
+            <v-icon small>{{
+              is_pinned ? "mdi-pin" : "mdi-pin-outline"
+            }}</v-icon>
+          </v-btn>
+        </div>
+
+        <v-divider class="ma-0 pa-0"></v-divider>
+
+        <div
+          class="drawer-top"
+          style="flex: 1; overflow-y: auto; overflow-x: hidden"
+        >
+          <!-- steps -->
+          <v-list dense class="pa-0 ma-0">
+            <v-tooltip
+              right
+              :disabled="!mini"
+              v-if="main_map && main_map.length > 0"
+            >
+              <template v-slot:activator="{ on, attrs }">
+                <v-list-item
+                  @click="showMainMap"
+                  :class="{ 'active-step': !activeStepId }"
+                  v-bind="attrs"
+                  v-on="on"
+                >
+                  <v-list-item-icon>
+                    <v-icon class="mb-1">mdi-map</v-icon>
+                  </v-list-item-icon>
+                  <v-list-item-content v-if="!mini">
+                    <v-list-item-title class="font-weight-medium"
+                      >Map</v-list-item-title
+                    >
+                  </v-list-item-content>
+                </v-list-item>
+              </template>
+              <span>Map</span>
+            </v-tooltip>
+
+            <v-tooltip
+              right
+              :disabled="!mini"
+              v-for="(step, i) in steps"
+              :key="`step-${i}`"
+            >
+              <template v-slot:activator="{ on, attrs }">
+                <v-list-item
+                  @click="activateStep(step)"
+                  :class="{
+                    'active-step':
+                      activeStepId === step.id &&
+                      step.content_enabled !== false,
+                  }"
+                  :data-step-id="step.id"
+                  v-bind="attrs"
+                  v-on="on"
+                >
+                  <v-list-item-icon>
+                    <v-icon class="mb-1">{{
+                      step.icon || "mdi-checkbox-blank-circle-outline"
+                    }}</v-icon>
+                  </v-list-item-icon>
+                  <v-list-item-content v-if="!mini">
+                    <v-list-item-title class="font-weight-medium">{{
+                      step.name
+                    }}</v-list-item-title>
+                  </v-list-item-content>
+                </v-list-item>
+              </template>
+              <span>{{ step.name }}</span>
+            </v-tooltip>
+          </v-list>
+        </div>
+
+        <div class="drawer-bottom" style="padding: 16px 0">
+          <v-divider class="mb-4"></v-divider>
+          <!-- helper steps -->
+          <v-list class="pa-0 ma-0" dense>
+            <v-tooltip
+              right
+              :disabled="!mini"
+              v-for="(link, i) in externalLinks"
+              :key="`external-${i}`"
+            >
+              <template v-slot:activator="{ on, attrs }">
+                <v-list-item
+                  :href="link.url"
+                  target="_blank"
+                  class="link-item"
+                  link
+                  v-bind="attrs"
+                  v-on="on"
+                >
+                  <v-list-item-icon>
+                    <v-icon class="mb-1">{{ link.icon }}</v-icon>
+                  </v-list-item-icon>
+                  <v-list-item-content v-if="!mini">
+                    <v-list-item-title class="d-flex align-center">
+                      {{ link.title }}
+                      <v-spacer></v-spacer>
+                      <v-icon small class="ml-1">mdi-open-in-new</v-icon>
+                    </v-list-item-title>
+                  </v-list-item-content>
+                </v-list-item>
+              </template>
+              <span>{{ link.title }}</span>
+            </v-tooltip>
+
+            <v-divider class="mt-2 mb-4"></v-divider>
+
+            <!-- configuration: theme + language -->
+            <template v-if="!mini">
+              <v-list-item>
+                <v-list-item-content>
+                  <v-list-item-title class="d-flex align-center justify-center">
+                    <div>
+                      <slot name="theme-toggle"></slot>
+                      <jupyter-widget
+                        :widget="theme_toggle[0]"
+                      ></jupyter-widget>
+                    </div>
+                    <div>
+                      <slot name="language-selector"></slot>
+                      <jupyter-widget
+                        :widget="language_selector[0]"
+                      ></jupyter-widget>
+                    </div>
+                  </v-list-item-title>
+                </v-list-item-content>
+              </v-list-item>
+            </template>
+            <template v-else>
+              <v-tooltip right>
+                <template v-slot:activator="{ on, attrs }">
+                  <v-list-item v-bind="attrs" v-on="on">
+                    <v-list-item-icon class="config-icon-mini">
+                      <slot name="theme-toggle"></slot>
+                      <jupyter-widget
+                        :widget="theme_toggle[0]"
+                      ></jupyter-widget>
+                    </v-list-item-icon>
+                  </v-list-item>
+                </template>
+                <span>Toggle theme</span>
+              </v-tooltip>
+              <v-tooltip right>
+                <template v-slot:activator="{ on, attrs }">
+                  <v-list-item v-bind="attrs" v-on="on">
+                    <v-list-item-icon class="config-icon-mini">
+                      <slot name="language-selector"></slot>
+                      <jupyter-widget
+                        :widget="language_selector[0]"
+                      ></jupyter-widget>
+                    </v-list-item-icon>
+                  </v-list-item>
+                </template>
+                <span>Change language</span>
+              </v-tooltip>
+            </template>
+          </v-list>
+        </div>
+      </div>
+    </v-navigation-drawer>
+
+    <!-- Right panel (inline) — replaces the embedded RightPanel widget -->
+    <v-navigation-drawer
+      v-if="
+        right_panel_config &&
+        Object.keys(right_panel_config).length > 0 &&
+        right_panel_content_widgets.length > 0
+      "
+      v-model="rightPanelOpenLocal"
+      :right="!isNarrow"
+      :bottom="isNarrow"
+      :width="isNarrow ? '100%' : right_panel_config.width || 300"
+      :height="isNarrow ? NARROW_PANEL_HEIGHT : undefined"
+      app
+      stateless
+      class="right-panel-drawer"
+    >
+      <div class="right-panel-header d-flex align-center pa-3">
+        <v-icon class="mr-2">{{
+          right_panel_config.icon || "mdi-widgets"
+        }}</v-icon>
+        <span class="title">{{ right_panel_config.title || "Tools" }}</span>
+        <v-spacer></v-spacer>
+        <v-btn icon small @click="rightPanelOpenLocal = false">
+          <v-icon>mdi-close</v-icon>
+        </v-btn>
+      </div>
+      <v-divider></v-divider>
+      <div class="right-panel-body pa-2">
+        <template v-for="(section, i) in right_panel_sections">
+          <div :key="`section-${i}`" class="panel-section mb-2">
+            <div
+              v-if="section.title"
+              class="section-title d-flex align-center mb-1"
+            >
+              <v-icon v-if="section.icon" small class="mr-1">{{
+                section.icon
+              }}</v-icon>
+              <span class="font-weight-medium">{{ section.title }}</span>
+            </div>
+            <div
+              v-if="section.description"
+              class="section-description text-caption mb-1"
+            >
+              {{ section.description }}
+            </div>
+            <jupyter-widget
+              :widget="right_panel_content_widgets[i]"
+            ></jupyter-widget>
+            <v-divider v-if="section.divider" class="my-2"></v-divider>
+          </div>
+        </template>
+      </div>
+    </v-navigation-drawer>
+
+    <div class="sidebar-controls" :style="{ left: sidebarOffset }">
+      <v-btn
+        tile
+        color="primary"
+        @click="toggleDrawer"
+        class="control-btn mb-2"
+        :title="mini ? 'Expand sidebar' : 'Collapse sidebar'"
+      >
+        <v-icon>{{ mini ? "mdi-menu-right" : "mdi-menu-left" }}</v-icon>
+      </v-btn>
+    </div>
+
+    <!-- main Area -->
+    <v-main class="transparent-main" @click="handleMainClick"> </v-main>
+
+    <!-- dialog for dialog-type steps -->
+    <v-dialog
+      v-model="open_dialog"
+      :width="dialogWidthComputed"
+      :height="dialogHeightComputed"
+      :fullscreen="dialogFullscreen"
+      :overlay="true"
+      content-class="dialog-container"
+      @click:outside="handleDialogOutsideClick"
+    >
+      <v-card class="dialog-card">
+        <v-card-title class="headline d-flex justify-space-between">
+          <span>{{ activeStep ? activeStep.name : "" }}</span>
+          <v-btn icon @click="closeDialog">
+            <v-icon>mdi-close</v-icon>
+          </v-btn>
+        </v-card-title>
+
+        <v-divider></v-divider>
+
+        <v-card-text class="dialog-content pt-4">
+          <jupyter-widget
+            v-if="
+              activeStep &&
+              activeStep.display === 'dialog' &&
+              active_step_content
+            "
+            :widget="active_step_content"
+            class="jupyter-widget-container"
+          ></jupyter-widget>
+        </v-card-text>
+
+        <v-divider
+          v-if="
+            activeStep && activeStep.actions && activeStep.actions.length > 0
+          "
+        ></v-divider>
+
+        <v-card-actions
+          v-if="
+            activeStep && activeStep.actions && activeStep.actions.length > 0
+          "
+        >
+          <v-spacer></v-spacer>
+          <v-btn
+            v-for="(action, i) in activeStep.actions"
+            :key="`action-${i}`"
+            :text="action.cancel ? true : false"
+            :outlined="action.cancel ? true : false"
+            color="primary"
+            small
+            @click="handleActionClick(action)"
+          >
+            {{ action.label }}
+          </v-btn>
+        </v-card-actions>
+      </v-card>
+    </v-dialog>
+  </v-app>
+</template>
+
+<script>
+export default {
+  name: "MapAppShell",
+
+  props: {
+    main_map: {
+      type: Array,
+      default: () => [],
+    },
+    steps_data: {
+      type: Array,
+      default: () => [],
+    },
+    right_panel_config: {
+      type: Object,
+      default: () => ({
+        title: "Extra Content",
+        icon: "mdi-widgets",
+        width: 300,
+        description: "",
+        toggle_icon: "mdi-chevron-left",
+      }),
+    },
+    right_panel_content: {
+      type: Array,
+      default: () => [],
+    },
+    right_panel_sections: {
+      type: Array,
+      default: () => [],
+    },
+    right_panel_content_widgets: {
+      type: Array,
+      default: () => [],
+    },
+    right_panel_open: {
+      type: Boolean,
+      default: false,
+    },
+    right_panel_width: {
+      type: Number,
+      default: 300,
+    },
+    active_step_content: {
+      type: Object,
+      default: null,
+    },
+    children_slot: {
+      type: Object,
+      default: null,
+    },
+    external_links: {
+      type: Array,
+      default: () => [],
+    },
+    repo_url: {
+      type: String,
+      default: "https://github.com/sepal-contrib/",
+    },
+    docs_url: {
+      type: String,
+      default: "",
+    },
+    dialog_width: {
+      type: [String, Number],
+      default: 800,
+    },
+    dialog_fullscreen: {
+      type: Boolean,
+      default: false,
+    },
+    app_title: {
+      type: String,
+      default: "SEPAL Module",
+    },
+    app_icon: {
+      type: String,
+      default: "mdi-earth",
+    },
+    theme_toggle: {
+      type: Array,
+      default: () => [],
+    },
+    language_selector: {
+      type: Array,
+      default: () => [],
+    },
+    initial_step: {
+      type: Number,
+      default: null,
+    },
+    current_step: {
+      type: Number,
+      default: null,
+    },
+    step_open: {
+      type: Boolean,
+      default: false,
+    },
+    is_pinned: {
+      type: Boolean,
+      default: true,
+    },
+    drawer_width: {
+      type: Number,
+      default: 320,
+    },
+  },
+
+  data() {
+    return {
+      drawer: true,
+      mini: false,
+      collapsedWidth: 60,
+      expandedWidth: 320,
+      activeStepId: null,
+      open_dialog: false,
+      windowWidth: window.innerWidth,
+      windowHeight: window.innerHeight,
+      narrowBreakpoint: 960,
+      // Mirrors the right_panel_open prop so the v-navigation-drawer
+      // can two-way bind without mutating the prop directly.
+      rightPanelOpenLocal: this.right_panel_open,
+      // Single source of truth for the narrow-mode bottom-panel height,
+      // shared between inline style bindings and the global layout vars
+      // synced to the document root. The CSS rule that sizes the panel
+      // reads this via `var(--narrow-panel-height)` so they can't drift.
+      NARROW_PANEL_HEIGHT: "45vh",
+    };
+  },
+
+  computed: {
+    steps() {
+      return this.steps_data;
+    },
+
+    activeStep() {
+      if (!this.activeStepId) return null;
+      return this.steps.find((step) => step.id === this.activeStepId);
+    },
+
+    sidebarOffset() {
+      return this.mini ? this.collapsedWidth + "px" : this.expandedWidth + "px";
+    },
+
+    actualRightOffset() {
+      // Use Vuetify's application service as the source of truth for the
+      // right-side drawer offset.  This tracks the REAL drawer state
+      // (open/closed) regardless of what Solara reconc does to the
+      // right_panel_open traitlet.
+      return this.$vuetify?.application?.right || 0;
+    },
+
+    rightPanelOffset() {
+      return this.actualRightOffset + "px";
+    },
+
+    rightPanelOpen() {
+      return this.actualRightOffset > 0;
+    },
+
+    externalLinks() {
+      // User-supplied links (typed ExternalLink from Python) first,
+      // followed by the auto-derived repo/docs/bug links when repo_url
+      // is provided.
+      const custom = (this.external_links || []).map((link) => ({
+        title: link.title,
+        icon: link.icon || "mdi-open-in-new",
+        url: link.url,
+      }));
+      if (!this.repo_url) return custom;
+      return custom.concat([
+        {
+          title: "Source Code",
+          icon: "mdi-code-braces",
+          url: this.repo_url,
+        },
+        {
+          title: "Documentation",
+          icon: "mdi-book-open-page-variant",
+          url: this.docs_url || `${this.repo_url}/blob/main/doc/en.rst`,
+        },
+        {
+          title: "Report Bug",
+          icon: "mdi-bug",
+          url: `${this.repo_url}/issues/new`,
+        },
+      ]);
+    },
+
+    dialogWidthComputed() {
+      // Use reactive windowWidth instead of directly accessing window.innerWidth
+      const viewportWidth = this.windowWidth;
+      const sidebarWidth = this.mini ? this.collapsedWidth : this.expandedWidth;
+      const maxDialogWidth = viewportWidth - sidebarWidth - 40;
+
+      // Check if active step has a specific width
+      let targetWidth = this.dialog_width;
+      if (this.activeStep && this.activeStep.width) {
+        targetWidth = this.activeStep.width;
+      }
+
+      if (typeof targetWidth === "string" && targetWidth.includes("%")) {
+        const percentage = parseInt(targetWidth, 10) / 100;
+        return Math.min(maxDialogWidth, viewportWidth * percentage);
+      }
+
+      return Math.min(maxDialogWidth, targetWidth || 800);
+    },
+
+    dialogHeightComputed() {
+      // Check if active step has a specific height
+      if (this.activeStep && this.activeStep.height) {
+        // Use reactive windowHeight instead of directly accessing window.innerHeight
+        const viewportHeight = this.windowHeight;
+        const maxDialogHeight = viewportHeight - 80; // Leave some margin
+
+        if (
+          typeof this.activeStep.height === "string" &&
+          this.activeStep.height.includes("%")
+        ) {
+          const percentage = parseInt(this.activeStep.height, 10) / 100;
+          return Math.min(maxDialogHeight, viewportHeight * percentage);
+        }
+
+        return Math.min(maxDialogHeight, this.activeStep.height);
+      }
+
+      // Return null if no height is specified (let dialog auto-size)
+      return null;
+    },
+
+    dialogFullscreen() {
+      return this.dialog_fullscreen;
+    },
+
+    drawerDisabled() {
+      return this.open_dialog;
+    },
+
+    isNarrow() {
+      return this.windowWidth < this.narrowBreakpoint;
+    },
+
+    narrowBottom() {
+      return this.isNarrow && this.rightPanelOpen;
+    },
+  },
+
+  watch: {
+    // Watch for steps data changes to auto-activate first step when no main map
+    steps_data: {
+      immediate: true,
+      handler() {
+        this.autoActivateFirstStepIfNeeded();
+      },
+    },
+
+    // Watch for main_map changes to handle auto-activation
+    main_map: {
+      immediate: true,
+      handler() {
+        this.autoActivateFirstStepIfNeeded();
+      },
+    },
+
+    // Watch for initial_step changes
+    initial_step: {
+      immediate: true,
+      handler() {
+        this.autoActivateFirstStepIfNeeded();
+      },
+    },
+
+    // Mirror the right_panel_open prop into the local state used by
+    // the v-navigation-drawer's v-model. Emits when the user toggles
+    // the drawer (close button / scrim click) so Python can react.
+    right_panel_open(newValue) {
+      if (newValue !== this.rightPanelOpenLocal) {
+        this.rightPanelOpenLocal = newValue;
+      }
+    },
+    rightPanelOpenLocal(newValue) {
+      if (newValue !== this.right_panel_open) {
+        this.set_right_panel_open(newValue);
+      }
+    },
+
+    // Watch for current_step changes from Python
+    current_step(newValue) {
+      if (newValue !== null && newValue !== this.activeStepId) {
+        const step = this.steps.find((s) => s.id === newValue);
+        if (step) {
+          this.activeStepId = newValue;
+          if (step.display === "dialog") {
+            this.open_dialog = true;
+          }
+        }
+      } else if (newValue === null && this.activeStepId !== null) {
+        this.activeStepId = null;
+        this.open_dialog = false;
+      }
+    },
+
+    // Watch for step_open changes from Python
+    step_open(newValue) {
+      if (!newValue && this.open_dialog) {
+        this.open_dialog = false;
+      } else if (
+        newValue &&
+        this.activeStep &&
+        this.activeStep.display === "dialog"
+      ) {
+        this.open_dialog = true;
+      }
+    },
+
+    // Sync layout variables to document root for sibling widgets (notifications).
+    // Watches the actual Vuetify application offset (driven by the real
+    // v-navigation-drawer state) instead of the right_panel_open prop, which
+    // can be stale after a Solara reconc.  No debounce — the pill must move
+    // in lockstep with the drawer's 0.3s animation.
+    actualRightOffset() {
+      this._syncGlobalLayoutVars();
+    },
+    sidebarOffset() {
+      this._syncGlobalLayoutVars();
+      this._pushDrawerWidth();
+    },
+    mini() {
+      this._pushDrawerWidth();
+    },
+
+    // Toggle a body-level class while a step dialog is open so siblings
+    // mounted outside the v-app stacking context (e.g. Legend, mounted via
+    // its own jupyter-widget) can hide themselves cleanly.
+    open_dialog: {
+      immediate: true,
+      handler(open) {
+        document.body.classList.toggle("sepal-modal-open", !!open);
+      },
+    },
+
+    // Nudge leaflet to recompute its canvas when the bottom-panel layout
+    // toggles — the map-container's height changes via CSS, but leaflet
+    // only listens to window resize. Also re-sync global layout vars so
+    // Legend / NotificationUI stop tracking a right edge that no longer
+    // exists in narrow-bottom mode.
+    narrowBottom() {
+      this._syncGlobalLayoutVars();
+      this.$nextTick(() => {
+        window.dispatchEvent(new Event("resize"));
+      });
+    },
+
+    // Auto-collapse the drawer on narrow viewports regardless of pin state,
+    // and restore the pinned-open state when the viewport grows back.
+    isNarrow: {
+      immediate: true,
+      handler(narrow) {
+        if (narrow) {
+          if (!this.mini) this.mini = true;
+        } else if (this.is_pinned && this.mini) {
+          this.mini = false;
+        }
+        this._syncGlobalLayoutVars();
+      },
+    },
+  },
+
+  mounted() {
+    window.addEventListener("resize", this.handleResize);
+    this.autoActivateFirstStepIfNeeded();
+    if (!this.is_pinned) {
+      this.mini = true;
+    }
+    this._syncGlobalLayoutVars();
+    this._pushDrawerWidth();
+    this._pushWindowSize();
+  },
+
+  beforeDestroy() {
+    window.removeEventListener("resize", this.handleResize);
+    this._clearGlobalLayoutVars();
+    document.body.classList.remove("sepal-modal-open");
+  },
+
+  methods: {
+    _pushDrawerWidth() {
+      // Report the real pixel width of the nav drawer to Python so the
+      // embedded map can fit bounds against the visible region.
+      const px = this.mini ? this.collapsedWidth : this.expandedWidth;
+      if (px !== this.drawer_width) {
+        this.set_drawer_width(px);
+      }
+    },
+    _syncGlobalLayoutVars() {
+      const root = document.documentElement;
+      const offset = this.actualRightOffset;
+      // In narrow-bottom mode the right panel is docked at the bottom, so
+      // downstream consumers (Legend, notifications) should treat the right
+      // edge as flush and instead leave room at the bottom.
+      const rightOffset = this.narrowBottom ? 0 : offset;
+      const isOpen = this.narrowBottom ? false : offset > 0;
+      root.style.setProperty("--sepal-right-panel-width", rightOffset + "px");
+      root.style.setProperty("--sepal-right-panel-open", isOpen ? "1" : "0");
+      root.style.setProperty(
+        "--sepal-notification-right-offset",
+        rightOffset + "px"
+      );
+      root.style.setProperty("--sepal-drawer-width", this.sidebarOffset);
+      // Reserved space at the bottom edge for floating components (Legend,
+      // toasts) — equals the panel height when open, the toggle-tab height
+      // when narrow + closed, else 0.
+      const hasRightPanel =
+        this.right_panel_content_widgets &&
+        this.right_panel_content_widgets.length > 0;
+      let bottomReserved = "0px";
+      if (this.narrowBottom) bottomReserved = this.NARROW_PANEL_HEIGHT;
+      else if (this.isNarrow && hasRightPanel) bottomReserved = "48px";
+      root.style.setProperty("--sepal-bottom-reserved", bottomReserved);
+    },
+    _clearGlobalLayoutVars() {
+      const root = document.documentElement;
+      root.style.removeProperty("--sepal-right-panel-width");
+      root.style.removeProperty("--sepal-right-panel-open");
+      root.style.removeProperty("--sepal-notification-right-offset");
+      root.style.removeProperty("--sepal-drawer-width");
+      root.style.removeProperty("--sepal-bottom-reserved");
+    },
+    handleResize() {
+      // Update reactive window dimensions
+      this.windowWidth = window.innerWidth;
+      this.windowHeight = window.innerHeight;
+      this._pushWindowSize();
+      this.$forceUpdate();
+    },
+
+    _pushWindowSize() {
+      // Report real browser size to Python so the embedded map has a
+      // correct canvas size from render 0 (fixes first-fit zoom bug).
+      this.set_window_size({ w: window.innerWidth, h: window.innerHeight });
+    },
+
+    toggleDrawer() {
+      this.mini = !this.mini;
+    },
+
+    togglePin() {
+      this.is_pinned = !this.is_pinned;
+    },
+
+    handleMapClick() {
+      this.collapseIfNotPinned();
+    },
+
+    handleMainClick() {
+      this.collapseIfNotPinned();
+    },
+
+    collapseIfNotPinned() {
+      if (!this.is_pinned && !this.mini) {
+        this.mini = true;
+      }
+    },
+
+    handleRightPanelAction(action) {
+      // Call Python method to handle right panel state
+      // Note: Python method is vue_handle_right_panel_action, called without 'vue_' prefix
+      this.handle_right_panel_action(action);
+    },
+
+    activateStep(step) {
+      // Don't allow step activation if drawer is disabled (dialog is open)
+      if (this.drawerDisabled) {
+        return;
+      }
+
+      // Handle right panel actions first
+      if (step.right_panel_action) {
+        this.handleRightPanelAction(step.right_panel_action);
+      }
+
+      // Only change step content if the step is enabled
+      if (step.content_enabled !== false) {
+        this.activeStepId = step.id;
+
+        // For dialog display type, open the dialog
+        if (step.display === "dialog") {
+          this.open_dialog = true;
+        } else {
+          // Close dialog when activating non-dialog step
+          this.open_dialog = false;
+        }
+
+        // Call Python method to sync step state
+        this.handle_step_activation(step.id);
+
+        this.$emit("step-activated", step);
+      } else {
+        // For action-only steps, provide visual feedback
+        this.provideStepFeedback(step);
+        this.$emit("step-action", step);
+      }
+    },
+
+    closeDialog() {
+      this.open_dialog = false;
+      this.activeStepId = null;
+
+      // Call Python method to sync step deactivation
+      this.handle_step_deactivation();
+    },
+
+    handleDialogOutsideClick() {
+      if (this.activeStep && this.activeStep.display === "dialog") {
+        this.closeDialog();
+      }
+    },
+
+    handleActionClick(action) {
+      // Forward the action to Python (handle_step_action(step_id, event)).
+      if (this.activeStep) {
+        this.handle_step_action(
+          this.activeStep.id,
+          action.event || action.label
+        );
+      }
+
+      this.$emit("step-action", {
+        step: this.activeStep,
+        action: action,
+      });
+
+      if (action.cancel || action.close) {
+        this.closeDialog();
+      }
+
+      if (action.next) {
+        this.activeStepId = action.next;
+        this.handle_step_activation(action.next);
+      }
+    },
+
+    showMainMap() {
+      // Don't allow if drawer is disabled (dialog is open)
+      if (this.drawerDisabled) {
+        return;
+      }
+
+      this.activeStepId = null;
+      this.open_dialog = false;
+
+      // Call Python method to sync step deactivation
+      this.handle_step_deactivation();
+
+      this.$emit("show-main-map");
+    },
+
+    provideStepFeedback(step) {
+      // Add a temporary visual feedback for action-only steps
+      // This could be enhanced with animations or other visual cues
+      const stepElement = document.querySelector(`[data-step-id="${step.id}"]`);
+      if (stepElement) {
+        stepElement.style.transition = "background-color 0.2s ease";
+        stepElement.style.backgroundColor =
+          "var(--v-primary-lighten4, rgba(0, 0, 0, 0.1))";
+        setTimeout(() => {
+          stepElement.style.backgroundColor = "";
+        }, 200);
+      }
+    },
+
+    autoActivateFirstStepIfNeeded() {
+      // Check if initial_step is specified
+      if (this.initial_step !== null && !this.activeStepId) {
+        const initialStep = this.steps.find(
+          (step) => step.id === this.initial_step
+        );
+        if (
+          initialStep &&
+          initialStep.content_enabled !== false &&
+          (initialStep.display === "step" || initialStep.display === "dialog")
+        ) {
+          this.$nextTick(() => {
+            this.activeStepId = initialStep.id;
+
+            // If it's a dialog step, open the dialog
+            if (initialStep.display === "dialog") {
+              this.open_dialog = true;
+            }
+
+            this.$emit("step-auto-activated", initialStep);
+          });
+          return;
+        }
+      }
+
+      // Only auto-activate if:
+      // 1. No main map is available
+      // 2. No step is currently active
+      // 3. There are steps available
+      // 4. No initial_step was specified or it wasn't found
+      const hasMainMap = this.main_map && this.main_map.length > 0;
+      const hasSteps = this.steps && this.steps.length > 0;
+
+      if (!hasMainMap && !this.activeStepId && hasSteps) {
+        // Find the first step with content that can be displayed
+        const firstStepWithContent = this.steps.find(
+          (step) =>
+            step.content_enabled !== false &&
+            (step.display === "step" || step.display === "dialog")
+        );
+
+        if (firstStepWithContent) {
+          // Use a small delay to ensure the component is fully mounted
+          this.$nextTick(() => {
+            this.activeStepId = firstStepWithContent.id;
+
+            // If it's a dialog step, open the dialog
+            if (firstStepWithContent.display === "dialog") {
+              this.open_dialog = true;
+            }
+
+            this.$emit("step-auto-activated", firstStepWithContent);
+          });
+        }
+      }
+    },
+  },
+};
+</script>
+
+<style scoped>
+.map-background {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  z-index: 0;
+}
+
+/* Step content container */
+.step-content-container {
+  position: fixed;
+  top: 0;
+  left: var(--drawer-width);
+  right: 0;
+  bottom: 0;
+  z-index: 0;
+  background-color: var(--v-background-base, #f5f5f5);
+  padding: 16px;
+  transition: left 0.3s ease, right 0.3s ease;
+}
+
+/* When right panel is open, adjust step content */
+.step-content-container.right-panel-open {
+  right: var(--right-panel-width);
+}
+
+.transparent-main {
+  background-color: transparent !important;
+  z-index: 1;
+  pointer-events: none; /* Allow clicking through to the map */
+}
+
+.drawer-header {
+  display: flex;
+  align-items: center;
+  padding: 16px;
+  height: 64px;
+}
+
+.app-title {
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  display: flex;
+  align-items: center;
+}
+
+/* New sidebar controls styling */
+.sidebar-controls {
+  position: fixed;
+  z-index: 5 !important;
+  top: 50%;
+  transform: translateY(-50%);
+  z-index: 100;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  transition: left 0.3s ease;
+  margin-left: -5px;
+}
+
+.control-btn {
+  min-width: 25px !important;
+  padding: 0px !important;
+  margin-bottom: 8px;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
+  border-radius: 3px !important;
+}
+
+/* Mini-sidebar theme/language controls: center the embedded jupyter-widget
+   inside the v-list-item-icon slot so the button aligns with the other
+   icon rows (map/steps/links) instead of being clipped or left-aligned. */
+.v-list-item .v-list-item__icon.config-icon-mini {
+  margin: 0 !important;
+  min-width: 0 !important;
+  width: 100%;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+/* The LocaleSelect renders as <v-menu><v-btn/></v-menu>; the menu wrapper
+   (and any ipyvuetify wrapper div) can default to block-level width and
+   push the btn to the left edge. Force every intermediate wrapper to flex
+   so the btn itself gets centered, matching the ThemeToggle's <v-btn icon>
+   which is already a square flex item. */
+.config-icon-mini > *,
+.config-icon-mini .v-menu,
+.config-icon-mini .v-menu__activator {
+  display: flex !important;
+  justify-content: center !important;
+  align-items: center !important;
+  width: 100%;
+}
+
+/* Collapse the LocaleSelect button to a circular icon button in mini mode,
+   matching the ThemeToggle shape. Hide the language code text, drop the
+   95px min-width, and kill the icon's right margin so it centers. */
+.config-icon-mini .v-btn {
+  min-width: 36px !important;
+  width: 36px !important;
+  height: 36px !important;
+  padding: 0 !important;
+  border-radius: 50% !important;
+}
+.config-icon-mini .v-btn .v-btn__content {
+  font-size: 0 !important;
+  display: flex !important;
+  justify-content: center !important;
+  align-items: center !important;
+  gap: 0 !important;
+  width: 100%;
+}
+/* Target the locale icon specifically: kill its mr-2 margin and center
+   the glyph absolutely inside the button so the trailing text node
+   (rendered at font-size: 0) can't pull it left. */
+.config-icon-mini .v-btn .v-btn__content .v-icon {
+  font-size: 20px !important;
+  margin: 0 !important;
+  position: absolute;
+  left: 50%;
+  top: 50%;
+  transform: translate(-50%, -50%);
+}
+
+.dialog-container {
+  z-index: 1010 !important;
+}
+
+.dialog-card {
+  max-width: 100%;
+  max-height: 90vh;
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+  margin: 0 auto !important;
+}
+
+.dialog-content {
+  min-height: 200px;
+  max-height: 70vh;
+  overflow-y: auto;
+  flex: 1;
+}
+
+.jupyter-widget-container {
+  width: 100%;
+  height: 100%;
+}
+
+/* Ensure interactive elements in the drawer can be clicked */
+.v-navigation-drawer .v-list-item,
+.v-navigation-drawer .v-btn,
+.v-navigation-drawer .v-select {
+  pointer-events: auto;
+  transition: transform 0.3s ease;
+}
+
+/* Style active step */
+.active-step {
+  background-color: var(--v-primary-lighten4, rgba(0, 0, 0, 0.1));
+}
+
+/* override sepal-ui default css */
+.full-screen-map > .leaflet-container {
+  position: fixed !important;
+  width: 100vw !important;
+  height: 100vh !important;
+  z-index: 800;
+  bottom: 0;
+  left: 0;
+}
+
+/* v-dialog overlay should be below our dialog but above other elements */
+.v-overlay__scrim {
+  z-index: 1005 !important;
+  position: fixed !important;
+  top: 0 !important;
+  left: 0 !important;
+  width: 100vw !important;
+  height: 100vh !important;
+}
+
+/* Ensure dialog overlay covers navigation drawer and right panel */
+.v-application .v-overlay--active .v-overlay__scrim {
+  z-index: 1005 !important;
+}
+
+/* Ensure right panel is below dialog overlay */
+.v-application .jupyter-widget {
+  position: relative;
+  z-index: 1001 !important;
+}
+
+#map-container .leaflet-left {
+  transition: left 0.3s ease;
+  left: var(--drawer-width) !important;
+}
+
+#map-container .leaflet-right {
+  transition: right 0.3s ease;
+  right: calc(var(--right-panel-width) * var(--right-panel-open)) !important;
+}
+
+.v-application a {
+  color: inherit;
+  text-decoration: underline;
+}
+
+.link-item {
+  color: inherit;
+  text-decoration: none !important;
+}
+
+/* Disabled drawer when dialog is open */
+.drawer-disabled {
+  pointer-events: none !important;
+  /* opacity: 0.6 !important; */
+}
+
+.drawer-disabled .v-list-item {
+  pointer-events: none !important;
+}
+
+/* Narrow viewports: dock the right panel to the bottom and shrink the map
+   above it. Despite the right-panel widget being mounted via a separate
+   jupyter-widget, these scoped rules still apply in the ipyvue runtime —
+   moving them to a non-scoped block was tried and broke the layout, so
+   they stay here. The panel height is read from --narrow-panel-height so
+   it cannot drift from the JS value used elsewhere for layout offsets.
+
+   `narrow-mode` (always when narrow) reshapes the right-panel into a bottom
+   sheet so its open/close transition slides vertically instead of from the
+   right edge. `narrow-bottom-panel` (narrow + open) drives the layout shift
+   for siblings: map shrinks upward, left drawer height shrinks, etc. */
+.narrow-mode .right-panel.v-navigation-drawer {
+  top: auto !important;
+  left: 0 !important;
+  right: 0 !important;
+  bottom: 0 !important;
+  width: 100vw !important;
+  max-width: 100vw !important;
+  height: var(--narrow-panel-height, 45vh) !important;
+  box-shadow: 0 -2px 18px rgba(0, 0, 0, 0.12) !important;
+  transition: transform 0.3s ease !important;
+}
+.narrow-mode .right-panel.v-navigation-drawer--close,
+.narrow-mode .right-panel.v-navigation-drawer:not(.v-navigation-drawer--open) {
+  transform: translateY(100%) !important;
+}
+.narrow-mode .right-panel.v-navigation-drawer--open {
+  transform: translateY(0) !important;
+}
+
+/* In narrow mode the map ALWAYS reserves the bottom-panel height, even
+   when the panel is closed. This keeps the visible map area stable so
+   downstream calculations (e.g. image centering against the map size)
+   don't shift every time the panel toggles. The closed-panel state shows
+   an empty band below the map where the panel tab sits; the open panel
+   slides in on top of that band. */
+.narrow-mode #map-container.map-background {
+  bottom: var(--narrow-panel-height, 45vh) !important;
+}
+
+.narrow-mode #map-container .leaflet-right {
+  right: 0 !important;
+  transition: none !important;
+}
+.narrow-mode #map-container .leaflet-left {
+  transition: none !important;
+}
+
+/* Left drawer should only span the visible map area, not run behind the
+   bottom panel. Vuetify positions the drawer with top:0 + height:100%; we
+   shrink height (and pin bottom) so it stops at the panel's top edge. */
+.narrow-mode .left-drawer.v-navigation-drawer {
+  transition: height 0.3s ease, bottom 0.3s ease,
+    transform 0.2s cubic-bezier(0.25, 0.8, 0.5, 1) !important;
+}
+.narrow-bottom-panel .left-drawer.v-navigation-drawer {
+  height: calc(100vh - var(--bottom-panel-height)) !important;
+  bottom: var(--bottom-panel-height) !important;
+}
+
+/* Step-type content (when used instead of the map) must also leave room
+   for the bottom panel. */
+.narrow-bottom-panel .step-content-container {
+  bottom: var(--bottom-panel-height);
+}
+
+/* Re-center the sidebar collapse/expand arrow on the visible map area. */
+.narrow-bottom-panel .sidebar-controls {
+  top: calc((100vh - var(--bottom-panel-height)) / 2);
+}
+
+/* Right-panel toggle tab: when narrow, dock it flush to the bottom-center
+   so the panel slides up from below it. The button flips orientation —
+   on the right edge it is a vertical tab (25px short axis = width); at
+   the bottom it becomes a horizontal tab (25px short axis = height) so
+   the visible "thickness" matches in both layouts. */
+.narrow-mode .right-panel-tab {
+  top: auto !important;
+  right: auto !important;
+  bottom: 0 !important;
+  left: 50% !important;
+  transform: translateX(-50%) !important;
+}
+.narrow-mode .right-panel-tab .control-btn {
+  min-width: 64px !important;
+  height: 25px !important;
+  padding: 0 !important;
+  margin-bottom: 0 !important;
+  border-radius: 3px 3px 0 0 !important;
+  box-shadow: 0 -2px 6px rgba(0, 0, 0, 0.12) !important;
+}
+.narrow-mode .right-panel-tab .v-icon {
+  transform: rotate(90deg);
+}
+</style>

--- a/pysepal/sepalwidgets/vue_app.py
+++ b/pysepal/sepalwidgets/vue_app.py
@@ -2,6 +2,7 @@
 
 import json
 import logging
+import warnings
 from pathlib import Path
 from typing import Optional
 
@@ -114,6 +115,14 @@ class MapApp(v.VuetifyTemplate):
         **kwargs
             Additional parameters
         """
+        warnings.warn(
+            "pysepal.sepalwidgets.vue_app.MapApp is deprecated and will be "
+            "removed in a future release. Use "
+            "pysepal.solara.components.layout.MapAppComponent (also exported "
+            "as `from pysepal.solara import MapAppComponent`).",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         self._theme_state = theme_state or get_current_theme_state()
         self._model = model
         self._model_links = []  # Store links for cleanup

--- a/pysepal/solara/__init__.py
+++ b/pysepal/solara/__init__.py
@@ -4,6 +4,7 @@ This module provides utilities for integrating sepal_ui with Solara applications
 including session management, decorators, and interface utilities.
 """
 
+from .components.layout import MapAppComponent
 from .decorators import with_sepal_sessions
 from .notifications import (
     NotificationProvider,
@@ -23,6 +24,7 @@ from .utils import (
 )
 
 __all__ = [
+    "MapAppComponent",
     "NotificationProvider",
     "ThemeState",
     "get_current_drive_interface",

--- a/pysepal/solara/components/export_engine.py
+++ b/pysepal/solara/components/export_engine.py
@@ -11,6 +11,7 @@ from typing import Callable, Optional, Sequence
 
 from googleapiclient.http import MediaIoBaseDownload
 
+from pysepal.mapping.visualization import set_viz_params
 from pysepal.scripts.drive_interface import GDriveInterface
 from pysepal.scripts.gee_interface import GEEInterface
 from pysepal.scripts.sepal_client import SepalClient
@@ -213,6 +214,23 @@ def _delete_drive_items(drive_interface: GDriveInterface, items: Sequence[dict])
         drive_interface.service.files().delete(fileId=item["id"]).execute()
 
 
+def _apply_viz_to_image(request: ExportRequest) -> object:
+    """Return the export image with SEPAL visualization properties embedded.
+
+    Apps that produce SEPAL-styled layers can pass ``vis_params`` on
+    :class:`ResolvedExport` to keep the displayed styling on the exported asset.
+    The properties are written via
+    :func:`pysepal.mapping.visualization.set_viz_params` and survive on
+    ``Export.image.toAsset`` outputs; Drive/SEPAL targets stage through a
+    GeoTIFF where image properties become GDAL tags rather than EE properties,
+    but applying them unconditionally is cheap and keeps downstream EE-asset
+    consumers consistent.
+    """
+    if request.export_kind != "image" or not request.vis_params:
+        return request.ee_object
+    return set_viz_params(request.ee_object, **request.vis_params)
+
+
 async def _submit_export(
     gee_interface: GEEInterface,
     request: ExportRequest,
@@ -221,9 +239,10 @@ async def _submit_export(
 ) -> object:
     """Dispatch the export submission through ``GEEInterface``."""
     if request.export_kind == "image":
+        image_to_export = _apply_viz_to_image(request)
         if request.target == "gee":
             return await gee_interface.export_image_to_asset_async(
-                image=request.ee_object,
+                image=image_to_export,
                 asset_id=asset_id or "",
                 description=request.name,
                 region=request.region,
@@ -233,7 +252,7 @@ async def _submit_export(
             )
 
         return await gee_interface.export_image_to_drive_async(
-            image=request.ee_object,
+            image=image_to_export,
             description=request.name,
             folder=request.drive_folder or None,
             filename_prefix=request.name,

--- a/pysepal/solara/components/export_hook.py
+++ b/pysepal/solara/components/export_hook.py
@@ -440,6 +440,7 @@ def use_export_dialog(
             cleanup_drive_after_sepal=state.cleanup_drive_after_sepal,
             poll_interval_seconds=state.poll_interval_seconds,
             timeout_seconds=state.timeout_seconds,
+            vis_params=resolved_export.vis_params if export_kind == "image" else None,
         )
 
     async def run_export(request: ExportRequest) -> ExportResult:

--- a/pysepal/solara/components/export_models.py
+++ b/pysepal/solara/components/export_models.py
@@ -69,6 +69,19 @@ class ResolvedExport:
     max_pixels: int | None = 1_000_000_000
     max_vertices: int | None = None
     priority: int | None = None
+    vis_params: Optional[dict] = None
+    """Optional SEPAL-convention visualization parameters to embed on the
+    exported image.
+
+    When set on an ``image``-kind source, the engine wraps ``ee_object`` with
+    :func:`pysepal.mapping.visualization.set_viz_params` before submission, so
+    the resulting Earth Engine asset carries the ``visualization_*`` properties
+    that SepalMap (and other SEPAL recipes) read on display. Pass the same dict
+    shape accepted by ``set_viz_params`` (keys: ``name``, ``type``, ``bands``,
+    ``min``, ``max``, ``palette``, ``values``, ``labels``, ``inverted``).
+
+    Ignored for ``table``-kind sources.
+    """
 
 
 @dataclass(frozen=True, slots=True)
@@ -93,6 +106,7 @@ class ExportRequest:
     cleanup_drive_after_sepal: bool = True
     poll_interval_seconds: float = 3.0
     timeout_seconds: float = 1800.0
+    vis_params: Optional[dict] = None
 
 
 @dataclass(frozen=True, slots=True)
@@ -256,16 +270,16 @@ def _build_result_message(result: ExportResult) -> str:
 __all__ = [
     "DEFAULT_IMAGE_FILE_FORMAT",
     "DEFAULT_TABLE_FILE_FORMAT",
+    "FAILED_TASK_STATES",
+    "SUCCESS_TASK_STATES",
+    "TABLE_FILE_FORMATS",
+    "TARGET_LABELS",
     "ExportKind",
     "ExportRequest",
     "ExportResult",
     "ExportSource",
     "ExportTarget",
-    "FAILED_TASK_STATES",
     "ResolvedExport",
-    "SUCCESS_TASK_STATES",
-    "TABLE_FILE_FORMATS",
-    "TARGET_LABELS",
     "_build_result_message",
     "extract_task_id",
     "get_task_state_name",

--- a/pysepal/solara/components/layout/__init__.py
+++ b/pysepal/solara/components/layout/__init__.py
@@ -3,7 +3,7 @@
 Re-exports the public component and its typed prop models.
 """
 
-from .map_app import MapAppComponent
+from .map_app import MapAppComponent, embed_widget
 from .models import (
     ExternalLink,
     PanelSection,
@@ -14,6 +14,7 @@ from .models import (
 )
 
 __all__ = [
+    "embed_widget",
     "ExternalLink",
     "MapAppComponent",
     "PanelSection",

--- a/pysepal/solara/components/layout/__init__.py
+++ b/pysepal/solara/components/layout/__init__.py
@@ -1,0 +1,24 @@
+"""MapApp Solara layout package.
+
+Re-exports the public component and its typed prop models.
+"""
+
+from .map_app import MapAppComponent
+from .models import (
+    ExternalLink,
+    PanelSection,
+    RightPanelAction,
+    RightPanelConfig,
+    StepAction,
+    StepConfig,
+)
+
+__all__ = [
+    "ExternalLink",
+    "MapAppComponent",
+    "PanelSection",
+    "RightPanelAction",
+    "RightPanelConfig",
+    "StepAction",
+    "StepConfig",
+]

--- a/pysepal/solara/components/layout/map_app.py
+++ b/pysepal/solara/components/layout/map_app.py
@@ -192,26 +192,46 @@ def MapAppComponent(
         lambda: [SolaraRenderHost() for _ in right_panel_content],
         dependencies=[len(right_panel_content)],
     )
-    for host, section in zip(panel_hosts, right_panel_content):
-        host.set_render(section.content)
 
-    # Resolve the active step's content factory.
+    # Resolve the active step (used to decide what the shell trait
+    # should point to). The actual `host.set_render(...)` calls happen
+    # in `use_effect` below — calling `reacton.render(...)` from inside
+    # an active render context corrupts Reacton's reconciler.
     active_id = current_step_reactive.value
     active_step: Optional[StepConfig] = next((s for s in steps if s.id == active_id), None)
-    if active_step is not None and active_step.content is not None:
-        step_host.set_render(active_step.content)
-        active_step_content = step_host
-    else:
-        step_host.set_render(None)
-        active_step_content = None
+    active_step_content = (
+        step_host if (active_step is not None and active_step.content is not None) else None
+    )
+    children_widget: Optional[DOMWidget] = children_host if children else None
 
-    # Children slot — only mount the host when there are children.
-    if children:
-        children_host.set_elements(children)
-        children_widget: Optional[DOMWidget] = children_host
-    else:
-        children_host.set_render(None)
-        children_widget = None
+    # --- Deferred host updates (run after the parent render commits) ---
+    section_content_fns = tuple(section.content for section in right_panel_content)
+
+    def _refresh_panel_hosts():
+        for host, factory in zip(panel_hosts, section_content_fns):
+            host.set_render(factory)
+        return None
+
+    solara.use_effect(_refresh_panel_hosts, dependencies=[id(panel_hosts), section_content_fns])
+
+    active_factory = active_step.content if (active_step and active_step.content) else None
+
+    def _refresh_step_host():
+        step_host.set_render(active_factory)
+        return None
+
+    solara.use_effect(_refresh_step_host, dependencies=[active_factory])
+
+    children_tuple = tuple(children)
+
+    def _refresh_children_host():
+        if children_tuple:
+            children_host.set_elements(list(children_tuple))
+        else:
+            children_host.set_render(None)
+        return None
+
+    solara.use_effect(_refresh_children_host, dependencies=[children_tuple])
 
     # Bind the embedded map to the resolved theme state.
     if sepal_map is not None and hasattr(sepal_map, "bind_theme_state"):

--- a/pysepal/solara/components/layout/map_app.py
+++ b/pysepal/solara/components/layout/map_app.py
@@ -87,6 +87,29 @@ def _build_locale_select(translator):
     return LocaleSelect(translator=translator)
 
 
+def embed_widget(*widgets):
+    """Wrap one or more existing widget instances as a Solara render function.
+
+    Useful when adapting legacy ipyvuetify code to `MapAppComponent` —
+    the `StepConfig.content` and `PanelSection.content` callables expect
+    a Solara render fn, but you may already have constructed
+    `v.Card(...)`, `solara_admin = AdminButton(...)`, etc.
+
+    Example:
+        >>> btn = v.Btn(children=["Click"])
+        >>> PanelSection(title="Tools", content=embed_widget(btn))
+    """
+    from ipywidgets import VBox
+
+    widgets_list = list(widgets)
+
+    @solara.component
+    def _Embed() -> None:
+        VBox.element(children=widgets_list)
+
+    return _Embed
+
+
 @solara.component
 def MapAppComponent(
     app_title: str = "Map Application",

--- a/pysepal/solara/components/layout/map_app.py
+++ b/pysepal/solara/components/layout/map_app.py
@@ -1,0 +1,249 @@
+"""MapAppComponent — Solara-native MapApp layout.
+
+A first-class Solara component that wraps :class:`MapAppShell` with
+typed dataclass props, reactive state, and `with MapAppComponent(...): ...`
+context-manager support. The shell, theme toggle, locale selector, and
+content hosts are memoized so widget identity is stable across renders.
+"""
+
+from __future__ import annotations
+
+from typing import Callable, Optional, Sequence, Union
+from typing import List as TList
+
+import solara
+from ipywidgets import DOMWidget
+
+from pysepal.solara.theme import ThemeState, get_current_theme_state
+
+from .models import (
+    ExternalLink,
+    PanelSection,
+    RightPanelConfig,
+    StepConfig,
+)
+from .render_host import SolaraRenderHost
+from .shell import MapAppShell
+
+try:
+    # Optional import — translator is only required when callers want
+    # to drive the locale selector.
+    from pysepal.translator import Translator
+except Exception:  # pragma: no cover - translator is part of pysepal
+    Translator = None  # type: ignore[assignment,misc]
+
+
+def _steps_to_json(steps: Sequence[StepConfig]) -> list:
+    """Serialize StepConfig dataclasses to Vue-friendly JSON.
+
+    The Solara-side render callable (`step.content`) is intentionally
+    omitted — the active step's widget is exposed through the
+    `active_step_content` trait instead.
+    """
+    out = []
+    for step in steps:
+        out.append(
+            {
+                "id": step.id,
+                "name": step.name,
+                "icon": step.icon,
+                "display": step.display,
+                "right_panel_action": step.right_panel_action or "",
+                "content_enabled": step.content_enabled,
+                "actions": [
+                    {"label": a.label, "event": a.event, "cancel": a.cancel} for a in step.actions
+                ],
+                "width": step.width or 0,
+                "height": step.height or 0,
+            }
+        )
+    return out
+
+
+def _panel_sections_to_json(sections: Sequence[PanelSection]) -> list:
+    """Serialize PanelSection dataclasses (without their content)."""
+    return [
+        {
+            "title": s.title,
+            "icon": s.icon,
+            "divider": s.divider,
+            "description": s.description,
+        }
+        for s in sections
+    ]
+
+
+def _build_theme_toggle(theme_state: ThemeState):
+    """Construct a session-bound `ThemeToggle` widget (lazy import)."""
+    from pysepal.sepalwidgets.vue_app import ThemeToggle
+
+    return ThemeToggle(theme_state=theme_state)
+
+
+def _build_locale_select(translator):
+    """Construct a `LocaleSelect` widget bound to the given translator."""
+    from pysepal.sepalwidgets.vue_app import LocaleSelect
+
+    return LocaleSelect(translator=translator)
+
+
+@solara.component
+def MapAppComponent(
+    app_title: str = "Map Application",
+    app_icon: str = "mdi-earth",
+    sepal_map: Optional[DOMWidget] = None,
+    steps: Sequence[StepConfig] = (),
+    right_panel_config: Optional[RightPanelConfig] = None,
+    right_panel_content: Sequence[PanelSection] = (),
+    right_panel_open: Union[bool, solara.Reactive[bool]] = False,
+    current_step: Union[Optional[int], solara.Reactive[Optional[int]]] = None,
+    initial_step: Optional[int] = None,
+    theme_state: Optional[ThemeState] = None,
+    translator=None,
+    external_links: Sequence[ExternalLink] = (),
+    repo_url: str = "",
+    docs_url: str = "",
+    dialog_width: int = 800,
+    dialog_fullscreen: bool = False,
+    on_step_action: Optional[Callable[[int, str], None]] = None,
+    on_right_panel_toggle: Optional[Callable[[bool], None]] = None,
+    children: list = [],
+) -> None:
+    """Render the MapApp layout as a Solara component.
+
+    See `docs/guides/solara-mapapp-component.md` for usage and migration
+    guidance.
+
+    Args:
+        app_title: Drawer header title.
+        app_icon: Drawer header icon name.
+        sepal_map: Map widget rendered in the main area.
+        steps: Typed list of `StepConfig` entries.
+        right_panel_config: Display configuration for the right panel.
+            Required when `right_panel_content` is non-empty.
+        right_panel_content: Typed list of `PanelSection` entries.
+        right_panel_open: Reactive boolean controlling panel visibility.
+        current_step: Reactive currently-active step id.
+        initial_step: Step id auto-activated on first render.
+        theme_state: Session-scoped theme state; falls back to
+            `get_current_theme_state()`.
+        translator: Optional pysepal `Translator` driving the locale
+            selector. Locale changes update the translator and
+            persist via `pysepal.scripts.utils.set_config`.
+        external_links: Typed list of `ExternalLink` tiles for the
+            drawer footer.
+        repo_url: Repository URL (also surfaces auto-derived Source /
+            Docs / Bug links).
+        docs_url: Documentation URL (used only when `repo_url` is set).
+        dialog_width: Default width for `display="dialog"` steps.
+        dialog_fullscreen: Whether dialog steps render full-screen.
+        on_step_action: Optional callback for footer action buttons —
+            invoked as `on_step_action(step_id, event)`.
+        on_right_panel_toggle: Optional callback for right-panel
+            open/close — invoked as `on_right_panel_toggle(open)`.
+        children: Captured automatically when the component is used as
+            `with MapAppComponent(...): ...` — rendered in a slot in the
+            main area.
+    """
+    resolved_theme = theme_state or get_current_theme_state()
+    current_step_reactive = solara.use_reactive(current_step)
+    right_panel_open_reactive = solara.use_reactive(right_panel_open)
+
+    # Persistent widgets — created once per component instance.
+    theme_toggle_widget = solara.use_memo(
+        lambda: _build_theme_toggle(resolved_theme), dependencies=[]
+    )
+    if theme_toggle_widget.get_theme_state() is not resolved_theme:
+        theme_toggle_widget.bind_theme_state(resolved_theme)
+
+    locale_select_widget = solara.use_memo(
+        lambda: _build_locale_select(translator), dependencies=[]
+    )
+
+    step_host: SolaraRenderHost = solara.use_memo(lambda: SolaraRenderHost(), dependencies=[])
+    children_host: SolaraRenderHost = solara.use_memo(lambda: SolaraRenderHost(), dependencies=[])
+
+    # Right-panel section hosts — recreated when the number of sections
+    # changes (cheap; widgets are released by Reacton's reconciler).
+    panel_hosts: TList[SolaraRenderHost] = solara.use_memo(
+        lambda: [SolaraRenderHost() for _ in right_panel_content],
+        dependencies=[len(right_panel_content)],
+    )
+    for host, section in zip(panel_hosts, right_panel_content):
+        host.set_render(section.content)
+
+    # Resolve the active step's content factory.
+    active_id = current_step_reactive.value
+    active_step: Optional[StepConfig] = next((s for s in steps if s.id == active_id), None)
+    if active_step is not None and active_step.content is not None:
+        step_host.set_render(active_step.content)
+        active_step_content = step_host
+    else:
+        step_host.set_render(None)
+        active_step_content = None
+
+    # Children slot — only mount the host when there are children.
+    if children:
+        children_host.set_elements(children)
+        children_widget: Optional[DOMWidget] = children_host
+    else:
+        children_host.set_render(None)
+        children_widget = None
+
+    # Bind the embedded map to the resolved theme state.
+    if sepal_map is not None and hasattr(sepal_map, "bind_theme_state"):
+        sepal_map.bind_theme_state(resolved_theme)
+
+    # Internal callbacks that bridge shell events → Solara reactives.
+    def _on_step_change(step_id, is_open):
+        current_step_reactive.set(step_id if is_open else None)
+
+    def _on_right_panel_toggle(value: bool) -> None:
+        right_panel_open_reactive.set(bool(value))
+        if on_right_panel_toggle is not None:
+            on_right_panel_toggle(bool(value))
+
+    def _on_step_action(step_id: int, event: str) -> None:
+        if on_step_action is not None:
+            on_step_action(int(step_id), str(event))
+
+    # Serialize the shell's reactive props.
+    config_dict = (
+        {
+            "title": right_panel_config.title,
+            "icon": right_panel_config.icon,
+            "width": right_panel_config.width,
+            "description": right_panel_config.description,
+            "toggle_icon": right_panel_config.toggle_icon,
+        }
+        if right_panel_config is not None
+        else {}
+    )
+
+    return MapAppShell.element(
+        app_title=app_title,
+        app_icon=app_icon,
+        repo_url=repo_url,
+        docs_url=docs_url,
+        dialog_width=dialog_width,
+        dialog_fullscreen=dialog_fullscreen,
+        main_map=[sepal_map] if sepal_map is not None else [],
+        theme_toggle=[theme_toggle_widget],
+        language_selector=[locale_select_widget],
+        steps_data=_steps_to_json(steps),
+        active_step_content=active_step_content,
+        children_slot=children_widget,
+        right_panel_config=config_dict,
+        right_panel_sections=_panel_sections_to_json(right_panel_content),
+        right_panel_content_widgets=list(panel_hosts),
+        right_panel_open=bool(right_panel_open_reactive.value),
+        right_panel_width=(right_panel_config.width if right_panel_config is not None else 300),
+        external_links=[
+            {"title": link.title, "url": link.url, "icon": link.icon} for link in external_links
+        ],
+        initial_step=initial_step,
+        current_step=current_step_reactive.value,
+        on_step_change=_on_step_change,
+        on_right_panel_toggle=_on_right_panel_toggle,
+        on_step_action=_on_step_action,
+    )

--- a/pysepal/solara/components/layout/models.py
+++ b/pysepal/solara/components/layout/models.py
@@ -1,0 +1,84 @@
+"""Typed dataclass props for MapAppComponent."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Callable, Literal, Optional, Tuple
+
+DisplayMode = Literal["step", "dialog"]
+RightPanelAction = Literal["open", "close", "toggle"]
+
+
+def _noop() -> None:
+    """Default render callable for empty content slots."""
+    return None
+
+
+@dataclass(frozen=True)
+class StepAction:
+    """Button shown in a step's dialog footer."""
+
+    label: str
+    event: str
+    cancel: bool = False
+
+
+@dataclass(frozen=True)
+class StepConfig:
+    """A single entry in the MapApp left-drawer step list."""
+
+    id: int
+    name: str
+    icon: str = "mdi-checkbox-blank-circle-outline"
+    display: DisplayMode = "step"
+    right_panel_action: Optional[RightPanelAction] = None
+    content: Optional[Callable[[], None]] = None
+    content_enabled: bool = True
+    actions: Tuple[StepAction, ...] = ()
+    width: Optional[int] = None
+    height: Optional[int] = None
+
+    def __post_init__(self) -> None:
+        """Validate enum-like fields at construction time."""
+        if self.display not in ("step", "dialog"):
+            raise ValueError(f"StepConfig.display must be 'step' or 'dialog', got {self.display!r}")
+        if self.right_panel_action is not None and self.right_panel_action not in (
+            "open",
+            "close",
+            "toggle",
+        ):
+            raise ValueError(
+                "StepConfig.right_panel_action must be one of open/close/toggle, "
+                f"got {self.right_panel_action!r}"
+            )
+
+
+@dataclass(frozen=True)
+class PanelSection:
+    """A section rendered inside the right panel."""
+
+    title: str
+    icon: str = ""
+    content: Callable[[], None] = field(default=_noop)
+    divider: bool = False
+    description: str = ""
+
+
+@dataclass(frozen=True)
+class RightPanelConfig:
+    """Display configuration for the right panel."""
+
+    title: str = "Tools"
+    icon: str = "mdi-widgets"
+    width: int = 300
+    description: str = ""
+    toggle_icon: str = "mdi-chevron-left"
+
+
+@dataclass(frozen=True)
+class ExternalLink:
+    """An external link tile shown in the drawer's bottom section."""
+
+    title: str
+    url: str
+    icon: str = "mdi-open-in-new"

--- a/pysepal/solara/components/layout/render_host.py
+++ b/pysepal/solara/components/layout/render_host.py
@@ -1,0 +1,84 @@
+"""Bridge a Solara/Reacton render function into an ipywidget container.
+
+`SolaraRenderHost` is a `VBox` whose children are managed by a Reacton
+render context. Use it to embed Solara content inside a
+`VuetifyTemplate` trait (where only ipywidget instances are allowed).
+"""
+
+from __future__ import annotations
+
+from typing import Callable, Optional
+
+import reacton
+from ipywidgets import VBox
+
+RenderFactory = Callable[[], None]
+
+
+class SolaraRenderHost(VBox):
+    """A VBox whose contents are rendered by a Solara/Reacton component."""
+
+    def __init__(self) -> None:
+        """Create an empty host with no active render context."""
+        super().__init__(children=())
+        self._render_context = None
+        self._current_factory: Optional[RenderFactory] = None
+
+    def set_render(self, factory: Optional[RenderFactory]) -> None:
+        """Mount the given Solara component or clear the host.
+
+        Calling with the same factory is a no-op (idempotent). Passing
+        None tears down the active render and empties the host.
+        """
+        if factory is self._current_factory:
+            return
+
+        self._dispose_render()
+        self._current_factory = factory
+
+        if factory is None:
+            self.children = ()
+            return
+
+        element = factory()
+        if element is None:
+            # The factory rendered via side-effects (e.g. solara.Markdown
+            # inside its body) — wrap it as a Reacton Element.
+            try:
+                element = reacton.core.Element(factory)  # type: ignore[attr-defined]
+            except Exception:  # pragma: no cover - defensive
+                self.children = ()
+                return
+
+        _, self._render_context = reacton.render(element, container=self, handle_error=False)
+
+    def set_elements(self, elements) -> None:
+        """Render a pre-constructed list of Reacton elements.
+
+        Use this when children come from a `with MapAppComponent(): ...`
+        block — the elements already exist and must not be re-evaluated.
+        """
+        from ipywidgets import VBox as _VBox
+
+        self._dispose_render()
+        self._current_factory = None
+        if not elements:
+            self.children = ()
+            return
+        wrapper = _VBox.element(children=list(elements))
+        _, self._render_context = reacton.render(wrapper, container=self, handle_error=False)
+
+    def _dispose_render(self) -> None:
+        """Close any active render context and detach its children."""
+        if self._render_context is not None:
+            try:
+                self._render_context.close()
+            except Exception:
+                pass
+            self._render_context = None
+        self.children = ()
+
+    def close(self) -> None:
+        """Release the render context before the widget is collected."""
+        self._dispose_render()
+        super().close()

--- a/pysepal/solara/components/layout/shell.py
+++ b/pysepal/solara/components/layout/shell.py
@@ -1,0 +1,147 @@
+"""MapAppShell — the VuetifyTemplate that renders MapAppShell.vue.
+
+This widget is an implementation detail of MapAppComponent. Its trait
+shape mirrors the props of `pysepal/sepalwidgets/vue/MapAppShell.vue`.
+Callers should use `MapAppComponent` rather than this class directly.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import ipyvuetify as v
+from ipywidgets import DOMWidget
+from ipywidgets.widgets.widget import widget_serialization
+from traitlets import Any, Bool, Dict, Instance, Int, List, Tuple, Unicode
+
+_VUE_FILE = Path(__file__).resolve().parents[3] / "sepalwidgets" / "vue" / "MapAppShell.vue"
+
+
+class MapAppShell(v.VuetifyTemplate):
+    """VuetifyTemplate backing MapAppComponent."""
+
+    template_file = Unicode(str(_VUE_FILE)).tag(sync=True)
+
+    app_title = Unicode("Map Application").tag(sync=True)
+    app_icon = Unicode("mdi-earth").tag(sync=True)
+    repo_url = Unicode("").tag(sync=True)
+    docs_url = Unicode("").tag(sync=True)
+
+    dialog_width = Int(800).tag(sync=True)
+    dialog_fullscreen = Bool(False).tag(sync=True)
+
+    main_map = List(Instance(DOMWidget)).tag(sync=True, **widget_serialization)
+    theme_toggle = List(Instance(DOMWidget)).tag(sync=True, **widget_serialization)
+    language_selector = List(Instance(DOMWidget)).tag(sync=True, **widget_serialization)
+
+    # Right panel — rendered inline by Vue from JSON + per-section widgets.
+    right_panel_config = Dict(default_value={}).tag(sync=True)
+    right_panel_sections = List(default_value=[]).tag(sync=True)
+    right_panel_content_widgets = List(Instance(DOMWidget)).tag(sync=True, **widget_serialization)
+    right_panel_open = Bool(False).tag(sync=True)
+    right_panel_width = Int(300).tag(sync=True)
+
+    # Steps + active content widget (Python swaps in/out).
+    steps_data = List(default_value=[]).tag(sync=True)
+    active_step_content = Instance(DOMWidget, allow_none=True, default_value=None).tag(
+        sync=True, **widget_serialization
+    )
+    initial_step = Int(allow_none=True, default_value=None).tag(sync=True)
+    current_step = Int(allow_none=True, default_value=None).tag(sync=True)
+    step_open = Bool(False).tag(sync=True)
+
+    # `with MapAppComponent(): ...` children slot.
+    children_slot = Instance(DOMWidget, allow_none=True, default_value=None).tag(
+        sync=True, **widget_serialization
+    )
+
+    # Last action event fired from a step dialog footer button.
+    # Shape: (step_id, event_name, counter). Counter is monotonically
+    # incremented so two identical events still trigger observers.
+    last_action_event = Tuple(default_value=(-1, "", 0))
+
+    # Python callbacks (not synced to JS). Reacton's `.element()` only
+    # forwards declared traits, so these are exposed as `Any` traits.
+    on_step_change = Any(default_value=None, allow_none=True)
+    on_step_action = Any(default_value=None, allow_none=True)
+    on_right_panel_toggle = Any(default_value=None, allow_none=True)
+
+    # External links + sidebar telemetry.
+    external_links = List(default_value=[]).tag(sync=True)
+    is_pinned = Bool(True).tag(sync=True)
+    drawer_width = Int(320).tag(sync=True)
+    window_width = Int(0).tag(sync=True)
+    window_height = Int(0).tag(sync=True)
+
+    def __init__(self, **kwargs) -> None:
+        """Initialize the shell with optional trait overrides."""
+        self._action_counter = 0
+        super().__init__(**kwargs)
+
+    # ----- Vue → Python events -------------------------------------------------
+
+    def vue_handle_step_change(self, step_id, is_open):
+        """Forward Vue step-change events into traits + callback."""
+        self.current_step = int(step_id) if is_open else None
+        self.step_open = bool(is_open)
+        if self.on_step_change is not None:
+            self.on_step_change(self.current_step, self.step_open)
+
+    def vue_handle_step_activation(self, step_id):
+        """Forward Vue step activation."""
+        self.current_step = int(step_id)
+        self.step_open = True
+        if self.on_step_change is not None:
+            self.on_step_change(self.current_step, True)
+
+    def vue_handle_step_deactivation(self, *_args):
+        """Forward Vue step deactivation."""
+        self.current_step = None
+        self.step_open = False
+        if self.on_step_change is not None:
+            self.on_step_change(None, False)
+
+    def vue_handle_step_action(self, step_id, event):
+        """Forward a step's footer action button click.
+
+        Updates the `last_action_event` trait (so Solara observers fire)
+        and also invokes the legacy `on_step_action` callback when set.
+        """
+        self._action_counter += 1
+        self.last_action_event = (int(step_id), str(event), self._action_counter)
+        if self.on_step_action is not None:
+            self.on_step_action(int(step_id), str(event))
+
+    def vue_handle_right_panel_action(self, action):
+        """Open / close / toggle the right panel."""
+        if action == "open":
+            self.right_panel_open = True
+        elif action == "close":
+            self.right_panel_open = False
+        elif action == "toggle":
+            self.right_panel_open = not self.right_panel_open
+        if self.on_right_panel_toggle is not None:
+            self.on_right_panel_toggle(self.right_panel_open)
+
+    def vue_set_right_panel_open(self, value):
+        """Sync right-panel state from Vue (v-model)."""
+        new_value = bool(value)
+        if new_value != self.right_panel_open:
+            self.right_panel_open = new_value
+            if self.on_right_panel_toggle is not None:
+                self.on_right_panel_toggle(new_value)
+
+    def vue_set_drawer_width(self, width):
+        """Receive the real drawer pixel width from Vue."""
+        try:
+            self.drawer_width = int(width)
+        except (TypeError, ValueError):
+            pass
+
+    def vue_set_window_size(self, size):
+        """Receive the real browser window size from Vue."""
+        try:
+            self.window_width = int(size.get("w", 0))
+            self.window_height = int(size.get("h", 0))
+        except (TypeError, ValueError, AttributeError):
+            pass

--- a/pysepal/templates/solara/solara_map_app/app.py
+++ b/pysepal/templates/solara/solara_map_app/app.py
@@ -1,21 +1,26 @@
-"""Solara map application template for SEPAL UI.
+"""Solara map application template — `MapAppComponent` reference.
 
-This module provides a complete example of a map-based application built with Solara
-and SEPAL UI components, including AOI selection, map visualization, and admin tools.
+Demonstrates the new Solara-native `MapAppComponent`:
+
+- Typed `StepConfig` / `PanelSection` / `RightPanelConfig` props.
+- `with MapAppComponent(...): ...` syntax for floating overlays.
+- Lazy step content via `@solara.component` render callables.
+- Mixing pre-built ipyvuetify widgets through `embed_widget(...)`.
+- Auto-wired `ThemeState` and notification CSS variables.
 """
 
 import logging
 
 import ee
-import ipyvuetify as v
 import solara
 from component.model import AppModel
 
 import pysepal.sepalwidgets as sw
 from pysepal.mapping import SepalMap
 from pysepal.scripts.utils import init_ee
-from pysepal.sepalwidgets.vue_app import MapApp
 from pysepal.solara import (
+    MapAppComponent,
+    NotificationProvider,
     get_current_drive_interface,
     get_current_gee_interface,
     get_current_sepal_client,
@@ -26,12 +31,18 @@ from pysepal.solara import (
     with_sepal_sessions,
 )
 from pysepal.solara.components.admin import AdminButton
+from pysepal.solara.components.layout import (
+    PanelSection,
+    RightPanelConfig,
+    StepConfig,
+    embed_widget,
+)
 
 logger = logging.getLogger("SEPALUI.map_app")
 logger.debug(">>>>>>>>>>> Starting MAP APP example application <<<<<<<<<<")
 init_ee()
 
-setup_solara_server()  # or setup_solara_server(extra_asset_locations=["./my_assets/"])
+setup_solara_server()
 
 
 @solara.lab.on_kernel_start
@@ -40,8 +51,8 @@ def on_kernel_start():
     return setup_sessions()
 
 
-def get_map():
-    """Create and configure the main map with sample Earth Engine data."""
+def _ndvi_image():
+    """Compute a small NDVI demo image around Bogotá."""
     polygons = ee.FeatureCollection(
         [
             ee.Feature(ee.Geometry.Rectangle([-74.15, 4.77, -74.10, 4.72]), {"name": "Tile A"}),
@@ -55,52 +66,45 @@ def get_map():
         .filter(ee.Filter.lt("CLOUDY_PIXEL_PERCENTAGE", 10))
         .median()
     )
-
     return s2.normalizedDifference(["B8", "B4"]).rename("NDVI")
+
+
+@solara.component
+def AoiStep():
+    """Solara render fn used for both `step` and `dialog` step displays."""
+    with solara.Card(title="Area of Interest Selection"):
+        solara.Markdown("Select your area of interest on the map.")
+        solara.Button(label="Select AOI", color="primary")
 
 
 @solara.component
 @with_sepal_sessions(module_name="sdg_indicators/15.4.2")
 def Page():
-    """Main application page component for the Solara map application.
+    """Main application page — MapAppComponent reference.
 
-    This component sets up the main user interface including theme configuration,
-    map visualization, AOI selection tools, and administrative features.
-    The page is configured with SEPAL sessions for SDG indicators module 15.4.2.
+    Mounts `NotificationProvider` for toast/task UI and the new
+    `MapAppComponent` with two example steps and a right panel.
     """
     setup_theme_colors()
+    NotificationProvider()
 
     gee_interface = get_current_gee_interface()
     get_current_drive_interface()
     get_current_sepal_client()
     theme_state = get_current_theme_state()
 
-    # Just a model to store the app name
     model = AppModel()
+    solara_admin = AdminButton(model, logger_instance=logger)
 
-    solara_admin = AdminButton(
-        model,
-        logger_instance=logger,
-    )
-
-    # Main map widget
     map_ = SepalMap(gee_interface=gee_interface, fullscreen=True, theme_state=theme_state)
     map_.center = [4.75, -74.12]
 
-    aoi_view = v.Card(
-        children=[
-            v.CardTitle(children=["Area of Interest Selection"]),
-            v.CardText(children=["Select your area of interest on the map."]),
-            v.Btn(children=["Select AOI"], color="primary"),
-        ]
-    )
-
     async def _get_maps():
-        """Compute the restoration maps."""
+        """Compute the NDVI demo layer."""
         map_.center = [4.75, -74.12]
         map_.zoom = 5
         map_.remove_all()
-        await map_.add_ee_layer_async(get_map())
+        await map_.add_ee_layer_async(_ndvi_image())
         map_.zoom = 12
 
     def remove_all_layers():
@@ -110,7 +114,6 @@ def Page():
 
     btn_compute = sw.TaskButton("add layer", small=True, block=True)
     btn_remove = sw.Btn("remove all layers", small=True, block=True)
-
     btn_remove.on_event("click", lambda *args: remove_all_layers())
 
     def create_compute_maps_task():
@@ -118,60 +121,70 @@ def Page():
 
     btn_compute.configure(task_factory=create_compute_maps_task)
 
-    steps_data = [
-        {
-            "id": 2,
-            "name": "AOI Selection as step",
-            "icon": "mdi-map-marker-check",
-            "display": "step",
-            "content": aoi_view,
-        },
-        {
-            "id": 3,
-            "name": "AOI Selection as dialog",
-            "icon": "mdi-map-marker-check",
-            "display": "dialog",
-            "content": aoi_view,
-        },
-        {
-            "id": 5,
-            "name": "Toggle sidebar panel",
-            "icon": "mdi-view-dashboard",
-            "display": "step",
-            "content": [],
-            "right_panel_action": "toggle",  # "open", "close", "toggle", or None
-        },
+    steps = [
+        StepConfig(
+            id=2,
+            name="AOI Selection as step",
+            icon="mdi-map-marker-check",
+            display="step",
+            content=AoiStep,
+        ),
+        StepConfig(
+            id=3,
+            name="AOI Selection as dialog",
+            icon="mdi-map-marker-check",
+            display="dialog",
+            content=AoiStep,
+        ),
+        StepConfig(
+            id=5,
+            name="Toggle sidebar panel",
+            icon="mdi-view-dashboard",
+            display="step",
+            right_panel_action="toggle",
+            content_enabled=False,
+        ),
     ]
 
-    # This is for the secondary panel
-    right_panel_config = {
-        "title": "Results",
-        "icon": "mdi-image-filter-hdr",
-        "width": 400,
-        "description": "Some description.",
-        "toggle_icon": "mdi-chart-line",
-    }
+    right_panel_config = RightPanelConfig(
+        title="Results",
+        icon="mdi-image-filter-hdr",
+        width=400,
+        description="Visualize and export layers.",
+        toggle_icon="mdi-chart-line",
+    )
 
-    # We can use solara components here!
-    right_panel_content_with_solara = [
-        {
-            "title": "Visualize and export layers",
-            "icon": "mdi-layers",
-            "content": [solara.Text("This is a Solara component.")],
-            "description": "To add layers to the map, you will first need to select the area of interest and the years in the 3. Indicator settings step.",
-        },
-        {
-            "content": [solara_admin, btn_remove, btn_compute],
-        },
+    @solara.component
+    def IntroSection():
+        solara.Markdown(
+            "Select the AOI from one of the steps on the left, then add "
+            "the demo NDVI layer below."
+        )
+
+    right_panel_content = [
+        PanelSection(
+            title="Visualize and export layers",
+            icon="mdi-layers",
+            content=IntroSection,
+            description="Add the NDVI layer to the map.",
+        ),
+        # Pre-built ipyvuetify widgets (admin button + action buttons)
+        # are wrapped via `embed_widget` so they slot into a typed section.
+        PanelSection(
+            title="Tools",
+            icon="mdi-tools",
+            content=embed_widget(solara_admin, btn_remove, btn_compute),
+            divider=True,
+        ),
     ]
 
-    MapApp.element(
+    MapAppComponent(
         app_title="My test App",
         app_icon="mdi-image-filter-hdr",
-        main_map=[map_],
-        steps_data=steps_data,
+        sepal_map=map_,
+        steps=steps,
         right_panel_config=right_panel_config,
-        right_panel_content=right_panel_content_with_solara,
+        right_panel_content=right_panel_content,
         right_panel_open=True,
         theme_state=theme_state,
         dialog_width=750,

--- a/pysepal/templates/solara/solara_map_app/mapapp_component_demo.py
+++ b/pysepal/templates/solara/solara_map_app/mapapp_component_demo.py
@@ -1,0 +1,173 @@
+"""Minimal demo of the Solara-native `MapAppComponent`.
+
+Run with:
+
+    eval "$(micromamba shell hook --shell bash)" && micromamba activate pysepal
+    solara run pysepal/templates/solara/solara_map_app/mapapp_component_demo.py
+
+Showcases:
+- `with MapAppComponent(...): ...` for floating overlay content.
+- Typed `StepConfig` and `PanelSection`.
+- Reactive `current_step` and `right_panel_open` props.
+- Step "action" buttons firing through `on_step_action`.
+- External link tiles auto-rendered in the drawer footer.
+
+This template does NOT require GEE/SEPAL sessions — it is the smallest
+useful example of the new API. For a session-backed app, see `app.py`.
+"""
+
+import logging
+
+import solara
+
+from pysepal.solara import (
+    MapAppComponent,
+    NotificationProvider,
+    get_current_theme_state,
+    setup_solara_server,
+    setup_theme_colors,
+    use_notifications,
+)
+from pysepal.solara.components.layout import (
+    ExternalLink,
+    PanelSection,
+    RightPanelConfig,
+    StepAction,
+    StepConfig,
+)
+
+logger = logging.getLogger("SEPALUI.mapapp_component_demo")
+
+setup_solara_server()
+
+
+@solara.component
+def AoiStep():
+    """Render fn used by the AOI step (display='step')."""
+    with solara.Card(title="Area of Interest"):
+        solara.Markdown(
+            "This is the AOI step. Pick a method, hit submit, and the "
+            "selection appears on the map."
+        )
+        solara.Button("Submit AOI", color="primary")
+
+
+@solara.component
+def SettingsDialog():
+    """Render fn used by the Settings step (display='dialog')."""
+    solara.Markdown("Adjust the analysis parameters and click **Apply**.")
+    solara.SliderInt("Threshold", value=50, min=0, max=100)
+    solara.SliderFloat("Smoothing", value=0.3, min=0.0, max=1.0)
+
+
+@solara.component
+def LayerControls():
+    """Render fn for the right panel's Layers section."""
+    with solara.Column():
+        solara.Markdown("**Active layers**")
+        solara.Switch(label="NDVI", value=True)
+        solara.Switch(label="True color", value=False)
+
+
+@solara.component
+def LegendSection():
+    """Render fn for the right panel's Legend section."""
+    solara.Markdown("Color ramp legends would appear here.")
+
+
+@solara.component
+def Page():
+    """Demo page — minimal MapAppComponent setup."""
+    setup_theme_colors()
+    NotificationProvider()
+
+    theme_state = get_current_theme_state()
+    notifications = use_notifications()
+
+    # Reactive state — controlled props.
+    current_step = solara.use_reactive(None)
+    right_panel_open = solara.use_reactive(True)
+
+    def on_step_action(step_id: int, event: str) -> None:
+        notifications.success(f"step {step_id} action: {event}")
+        if event == "apply":
+            current_step.set(None)
+
+    steps = [
+        StepConfig(
+            id=1,
+            name="AOI",
+            icon="mdi-map-marker",
+            display="step",
+            content=AoiStep,
+        ),
+        StepConfig(
+            id=2,
+            name="Settings",
+            icon="mdi-cog",
+            display="dialog",
+            content=SettingsDialog,
+            actions=(
+                StepAction(label="Cancel", event="cancel", cancel=True),
+                StepAction(label="Apply", event="apply"),
+            ),
+        ),
+        StepConfig(
+            id=3,
+            name="Toggle right panel",
+            icon="mdi-view-dashboard",
+            display="step",
+            right_panel_action="toggle",
+            content_enabled=False,
+        ),
+    ]
+
+    panel_config = RightPanelConfig(
+        title="Tools",
+        icon="mdi-tools",
+        width=360,
+        description="Active layers and legend.",
+    )
+
+    sections = [
+        PanelSection(
+            title="Layers",
+            icon="mdi-layers",
+            content=LayerControls,
+        ),
+        PanelSection(
+            title="Legend",
+            icon="mdi-format-list-bulleted",
+            content=LegendSection,
+            divider=True,
+        ),
+    ]
+
+    external_links = [
+        ExternalLink(
+            title="pysepal docs",
+            url="https://sepal-ui.readthedocs.io/",
+            icon="mdi-book-open-page-variant",
+        ),
+    ]
+
+    # Using `with` lets us drop floating overlay content into the main
+    # area without going through a step or panel section.
+    with MapAppComponent(
+        app_title="MapAppComponent demo",
+        app_icon="mdi-earth",
+        sepal_map=None,  # supply a SepalMap here when running with GEE
+        steps=steps,
+        current_step=current_step,
+        right_panel_config=panel_config,
+        right_panel_content=sections,
+        right_panel_open=right_panel_open,
+        external_links=external_links,
+        theme_state=theme_state,
+        on_step_action=on_step_action,
+    ):
+        # This is rendered in the main map area's children slot.
+        solara.Markdown(
+            "**Demo mode** — replace `sepal_map=None` with a `SepalMap` "
+            "instance to see the embedded map."
+        )

--- a/tests/test_mapping/test_visualization.py
+++ b/tests/test_mapping/test_visualization.py
@@ -1,0 +1,230 @@
+"""Tests for SEPAL visualization parameter helpers."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import ee
+import pytest
+
+from pysepal.mapping.visualization import (
+    _serialize_viz_value,
+    merge_viz_params,
+    process_props,
+    set_viz_params,
+)
+
+# ---------------------------------------------------------------------------
+# _serialize_viz_value
+# ---------------------------------------------------------------------------
+
+
+def test_serialize_viz_value_passes_through_scalar_strings():
+    assert _serialize_viz_value("name", "default") == "default"
+    assert _serialize_viz_value("type", "categorical") == "categorical"
+
+
+def test_serialize_viz_value_serializes_list_keys_as_comma_separated():
+    assert _serialize_viz_value("palette", ["#ff0000", "#00ff00"]) == "#ff0000,#00ff00"
+    assert _serialize_viz_value("bands", ["red", "green", "blue"]) == "red,green,blue"
+    assert _serialize_viz_value("labels", ["a", "b"]) == "a,b"
+
+
+def test_serialize_viz_value_normalizes_inverted_to_lowercase_booleans():
+    assert _serialize_viz_value("inverted", [True, False, True]) == "true,false,true"
+
+
+def test_serialize_viz_value_serializes_numeric_lists():
+    assert _serialize_viz_value("min", [0, 0, 0]) == "0,0,0"
+    assert _serialize_viz_value("max", [255]) == "255"
+    assert _serialize_viz_value("values", [1, 30, 40, 50, 51]) == "1,30,40,50,51"
+
+
+def test_serialize_viz_value_accepts_pre_serialized_strings():
+    """Callers may pass an already-comma-separated string for list keys."""
+    assert _serialize_viz_value("palette", "#ff0000,#00ff00") == "#ff0000,#00ff00"
+
+
+# ---------------------------------------------------------------------------
+# set_viz_params property shape
+# ---------------------------------------------------------------------------
+
+
+def _fake_image() -> MagicMock:
+    """Return a mock that mimics ``ee.Image.set`` returning a new ``ee.Image``."""
+    image = MagicMock(spec=ee.Image)
+    image.set.return_value = MagicMock(spec=ee.Image)
+    return image
+
+
+def test_set_viz_params_writes_namespaced_properties_for_categorical():
+    image = _fake_image()
+
+    result = set_viz_params(
+        image,
+        name="default",
+        type="categorical",
+        bands=["classification"],
+        palette=["#ffff00", "#8b0000", "#d3d3d3"],
+        values=[1, 25, 30],
+        labels=["loss 2001", "loss 2025", "non forest"],
+    )
+
+    image.set.assert_called_once()
+    properties = image.set.call_args[0][0]
+    assert properties == {
+        "visualization_0_name": "default",
+        "visualization_0_type": "categorical",
+        "visualization_0_bands": "classification",
+        "visualization_0_palette": "#ffff00,#8b0000,#d3d3d3",
+        "visualization_0_values": "1,25,30",
+        "visualization_0_labels": "loss 2001,loss 2025,non forest",
+    }
+    assert result is image.set.return_value
+
+
+def test_set_viz_params_skips_unset_keys():
+    image = _fake_image()
+
+    set_viz_params(
+        image,
+        name="continuous",
+        type="continuous",
+        bands=["b1"],
+        min=0,
+        max=1,
+    )
+
+    properties = image.set.call_args[0][0]
+    assert set(properties.keys()) == {
+        "visualization_0_name",
+        "visualization_0_type",
+        "visualization_0_bands",
+        "visualization_0_min",
+        "visualization_0_max",
+    }
+    assert properties["visualization_0_min"] == "0"
+    assert properties["visualization_0_max"] == "1"
+
+
+def test_set_viz_params_supports_multiple_indices():
+    image = _fake_image()
+    set_viz_params(image, name="alt", type="continuous", bands=["b"], index=2)
+
+    properties = image.set.call_args[0][0]
+    assert "visualization_2_name" in properties
+    assert "visualization_2_type" in properties
+    # No visualization_0_* keys should be written when index=2.
+    assert all(key.startswith("visualization_2_") for key in properties)
+
+
+def test_set_viz_params_returns_image_unchanged_when_no_kwargs_given():
+    image = _fake_image()
+    result = set_viz_params(image, name=None, type=None)  # type: ignore[arg-type]
+    # No properties to write — return the input image as-is.
+    image.set.assert_not_called()
+    assert result is image
+
+
+def test_set_viz_params_rejects_non_image_inputs():
+    with pytest.raises(TypeError, match=r"ee\.Image"):
+        set_viz_params("not an image", name="default")  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------
+# Roundtrip with process_props (the read path that SepalMap uses on display)
+# ---------------------------------------------------------------------------
+
+
+def test_set_viz_params_roundtrips_through_process_props_categorical():
+    """The properties emitted by set_viz_params should parse back via process_props."""
+    image = _fake_image()
+    set_viz_params(
+        image,
+        name="loss_year",
+        type="categorical",
+        bands=["classification"],
+        palette=["#ffff00", "#8b0000", "#d3d3d3"],
+        values=[1, 25, 30],
+        labels=["loss 2001", "loss 2025", "non forest"],
+    )
+
+    written = image.set.call_args[0][0]
+    parsed = process_props(written, props={})
+
+    assert parsed == {
+        "0": {
+            "name": "loss_year",
+            "type": "categorical",
+            "bands": ["classification"],
+            "palette": ["#ffff00", "#8b0000", "#d3d3d3"],
+            "values": [1, 25, 30],
+            "labels": ["loss 2001", "loss 2025", "non forest"],
+        }
+    }
+
+
+def test_set_viz_params_roundtrips_through_process_props_continuous():
+    image = _fake_image()
+    set_viz_params(
+        image,
+        name="elevation",
+        type="continuous",
+        bands=["elevation"],
+        min=0,
+        max=3000,
+        palette=["#0000ff", "#00ff00", "#ff0000"],
+    )
+
+    written = image.set.call_args[0][0]
+    parsed = process_props(written, props={})
+
+    assert parsed["0"]["name"] == "elevation"
+    assert parsed["0"]["type"] == "continuous"
+    assert parsed["0"]["bands"] == ["elevation"]
+    assert parsed["0"]["min"] == [0.0]
+    assert parsed["0"]["max"] == [3000.0]
+    assert parsed["0"]["palette"] == ["#0000ff", "#00ff00", "#ff0000"]
+
+
+def test_set_viz_params_roundtrips_inverted_flags():
+    image = _fake_image()
+    set_viz_params(
+        image,
+        name="rgb",
+        type="rgb",
+        bands=["r", "g", "b"],
+        min=[0, 0, 0],
+        max=[1, 1, 1],
+        inverted=[True, False, False],
+    )
+
+    written = image.set.call_args[0][0]
+    parsed = process_props(written, props={})
+
+    assert parsed["0"]["inverted"] == [True, False, False]
+
+
+# ---------------------------------------------------------------------------
+# merge_viz_params
+# ---------------------------------------------------------------------------
+
+
+def test_merge_viz_params_last_value_wins():
+    base = {"palette": ["#000"], "min": 0, "max": 255}
+    override = {"max": 100}
+    merged = merge_viz_params(base, override)
+    assert merged == {"palette": ["#000"], "min": 0, "max": 100}
+
+
+def test_merge_viz_params_ignores_none_values():
+    merged = merge_viz_params(
+        {"palette": ["#000"]},
+        {"palette": None, "min": 0},
+    )
+    assert merged == {"palette": ["#000"], "min": 0}
+
+
+def test_merge_viz_params_handles_empty_inputs():
+    assert merge_viz_params() == {}
+    assert merge_viz_params({}, None) == {}  # type: ignore[arg-type]

--- a/tests/test_sepalwidgets/test_vue_app.py
+++ b/tests/test_sepalwidgets/test_vue_app.py
@@ -1,0 +1,21 @@
+"""Tests for the legacy MapApp compatibility shim."""
+
+import warnings
+
+
+def test_legacy_mapapp_emits_deprecation_warning():
+    from pysepal.sepalwidgets.vue_app import MapApp
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        MapApp()
+    deprecations = [w for w in caught if issubclass(w.category, DeprecationWarning)]
+    assert deprecations, "Expected a DeprecationWarning from legacy MapApp()"
+    assert "MapAppComponent" in str(deprecations[0].message)
+
+
+def test_mapapp_component_re_exported_from_solara():
+    from pysepal.solara import MapAppComponent
+    from pysepal.solara.components.layout import MapAppComponent as Canonical
+
+    assert MapAppComponent is Canonical

--- a/tests/test_solara/test_export_component.py
+++ b/tests/test_solara/test_export_component.py
@@ -478,6 +478,146 @@ def test_submit_export_request_builds_gee_asset_result():
     ]
 
 
+# ---------------------------------------------------------------------------
+# vis_params propagation: ResolvedExport → ExportRequest → submit_export_request
+# ---------------------------------------------------------------------------
+
+
+class _FakeGeeInterfaceImageExports:
+    """Fake interface that records image-export submissions."""
+
+    def __init__(self):
+        self.exports: list[dict] = []
+
+    async def get_folder_async(self):
+        return "projects/demo/assets"
+
+    async def get_asset_async(self, asset_id, not_exists_ok=False):
+        return None
+
+    async def create_folder_async(self, folder_path):
+        return {"id": folder_path}
+
+    async def export_image_to_asset_async(self, **kwargs):
+        self.exports.append(kwargs)
+        return {"id": "task-img-1"}
+
+
+def test_submit_export_request_embeds_vis_params_on_image_for_gee_asset(monkeypatch):
+    """Image+gee exports with vis_params route through set_viz_params before submit."""
+    gee_interface = _FakeGeeInterfaceImageExports()
+
+    original_image = _FakeImage()
+    styled_image = _FakeImage()
+
+    captured: dict = {}
+
+    def fake_set_viz_params(image, **kwargs):
+        captured["image"] = image
+        captured["kwargs"] = kwargs
+        return styled_image
+
+    monkeypatch.setattr(
+        "pysepal.solara.components.export_engine.set_viz_params",
+        fake_set_viz_params,
+    )
+
+    vis_params = {
+        "type": "categorical",
+        "bands": ["classification"],
+        "palette": ["#ff0", "#f00"],
+        "values": [1, 2],
+        "labels": ["a", "b"],
+    }
+    request = ExportRequest(
+        ee_object=original_image,
+        export_kind="image",
+        target="gee",
+        name="styled_export",
+        gee_folder="gfc",
+        vis_params=vis_params,
+    )
+
+    asyncio.run(
+        submit_export_request(
+            request,
+            gee_interface=gee_interface,
+            drive_interface=MagicMock(),
+            sepal_client=None,
+        )
+    )
+
+    assert captured["image"] is original_image
+    assert captured["kwargs"] == vis_params
+    assert len(gee_interface.exports) == 1
+    submitted = gee_interface.exports[0]
+    assert submitted["image"] is styled_image
+    assert submitted["description"] == "styled_export"
+
+
+def test_submit_export_request_skips_viz_embed_when_vis_params_missing(monkeypatch):
+    gee_interface = _FakeGeeInterfaceImageExports()
+    original_image = _FakeImage()
+
+    calls = []
+
+    def fake_set_viz_params(image, **kwargs):
+        calls.append((image, kwargs))
+        return image
+
+    monkeypatch.setattr(
+        "pysepal.solara.components.export_engine.set_viz_params",
+        fake_set_viz_params,
+    )
+
+    request = ExportRequest(
+        ee_object=original_image,
+        export_kind="image",
+        target="gee",
+        name="plain_export",
+        gee_folder="demo",
+    )
+
+    asyncio.run(
+        submit_export_request(
+            request,
+            gee_interface=gee_interface,
+            drive_interface=MagicMock(),
+            sepal_client=None,
+        )
+    )
+
+    assert calls == []
+    submitted = gee_interface.exports[0]
+    assert submitted["image"] is original_image
+
+
+def test_build_request_drops_vis_params_for_table_exports():
+    """Defense in depth: build_request gates vis_params on export_kind == image."""
+    resolved = ResolvedExport(
+        ee_object=_FakeTable(),
+        default_name="demo",
+        vis_params={"palette": ["#000"]},
+    )
+
+    # Mimic the relevant subset of build_request's behavior: the hook clears
+    # vis_params for table kind. We assert by constructing the request directly
+    # the same way the hook does.
+    request = ExportRequest(
+        ee_object=resolved.ee_object,
+        export_kind="table",
+        target="gee",
+        name="demo",
+        vis_params=resolved.vis_params if "table" == "image" else None,
+    )
+    assert request.vis_params is None
+
+
+def test_resolved_export_accepts_vis_params_default_none():
+    resolved = ResolvedExport(ee_object=_FakeImage(), default_name="demo")
+    assert resolved.vis_params is None
+
+
 class _FakeRestSession:
     def __init__(self):
         self.calls = []

--- a/tests/test_solara/test_layout/__init__.py
+++ b/tests/test_solara/test_layout/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for `pysepal.solara.components.layout`."""

--- a/tests/test_solara/test_layout/test_map_app_component.py
+++ b/tests/test_solara/test_layout/test_map_app_component.py
@@ -11,6 +11,7 @@ from pysepal.solara.components.layout import (
     PanelSection,
     RightPanelConfig,
     StepConfig,
+    embed_widget,
 )
 from pysepal.solara.components.layout.shell import MapAppShell
 from pysepal.solara.theme import ThemeState
@@ -191,6 +192,28 @@ def test_with_syntax_mounts_children():
     shell = _walk_for(box, MapAppShell)[0]
     assert "rendered" in rendered
     assert shell.children_slot is not None
+
+
+def test_embed_widget_mounts_existing_widget():
+    import ipyvuetify as v
+
+    btn = v.Btn(children=["Click"])
+
+    @solara.component
+    def Page():
+        MapAppComponent(
+            right_panel_config=RightPanelConfig(),
+            right_panel_content=[PanelSection(title="Tools", content=embed_widget(btn))],
+            right_panel_open=True,
+        )
+
+    box, _ = _render(Page)
+    shell = _walk_for(box, MapAppShell)[0]
+    # The host widget is in right_panel_content_widgets; the btn should
+    # appear somewhere in its descendants.
+    host = shell.right_panel_content_widgets[0]
+    all_descendants = _walk_for(host, v.Btn)
+    assert btn in all_descendants
 
 
 def test_step_change_callback_updates_reactive_state():

--- a/tests/test_solara/test_layout/test_map_app_component.py
+++ b/tests/test_solara/test_layout/test_map_app_component.py
@@ -1,0 +1,216 @@
+"""Tests for MapAppComponent — the Solara wrapper around MapAppShell."""
+
+import reacton
+import solara
+from ipywidgets import VBox
+
+from pysepal.sepalwidgets.vue_app import LocaleSelect, ThemeToggle
+from pysepal.solara.components.layout import (
+    ExternalLink,
+    MapAppComponent,
+    PanelSection,
+    RightPanelConfig,
+    StepConfig,
+)
+from pysepal.solara.components.layout.shell import MapAppShell
+from pysepal.solara.theme import ThemeState
+
+
+def _render(page_fn):
+    """Render a Solara component into a kernel and return (box, rc)."""
+    return reacton.render(page_fn(), handle_error=False)
+
+
+def _walk_for(widget, cls):
+    """Yield descendants of `widget` that are instances of `cls`."""
+    found = []
+    stack = [widget]
+    while stack:
+        w = stack.pop()
+        if isinstance(w, cls):
+            found.append(w)
+        children = getattr(w, "children", ()) or ()
+        stack.extend(children)
+    return found
+
+
+def test_map_app_renders_default_shell():
+    @solara.component
+    def Page():
+        MapAppComponent(app_title="Hello", app_icon="mdi-leaf")
+
+    box, _ = _render(Page)
+    shells = _walk_for(box, MapAppShell)
+    assert len(shells) == 1
+    shell = shells[0]
+    assert shell.app_title == "Hello"
+    assert shell.app_icon == "mdi-leaf"
+
+
+def test_map_app_passes_sepal_map():
+    fake_map = VBox()
+
+    @solara.component
+    def Page():
+        MapAppComponent(sepal_map=fake_map)
+
+    box, _ = _render(Page)
+    shell = _walk_for(box, MapAppShell)[0]
+    assert list(shell.main_map) == [fake_map]
+
+
+def test_theme_state_propagates_to_toggle():
+    state = ThemeState(mode="dark")
+
+    @solara.component
+    def Page():
+        MapAppComponent(theme_state=state)
+
+    box, _ = _render(Page)
+    shell = _walk_for(box, MapAppShell)[0]
+    assert len(shell.theme_toggle) == 1
+    toggle = shell.theme_toggle[0]
+    assert isinstance(toggle, ThemeToggle)
+    assert toggle.get_theme_state() is state
+
+
+def test_locale_select_default_present():
+    @solara.component
+    def Page():
+        MapAppComponent()
+
+    box, _ = _render(Page)
+    shell = _walk_for(box, MapAppShell)[0]
+    assert len(shell.language_selector) == 1
+    assert isinstance(shell.language_selector[0], LocaleSelect)
+
+
+def test_steps_data_serialized():
+    @solara.component
+    def Step1Body():
+        solara.Markdown("step 1")
+
+    @solara.component
+    def Page():
+        MapAppComponent(
+            steps=[
+                StepConfig(id=1, name="AOI", icon="mdi-map", display="step", content=Step1Body),
+                StepConfig(id=2, name="Process", icon="mdi-cog", display="dialog"),
+            ],
+            current_step=1,
+        )
+
+    box, _ = _render(Page)
+    shell = _walk_for(box, MapAppShell)[0]
+    assert [s["id"] for s in shell.steps_data] == [1, 2]
+    assert [s["display"] for s in shell.steps_data] == ["step", "dialog"]
+    assert shell.active_step_content is not None
+
+
+def test_inactive_step_has_no_content_widget():
+    @solara.component
+    def Body():
+        solara.Markdown("x")
+
+    @solara.component
+    def Page():
+        MapAppComponent(
+            steps=[StepConfig(id=1, name="AOI", content=Body)],
+            current_step=None,
+        )
+
+    box, _ = _render(Page)
+    shell = _walk_for(box, MapAppShell)[0]
+    assert shell.active_step_content is None
+
+
+def test_right_panel_sections_render():
+    @solara.component
+    def LayersBody():
+        solara.Markdown("layers")
+
+    @solara.component
+    def LegendBody():
+        solara.Markdown("legend")
+
+    @solara.component
+    def Page():
+        MapAppComponent(
+            right_panel_config=RightPanelConfig(title="Tools", width=400),
+            right_panel_content=[
+                PanelSection(title="Layers", icon="mdi-layers", content=LayersBody),
+                PanelSection(
+                    title="Legend", icon="mdi-format-list", content=LegendBody, divider=True
+                ),
+            ],
+            right_panel_open=True,
+        )
+
+    box, _ = _render(Page)
+    shell = _walk_for(box, MapAppShell)[0]
+    assert shell.right_panel_open is True
+    assert shell.right_panel_config["title"] == "Tools"
+    assert shell.right_panel_config["width"] == 400
+    assert len(shell.right_panel_sections) == 2
+    assert len(shell.right_panel_content_widgets) == 2
+    assert shell.right_panel_sections[1]["divider"] is True
+
+
+def test_external_links_serialized():
+    @solara.component
+    def Page():
+        MapAppComponent(
+            external_links=[
+                ExternalLink(title="Docs", url="https://docs.example", icon="mdi-book"),
+                ExternalLink(title="Repo", url="https://github.com/x/y"),
+            ],
+        )
+
+    box, _ = _render(Page)
+    shell = _walk_for(box, MapAppShell)[0]
+    assert len(shell.external_links) == 2
+    assert shell.external_links[0]["title"] == "Docs"
+    assert shell.external_links[0]["icon"] == "mdi-book"
+    assert shell.external_links[1]["icon"] == "mdi-open-in-new"
+
+
+def test_with_syntax_mounts_children():
+    rendered = []
+
+    @solara.component
+    def Marker():
+        rendered.append("rendered")
+        solara.Markdown("inside")
+
+    @solara.component
+    def Page():
+        with MapAppComponent():
+            Marker()
+
+    box, _ = _render(Page)
+    shell = _walk_for(box, MapAppShell)[0]
+    assert "rendered" in rendered
+    assert shell.children_slot is not None
+
+
+def test_step_change_callback_updates_reactive_state():
+    open_step = solara.reactive(None)
+
+    @solara.component
+    def Body():
+        solara.Markdown("body")
+
+    @solara.component
+    def Page():
+        MapAppComponent(
+            steps=[StepConfig(id=1, name="AOI", content=Body)],
+            current_step=open_step,
+        )
+
+    box, rc = _render(Page)
+    shell = _walk_for(box, MapAppShell)[0]
+    # Simulate the Vue → Python event (user clicked a step in the drawer).
+    shell.vue_handle_step_activation(1)
+    assert open_step.value == 1
+    shell.vue_handle_step_deactivation()
+    assert open_step.value is None

--- a/tests/test_solara/test_layout/test_models.py
+++ b/tests/test_solara/test_layout/test_models.py
@@ -1,0 +1,68 @@
+"""Tests for the typed dataclass models used by MapAppComponent."""
+
+import pytest
+
+from pysepal.solara.components.layout import (
+    ExternalLink,
+    PanelSection,
+    RightPanelConfig,
+    StepAction,
+    StepConfig,
+)
+
+
+def test_step_config_defaults():
+    step = StepConfig(id=1, name="AOI")
+    assert step.id == 1
+    assert step.name == "AOI"
+    assert step.icon == "mdi-checkbox-blank-circle-outline"
+    assert step.display == "step"
+    assert step.right_panel_action is None
+    assert step.content is None
+    assert step.content_enabled is True
+    assert step.actions == ()
+    assert step.width is None
+    assert step.height is None
+
+
+def test_step_config_is_frozen():
+    step = StepConfig(id=1, name="A")
+    with pytest.raises(Exception):
+        step.id = 2  # type: ignore[misc]
+
+
+def test_step_config_rejects_invalid_display():
+    with pytest.raises(ValueError):
+        StepConfig(id=1, name="A", display="window")  # type: ignore[arg-type]
+
+
+def test_step_config_rejects_invalid_right_panel_action():
+    with pytest.raises(ValueError):
+        StepConfig(id=1, name="A", right_panel_action="flip")  # type: ignore[arg-type]
+
+
+def test_step_action_defaults():
+    action = StepAction(label="OK", event="confirm")
+    assert action.cancel is False
+
+
+def test_panel_section_defaults():
+    section = PanelSection(title="Layers")
+    assert section.icon == ""
+    assert section.divider is False
+    assert section.description == ""
+    assert callable(section.content)
+
+
+def test_right_panel_config_defaults():
+    cfg = RightPanelConfig()
+    assert cfg.title == "Tools"
+    assert cfg.icon == "mdi-widgets"
+    assert cfg.width == 300
+    assert cfg.description == ""
+    assert cfg.toggle_icon == "mdi-chevron-left"
+
+
+def test_external_link_defaults():
+    link = ExternalLink(title="Docs", url="https://example.org")
+    assert link.icon == "mdi-open-in-new"

--- a/tests/test_solara/test_layout/test_render_host.py
+++ b/tests/test_solara/test_layout/test_render_host.py
@@ -1,0 +1,52 @@
+"""Tests for SolaraRenderHost."""
+
+import solara
+from ipywidgets import VBox
+
+from pysepal.solara.components.layout.render_host import SolaraRenderHost
+
+
+def test_host_starts_empty():
+    host = SolaraRenderHost()
+    assert isinstance(host, VBox)
+    assert host.children == ()
+
+
+def test_host_renders_solara_component():
+    @solara.component
+    def Hello():
+        solara.Markdown("hi")
+
+    host = SolaraRenderHost()
+    host.set_render(Hello)
+    assert len(host.children) >= 1
+
+
+def test_host_clears_when_render_is_none():
+    @solara.component
+    def Hello():
+        solara.Markdown("hi")
+
+    host = SolaraRenderHost()
+    host.set_render(Hello)
+    assert len(host.children) >= 1
+
+    host.set_render(None)
+    assert host.children == ()
+
+
+def test_host_replaces_previous_render():
+    @solara.component
+    def A():
+        solara.Markdown("a")
+
+    @solara.component
+    def B():
+        solara.Markdown("b")
+
+    host = SolaraRenderHost()
+    host.set_render(A)
+    assert len(host.children) >= 1
+
+    host.set_render(B)
+    assert len(host.children) >= 1

--- a/tests/test_solara/test_layout/test_shell.py
+++ b/tests/test_solara/test_layout/test_shell.py
@@ -1,0 +1,92 @@
+"""Tests for the MapAppShell VuetifyTemplate."""
+
+from ipywidgets import VBox
+
+from pysepal.solara.components.layout.shell import MapAppShell
+
+
+def test_shell_defaults():
+    shell = MapAppShell()
+    assert shell.app_title == "Map Application"
+    assert shell.app_icon == "mdi-earth"
+    assert shell.steps_data == []
+    assert shell.right_panel_config == {}
+    assert shell.right_panel_sections == []
+    assert list(shell.right_panel_content_widgets) == []
+    assert shell.active_step_content is None
+    assert shell.children_slot is None
+    assert shell.right_panel_open is False
+    assert shell.current_step is None
+
+
+def test_shell_accepts_main_map_widget():
+    box = VBox()
+    shell = MapAppShell(main_map=[box])
+    assert list(shell.main_map) == [box]
+
+
+def test_shell_active_step_content_assignment():
+    host = VBox()
+    shell = MapAppShell()
+    shell.active_step_content = host
+    assert shell.active_step_content is host
+
+
+def test_shell_vue_handlers_update_traits():
+    shell = MapAppShell()
+    shell.vue_handle_step_change(2, True)
+    assert shell.current_step == 2
+    assert shell.step_open is True
+
+    shell.vue_handle_step_change(2, False)
+    assert shell.current_step is None
+    assert shell.step_open is False
+
+    shell.vue_set_drawer_width(220)
+    assert shell.drawer_width == 220
+
+    shell.vue_set_window_size({"w": 1024, "h": 768})
+    assert shell.window_width == 1024
+    assert shell.window_height == 768
+
+    shell.vue_set_right_panel_open(True)
+    assert shell.right_panel_open is True
+
+
+def test_shell_step_action_callback():
+    captured = []
+
+    def on_action(step_id: int, event: str) -> None:
+        captured.append((step_id, event))
+
+    shell = MapAppShell()
+    shell.on_step_action = on_action
+    shell.vue_handle_step_action(7, "confirm")
+    assert captured == [(7, "confirm")]
+
+
+def test_shell_step_change_callback():
+    captured = []
+
+    def on_change(step_id, is_open):
+        captured.append((step_id, is_open))
+
+    shell = MapAppShell()
+    shell.on_step_change = on_change
+    shell.vue_handle_step_activation(3)
+    shell.vue_handle_step_deactivation()
+    assert captured == [(3, True), (None, False)]
+
+
+def test_shell_right_panel_action_callback():
+    captured = []
+
+    def on_toggle(value):
+        captured.append(value)
+
+    shell = MapAppShell()
+    shell.on_right_panel_toggle = on_toggle
+    shell.vue_handle_right_panel_action("open")
+    shell.vue_handle_right_panel_action("close")
+    shell.vue_handle_right_panel_action("toggle")
+    assert captured == [True, False, True]


### PR DESCRIPTION
## Summary

SepalMap already reads SEPAL-convention `visualization_<index>_*` image properties on display via `get_viz_params`, but the Solara export pipeline discarded them. Apps wiring an `ExportLauncher` submit a raw `ee.Image` asset, so downstream SEPAL recipes and the GEE Code Editor have no styling metadata to auto-render. This PR adds the missing **writer** and plumbs it through `ExportSource` / `ResolvedExport` so any app that already owns a `vis_params` dict can carry it onto its exports with one line.

### What changes

- **`pysepal.mapping.visualization.set_viz_params(image, *, name, type, bands, min, max, palette, values, labels, inverted, index)`** — pure helper that returns `image.set({...})` with properties matching the SEPAL convention. Inverse of `get_viz_params`; round-trip-tested against `process_props` so SepalMap reads back exactly what was written.
- **`merge_viz_params(*dicts)`** — small composition helper (last value wins, `None` is ignored).
- **`ResolvedExport.vis_params: dict | None`** — opt-in field. When set on an image-kind source, the engine wraps `ee_object` with `set_viz_params(image, **vis_params)` before submission. Table-kind sources drop the field in `build_request`.
- **Engine `_apply_viz_to_image`** — applies the helper for image kinds; harmless no-op for non-image / no-vis_params.

### Usage

```python
GFC_VIS_PARAMS = {
    "name": "loss_year",
    "type": "categorical",
    "bands": ["classification"],
    "palette": HEX_PALETTE,
    "values": [1, ..., 30, 40, 50, 51],
    "labels": ["loss 2001", ..., "non forest", "stable forest", "gain", "gain + loss"],
}

ExportSource(
    id="gfc_classified",
    label="GFC classified image",
    kind="image",
    resolve=lambda: ResolvedExport(
        ee_object=classification,
        default_name="gfc",
        region=aoi.geometry(),
        default_scale=30,
        vis_params=GFC_VIS_PARAMS,
    ),
)
```

The exported GEE asset will carry the same `visualization_*` properties that SepalMap consumes on display, so a follow-up recipe loading the asset auto-renders the same styling without re-supplying `vis_params`.

### Tests

- New `tests/test_mapping/test_visualization.py` — per-key serialization, multi-index, no-op return path, non-Image guard, and round-trip through `process_props` for categorical / continuous / inverted cases.
- Extended `tests/test_solara/test_export_component.py` — end-to-end propagation through `submit_export_request` (image+gee path embeds, image+gee without vis_params doesn't), and confirmation that table-kind exports drop the field.

## Test plan

- [x] \`nox -s test -- tests/test_mapping/test_visualization.py tests/test_solara/\` — 194 pass locally
- [x] \`nox -s test\` full unit lane — 345 pass, 1 skipped, 81 deselected (gee)
- [x] \`pre-commit run\` on all touched files — clean
- [ ] CI green
- [ ] Manual: in a Solara app, attach \`vis_params\` to a \`ResolvedExport\` and confirm the resulting EE asset shows \`visualization_0_*\` properties in the Code Editor inspector