### PR TITLE
docs(guides): add pysepal skill reference guides

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,15 +13,14 @@ __pycache__/
 *.py[cod]
 *$py.class
 *[Uu]ntitled*
-guides/
+/guides/
 .plans/
 docs/plans/
-docs/guides/
 docs/superpowers/
 *legacy*
 
 .github/workflows/act_unit.yml
-guides/
+/guides/
 legacy/
 
 # C extensions

--- a/docs/guides/ipecharts.md
+++ b/docs/guides/ipecharts.md
@@ -1,0 +1,750 @@
+# ipecharts - Complete Guide to Creating Interactive Charts
+
+## Table of Contents
+
+1. [Introduction](#introduction)
+2. [Installation](#installation)
+3. [Quick Start](#quick-start)
+4. [Two Approaches to Creating Charts](#two-approaches-to-creating-charts)
+5. [Core Components](#core-components)
+6. [Chart Examples](#chart-examples)
+7. [Advanced Features](#advanced-features)
+8. [Best Practices](#best-practices)
+
+---
+
+## Introduction
+
+`ipecharts` is a Jupyter Widget library that brings interactive charts powered by [Apache ECharts](https://echarts.apache.org/en/index.html) to Jupyter notebooks. It provides two main ways to create charts:
+
+- **`EChartsRawWidget`**: Direct approach using option dictionaries (similar to JavaScript)
+- **`EChartsWidget`**: Object-oriented approach with reactive, typed Python classes
+
+### Key Features
+
+- ✅ Full compatibility with Jupyter Widget protocol
+- ✅ Reactive updates via traitlets
+- ✅ Support for 30+ chart types (2D and 3D)
+- ✅ Event handling and chart actions
+- ✅ Custom themes and styling
+- ✅ JavaScript function support
+
+---
+
+## Installation
+
+### Using pip
+
+```bash
+pip install ipecharts
+```
+
+### Using conda
+
+```bash
+conda install -c conda-forge ipecharts
+```
+
+---
+
+## Quick Start
+
+### Your First Chart
+
+```python
+from ipecharts import EChartsWidget
+from ipecharts.option import Option, XAxis, YAxis
+from ipecharts.option.series import Line
+
+# Create a simple line chart
+line = Line(data=[820, 932, 901, 934, 1290, 1330, 1320], areaStyle={})
+option = Option(
+    xAxis=XAxis(
+        type="category",
+        boundaryGap=False,
+        data=["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"]
+    ),
+    yAxis=YAxis(type="value"),
+    series=[line]
+)
+
+# Display the chart
+chart = EChartsWidget(option=option)
+chart
+```
+
+---
+
+## Two Approaches to Creating Charts
+
+### 1. EChartsRawWidget - Dictionary-Based Approach
+
+**Best for:** Quick prototypes, converting JavaScript examples
+
+```python
+from ipecharts import EChartsRawWidget
+
+option = {
+    'xAxis': {
+        'type': 'category',
+        'data': ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun']
+    },
+    'yAxis': {
+        'type': 'value'
+    },
+    'series': [{
+        'data': [820, 932, 901, 934, 1290, 1330, 1320],
+        'type': 'line',
+        'areaStyle': {}
+    }]
+}
+
+EChartsRawWidget(option=option)
+```
+
+**Pros:** Simple, direct translation from JavaScript examples  
+**Cons:** No reactivity, no type hints
+
+### 2. EChartsWidget - Object-Oriented Approach
+
+**Best for:** Interactive applications, reactive updates, maintainable code
+
+```python
+from ipecharts import EChartsWidget
+from ipecharts.option import Option, XAxis, YAxis
+from ipecharts.option.series import Line
+
+# Create reactive components
+line = Line(data=[820, 932, 901, 934, 1290, 1330, 1320], areaStyle={})
+option = Option(
+    xAxis=XAxis(type="category", data=["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"]),
+    yAxis=YAxis(type="value"),
+    series=[line]
+)
+
+chart = EChartsWidget(option=option)
+
+# Update data reactively - chart updates automatically!
+line.data = [100, 200, 300, 400, 500, 600, 700]
+```
+
+**Pros:** Reactive updates, type hints, IDE autocomplete  
+**Cons:** More verbose syntax
+
+---
+
+## Core Components
+
+### The Option Object
+
+The `Option` class is the root configuration object that contains all chart settings:
+
+```python
+from ipecharts.option import Option
+
+option = Option(
+    # Chart title
+    title=Title(text="My Chart", subtext="Subtitle"),
+
+    # Axes
+    xAxis=XAxis(type="category", data=categories),
+    yAxis=YAxis(type="value"),
+
+    # Series (actual data visualizations)
+    series=[line1, bar1, scatter1],
+
+    # Interactive components
+    legend=Legend(),
+    tooltip=Tooltip(trigger="axis"),
+    toolbox=Toolbox(),
+
+    # Styling
+    backgroundColor="#1e1e1e",
+    color=["#5470c6", "#91cc75", "#fac858"]
+)
+```
+
+### Common Components
+
+| Component        | Purpose           | Example                                   |
+| ---------------- | ----------------- | ----------------------------------------- |
+| `XAxis`, `YAxis` | Coordinate axes   | `XAxis(type="category", data=["A", "B"])` |
+| `Legend`         | Chart legend      | `Legend(data=["Series1", "Series2"])`     |
+| `Tooltip`        | Hover tooltips    | `Tooltip(trigger="axis")`                 |
+| `Grid`           | Chart positioning | `Grid(left="10%", right="10%")`           |
+| `Toolbox`        | Interactive tools | `Toolbox(show=True)`                      |
+| `Dataset`        | Data management   | `Dataset(source=data)`                    |
+
+### Series Types
+
+Available in `ipecharts.option.series`:
+
+**2D Charts:**
+
+- `Line`, `Bar`, `Pie`, `Scatter`, `EffectScatter`
+- `Heatmap`, `Boxplot`, `Candlestick`
+- `Graph`, `Sankey`, `Funnel`, `Gauge`
+- `Tree`, `Treemap`, `Sunburst`
+- `Lines`, `Map`, `ThemeRiver`
+
+**3D Charts:**
+
+- `Bar3D`, `Line3D`, `Scatter3D`, `Lines3D`
+- `Map3D`, `Surface`, `Polygons3D`
+
+---
+
+## Chart Examples
+
+### Example 1: Interactive Line Chart with Button Control
+
+```python
+from ipecharts import EChartsWidget
+from ipecharts.option import Option, XAxis, YAxis, Legend, Tooltip
+from ipecharts.option.series import Line
+from ipywidgets.widgets import Button
+import numpy as np
+
+# Create a smooth line chart
+line = Line(smooth=True, areaStyle={}, data=np.random.rand(10).tolist())
+option = Option(
+    xAxis=XAxis(type="category"),
+    yAxis=YAxis(type="value"),
+    series=[line],
+    tooltip=Tooltip(),
+    legend=Legend()
+)
+
+chart = EChartsWidget(option=option)
+
+# Add interactive button
+button = Button(description="Generate Random Data")
+
+def on_button_clicked(b):
+    line.data = np.random.rand(10).tolist()
+
+button.on_click(on_button_clicked)
+
+display(button, chart)
+```
+
+### Using ipecharts inside Solara
+
+You can mount an ipecharts widget directly inside a Solara component using
+the widget factory API. This is useful when building small Solara apps or
+examples where you don't want to manage widget references manually.
+
+```python
+import solara
+from ipecharts import EChartsWidget
+from ipecharts.option import Option, XAxis, YAxis
+from ipecharts.option.series import Line
+
+
+@solara.component
+def Page():
+    line = Line(data=[820, 932, 901, 934, 1290, 1330, 1320], areaStyle={})
+    option = Option(
+        xAxis=XAxis(
+            type="category",
+            boundaryGap=False,
+            data=["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"],
+        ),
+        yAxis=YAxis(type="value"),
+        series=[line],
+    )
+
+    # Mount the widget in the Solara component tree
+    EChartsWidget.element(option=option)
+
+
+```
+
+### Example 2: Horizontal Stacked Bar Chart
+
+```python
+from ipecharts import EChartsWidget
+from ipecharts.option import Option, XAxis, YAxis, Legend, Tooltip
+from ipecharts.option.series import Bar
+
+# Create multiple bar series with stacking
+bars = []
+categories = ["Region A", "Region B", "Region C"]
+series_data = {
+    "Suitable": [120, 200, 150],
+    "Moderately Suitable": [80, 100, 90],
+    "Marginally Suitable": [50, 60, 40]
+}
+colors = ["#2ecc71", "#f39c12", "#e74c3c"]
+
+for i, (name, values) in enumerate(series_data.items()):
+    bars.append(Bar(
+        name=name,
+        data=[round(v, 2) for v in values],
+        stack="Total",  # Stack all bars
+        itemStyle={"color": colors[i]}
+    ))
+
+option = Option(
+    backgroundColor="#1e1e1e00",  # Transparent background
+    xAxis=XAxis(type="value"),
+    yAxis=YAxis(type="category", data=categories),
+    series=bars,
+    tooltip=Tooltip(trigger="axis", axisPointer={"type": "shadow"}),
+    legend=Legend()
+)
+
+chart = EChartsWidget(option=option, style={"height": "300px"})
+chart
+```
+
+### Example 3: Graph/Network Visualization
+
+```python
+from ipecharts import EChartsWidget
+from ipecharts.option import Option, Title, Legend, Tooltip
+from ipecharts.option.series import Graph
+import json
+
+# Load graph data (nodes and edges)
+with open('les-miserables.json', 'r') as f:
+    graph_data = json.load(f)
+
+# Create graph series
+g = Graph(
+    name="Les Miserables",
+    layout="circular",
+    circular={"rotateLabel": True},
+    roam=True,
+    label={"position": "right", "formatter": "{b}"},
+    lineStyle={"color": "source", "curveness": 0.3}
+)
+
+g.data = graph_data['nodes']
+g.links = graph_data['links']
+g.categories = graph_data['categories']
+
+option = Option(
+    series=[g],
+    title=Title(text="Les Miserables", subtext="Circular layout"),
+    tooltip=Tooltip(),
+    legend=Legend(),
+    animationDurationUpdate=1500,
+    animationEasingUpdate="quinticInOut"
+)
+
+EChartsWidget(option=option)
+```
+
+### Example 4: 3D Bar Chart
+
+```python
+from ipecharts import EChartsWidget
+from ipecharts.option import Option, Grid3D, Tooltip, XAxis3D, YAxis3D, ZAxis3D, Dataset
+from ipecharts.option.series import Bar3D
+
+# Prepare dataset
+dataset = Dataset(
+    dimensions=["Income", "Life Expectancy", "Population", "Country", {"name": "Year", "type": "ordinal"}],
+    source=data  # Your data array
+)
+
+# Create 3D bar series
+bar3D = Bar3D(
+    shading="lambert",
+    encode={
+        "x": "Year",
+        "y": "Country",
+        "z": "Life Expectancy",
+        "tooltip": [0, 1, 2, 3, 4]
+    }
+)
+
+option = Option(
+    grid3D=Grid3D(),
+    tooltip=Tooltip(),
+    xAxis3D=XAxis3D(type="category"),
+    yAxis3D=YAxis3D(type="category"),
+    zAxis3D=ZAxis3D(),
+    dataset=dataset,
+    series=[bar3D]
+)
+
+EChartsWidget(option=option)
+```
+
+### Example 5: Custom Item Colors (from seplanexample.py)
+
+```python
+from ipecharts import EChartsWidget
+from ipecharts.option import Option, XAxis, YAxis, Tooltip, Legend
+from ipecharts.option.series import Bar
+
+def get_bars_series(values, series_names, series_colors=[], custom_item_color=False, custom_item_colors=None):
+    """Create bar series with optional custom colors per item."""
+
+    if not series_colors:
+        series_colors = [None] * len(series_names)
+
+    if not custom_item_colors:
+        custom_item_colors = [[None] * len(value) for value in values]
+
+    bars = []
+    for i, series_name in enumerate(series_names):
+        bars.append(Bar(
+            data=[
+                {
+                    "value": round(value, 2),
+                    "itemStyle": {"color": color if custom_item_color else None}
+                }
+                for value, color in zip(values[i], custom_item_colors[i])
+            ],
+            itemStyle={"color": series_colors[i]},
+            name=series_name,
+            type="bar"
+        ))
+
+    return bars
+
+# Example usage
+categories = ["Region A", "Region B", "Region C"]
+values = [[120, 200, 150]]
+series_names = ["Suitability"]
+custom_colors = [["#2ecc71", "#f39c12", "#e74c3c"]]
+
+bars = get_bars_series(
+    values,
+    series_names=series_names,
+    custom_item_color=True,
+    custom_item_colors=custom_colors
+)
+
+option = Option(
+    yAxis=YAxis(type="category", data=categories),
+    xAxis=XAxis(type="value"),
+    series=bars,
+    tooltip=Tooltip(trigger="axis")
+)
+
+chart = EChartsWidget(option=option, style={"height": "300px"})
+chart
+```
+
+---
+
+## Advanced Features
+
+### 1. Widget Initialization Parameters
+
+Customize ECharts initialization (applies to both `EChartsWidget` and `EChartsRawWidget`):
+
+```python
+chart = EChartsWidget(
+    option=option,
+
+    # Rendering
+    renderer="svg",              # 'canvas' or 'svg'
+    use_dirty_rect=True,         # Performance optimization
+
+    # Sizing
+    width="600px",               # Or "auto"
+    height="400px",              # Or "auto"
+
+    # Styling
+    style={
+        'border': '2px solid #ccc',
+        'backgroundColor': '#f0f0f0',
+        'borderRadius': '8px'
+    },
+
+    # Theme
+    theme="dark",                # Or None for default
+
+    # Advanced
+    device_pixel_ratio=2.0,
+    use_coarse_pointer=False,
+    locale="EN"                  # 'EN' or 'ZH'
+)
+```
+
+### 2. Dynamic Style Updates
+
+```python
+# Create chart
+chart = EChartsWidget(option=option, style={'height': '300px'})
+
+# Update style later
+chart.style = {
+    'width': '800px',
+    'height': '600px',
+    'border': '2px solid #000'
+}
+```
+
+### 3. Event Handling
+
+Listen to user interactions:
+
+```python
+chart = EChartsWidget(option=option)
+
+def on_click(params):
+    print(f"Clicked: {params}")
+
+def on_hover(params):
+    print(f"Hovering: {params['name']}")
+
+# Register event handlers
+chart.on('click', None, on_click)              # All click events
+chart.on('click', 'series.line', on_click)     # Only line series
+chart.on('mouseover', {'seriesIndex': 1}, on_hover)  # Specific series
+
+# Remove handlers
+chart.off('click')              # Remove all click handlers
+chart.off('mouseover', on_hover)  # Remove specific handler
+```
+
+### 4. Chart Actions
+
+Programmatically trigger chart behaviors:
+
+```python
+chart = EChartsWidget(option=option)
+
+# Highlight a data point
+chart.dispatchAction({
+    'type': 'highlight',
+    'seriesIndex': 0,
+    'dataIndex': 2
+})
+
+# Show tooltip
+chart.dispatchAction({
+    'type': 'showTip',
+    'seriesIndex': 0,
+    'dataIndex': 1
+})
+
+# Data zoom
+chart.dispatchAction({
+    'type': 'dataZoom',
+    'start': 20,
+    'end': 80
+})
+```
+
+### 5. Using JavaScript Functions
+
+For advanced formatting and callbacks:
+
+```python
+from ipecharts.tools import encode_js_fn
+from ipecharts.option import Tooltip
+
+# Create a JS function for custom tooltip formatting
+formatter = encode_js_fn(
+    ['params'],
+    "return params.value[3] + ': ' + params.value[0];"
+)
+
+tooltip = Tooltip(trigger='item', formatter=formatter)
+option = Option(tooltip=tooltip, series=[...])
+```
+
+### 6. Custom Theme Integration
+
+```python
+from pysepal.solara import get_current_theme_state
+
+class EChartsWidget(EChartsWidget):
+    """Extended widget bound to the session ThemeState."""
+
+    def __init__(self, theme_state=None, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        self.renderer = "svg"
+        self.theme_state = theme_state or get_current_theme_state()
+        self.theme = "dark" if self.theme_state.dark else "light"
+        self.theme_state.observe(self._on_theme_change, "dark")
+
+    def _on_theme_change(self, change):
+        self.theme = "dark" if change["new"] else "light"
+```
+
+> Observing `theme_state.dark` (the resolved boolean) picks up both explicit
+> user toggles and live `prefers-color-scheme` changes in auto mode.
+
+---
+
+## Best Practices
+
+### 1. Choose the Right Approach
+
+- **Use `EChartsRawWidget`** when:
+
+  - Converting JavaScript examples quickly
+  - Creating static charts without interactivity
+  - Prototyping
+
+- **Use `EChartsWidget`** when:
+  - Building interactive dashboards
+  - Need reactive data updates
+  - Working with other Jupyter widgets
+  - Want type hints and IDE support
+
+### 2. Performance Optimization
+
+```python
+# For large datasets, use canvas renderer (default)
+chart = EChartsWidget(option=option, renderer="canvas", use_dirty_rect=True)
+
+# For better quality/scalability, use SVG
+chart = EChartsWidget(option=option, renderer="svg")
+
+# Set explicit dimensions for better performance
+chart = EChartsWidget(option=option, width="800px", height="600px")
+```
+
+### 3. Data Management
+
+```python
+# Good: Use Dataset for complex data
+dataset = Dataset(
+    dimensions=["Product", "Sales", "Price"],
+    source=[
+        ["Product A", 43.3, 85.8],
+        ["Product B", 83.1, 73.4],
+        ["Product C", 86.4, 65.2]
+    ]
+)
+
+# Reference data in series
+bar = Bar(encode={"x": "Product", "y": "Sales"})
+option = Option(dataset=dataset, series=[bar])
+```
+
+### 4. Styling Consistency
+
+```python
+# Define color palette
+colors = ["#5470c6", "#91cc75", "#fac858", "#ee6666", "#73c0de"]
+
+option = Option(
+    color=colors,  # Apply to all series
+    backgroundColor="#1e1e1e00",  # Transparent
+    # ... rest of config
+)
+```
+
+### 5. Responsive Charts
+
+```python
+# Use relative sizing
+chart = EChartsWidget(
+    option=option,
+    style={
+        'width': '100%',   # Responsive width
+        'height': '400px'  # Fixed height
+    }
+)
+
+# Or calculate height dynamically
+num_categories = len(categories)
+height = max(200, 50 + 75 * num_categories)
+chart = EChartsWidget(option=option, height=f"{height}px")
+```
+
+### 6. Reusable Components
+
+```python
+def create_bar_chart(categories, values, title="", height="300px"):
+    """Reusable bar chart factory."""
+    bar = Bar(data=values)
+    option = Option(
+        title=Title(text=title),
+        xAxis=XAxis(type="category", data=categories),
+        yAxis=YAxis(type="value"),
+        series=[bar],
+        tooltip=Tooltip(trigger="axis")
+    )
+    return EChartsWidget(option=option, style={"height": height})
+
+# Usage
+chart = create_bar_chart(
+    ["A", "B", "C"],
+    [120, 200, 150],
+    title="Sales by Region"
+)
+```
+
+### 7. Error Handling
+
+```python
+# Always validate data before creating charts
+def validate_data(values, series_names, custom_colors=None):
+    if len(values) != len(series_names):
+        raise ValueError(
+            f"Mismatch: {len(values)} value series vs {len(series_names)} names"
+        )
+
+    if custom_colors and len(custom_colors) != len(values):
+        raise ValueError(
+            f"Mismatch: {len(custom_colors)} color series vs {len(values)} value series"
+        )
+
+    return True
+
+# Use before creating charts
+validate_data(values, series_names, custom_colors)
+bars = get_bars_series(values, series_names, custom_item_colors=custom_colors)
+```
+
+---
+
+## Summary
+
+`ipecharts` provides a powerful, flexible way to create interactive charts in Jupyter notebooks:
+
+1. **Two approaches**: Dictionary-based (`EChartsRawWidget`) or object-oriented (`EChartsWidget`)
+2. **Reactive updates**: Change data properties and charts update automatically
+3. **Rich components**: 30+ chart types, axes, legends, tooltips, etc.
+4. **Event handling**: Respond to user interactions
+5. **Customizable**: Themes, styling, JavaScript functions
+6. **Integration**: Works with ipywidgets and other Jupyter tools
+
+For more information:
+
+- 📚 [Documentation](https://ipecharts.readthedocs.io/)
+- 🌐 [Try it online](https://trungleduc.github.io/ipecharts/)
+- 💻 [GitHub Repository](https://github.com/trungleduc/ipecharts)
+- 📊 [ECharts Documentation](https://echarts.apache.org/en/index.html)
+
+---
+
+## Additional Resources
+
+### Converting JavaScript Examples
+
+When you find an ECharts example in JavaScript:
+
+1. Copy the `option` object
+2. Convert JavaScript syntax to Python:
+   - `camelCase` → `snake_case` for parameters (optional)
+   - `true/false` → `True/False`
+   - Single quotes → Double quotes (optional)
+3. Use `EChartsRawWidget` for quick testing
+4. Convert to `EChartsWidget` for production use
+
+### Common Gotchas
+
+1. **Series must be in a list**: `series=[line]` not `series=line`
+2. **Data updates**: Use `line.data = new_data` not `line['data'] = new_data`
+3. **Height defaults**: Charts default to 500px, set explicitly for control
+4. **Theme updates**: Changing theme requires widget recreation or custom handler
+
+### Performance Tips
+
+- Use `renderer="canvas"` for large datasets
+- Enable `use_dirty_rect=True` for animations
+- Set explicit `width` and `height` when possible
+- Debounce rapid data updates in interactive applications

--- a/docs/guides/ipyvuetify-widgets.md
+++ b/docs/guides/ipyvuetify-widgets.md
@@ -1,0 +1,405 @@
+# Creating ipyvuetify VuetifyTemplate Widgets
+
+Guide for building custom Vue.js widgets with Python backend integration using
+ipyvuetify's `VuetifyTemplate` in pysepal.
+
+## When to Use Vue vs Pure Solara
+
+From [Solara's official guidance](https://solara.dev/documentation/api/utilities/component_vue):
+
+> _"Although many components can be made from the Python side, sometimes it
+> is easier to write components using Vue directly. It can also be beneficial
+> for performance, since instead of creating many widgets from the Python
+> side we only send data to the frontend. If event handling is also done on
+> the frontend, this reduces latency and makes your app feel much smoother."_
+
+**Use Vue (`VuetifyTemplate` or `component_vue`) when:**
+
+- The UI has complex layout logic (responsive positioning, CSS variables,
+  viewport-aware sizing, animations)
+- Frontend event handling would reduce latency (drag, resize, hover)
+- You need the full Vuetify component API (watchers, computed, lifecycle hooks)
+- You're wrapping a JavaScript library that has no ipywidget binding
+- Performance matters — fewer Python-to-frontend roundtrips
+
+**Use pure Solara (`@solara.component` with `rv.*`) when:**
+
+- The component is straightforward form inputs, buttons, state display
+- All logic is Python-side (no frontend event handling needed)
+- Type safety and IDE support are a priority
+- The component doesn't need custom CSS or complex layout
+
+**Hybrid approach (recommended for complex widgets):**
+Keep the Vue template for rendering and frontend logic. Wrap it in a Solara
+component that provides a typed Python API with `value`/`on_value` reactive
+parameters. This gives you the best of both: proven Vue rendering + clean
+Solara integration.
+
+## Two Approaches
+
+### Approach 1: `solara.component_vue` (recommended for new widgets)
+
+The simplest way to create a Vue-backed Solara component. The decorator
+auto-generates traitlets from the function signature:
+
+```python
+import solara
+
+@solara.component_vue("MyWidget.vue")
+def MyWidget(
+    title: str = "Default",
+    items: list = [],
+    value: dict = {},
+    on_value: Callable[[dict], None] = None,
+    event_item_click: Callable[[str], None] = None,
+):
+    pass
+```
+
+- `foo` + `on_foo` pairs become reactive props (Solara handles the
+  callback wiring)
+- `event_foo` arguments become Vue-callable methods (accessible as
+  `this.foo()` or `this.event_foo()` in Vue)
+- The `.vue` file path is relative to the Python file
+- No traitlets, no `__init__`, no widget class — just a function signature
+
+**Vue template** (`MyWidget.vue`):
+
+```vue
+<template>
+  <v-card>
+    <v-card-title>{{ title }}</v-card-title>
+    <v-list>
+      <v-list-item
+        v-for="item in items"
+        :key="item"
+        @click="event_item_click(item)"
+      >
+        {{ item }}
+      </v-list-item>
+    </v-list>
+  </v-card>
+</template>
+```
+
+**Usage in Solara apps:**
+
+```python
+@solara.component
+def Page():
+    value = solara.use_reactive({})
+    MyWidget(title="Picker", items=["a", "b"], value=value)
+```
+
+### Approach 2: `v.VuetifyTemplate` subclass (existing pysepal pattern)
+
+More control, needed when you want `SepalWidget` helpers, custom
+`__init__`, or complex traitlet configuration:
+
+## File Structure
+
+```
+pysepal/sepalwidgets/
+├── your_widget.py              # Python VuetifyTemplate class
+├── vue/
+│   └── YourWidget.vue          # Vue component template
+```
+
+Existing pysepal VuetifyTemplate widgets follow this layout:
+
+| Widget       | Python file      | Vue template           |
+| ------------ | ---------------- | ---------------------- |
+| MapApp       | `vue_app.py`     | `vue/MapApp.vue`       |
+| ThemeToggle  | `vue_app.py`     | `vue/Theming.vue`      |
+| RightPanel   | `vue_app.py`     | `vue/RightPanel.vue`   |
+| FileInput    | `file_input.py`  | `vue/FileInput.vue`    |
+| TaskButton   | `btn.py`         | `vue/TaskButton.vue`   |
+| Dialog       | `sepalwidget.py` | `vue/Dialog.vue`       |
+| Tabs         | `vue_widgets.py` | `vue/Tabs.vue`         |
+| LocaleSelect | `vue_app.py`     | `vue/LocaleSelect.vue` |
+| DrawerItem   | `app.py`         | `vue/DrawerItem.vue`   |
+
+## Python Backend
+
+```python
+from pathlib import Path
+
+import ipyvuetify as v
+from traitlets import Bool, Dict, List, Unicode, observe
+
+from pysepal.sepalwidgets.widget import SepalWidget
+
+
+class YourWidget(v.VuetifyTemplate, SepalWidget):
+    # Point to Vue template
+    template_file = Unicode(
+        str(Path(__file__).parent / "vue/YourWidget.vue")
+    ).tag(sync=True)
+
+    # Synchronized properties — .tag(sync=True) is required
+    title = Unicode("Default Title").tag(sync=True)
+    items = List([]).tag(sync=True)
+    v_model = Dict({}).tag(sync=True)
+    loading = Bool(False).tag(sync=True)
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self.items = ["Item 1", "Item 2"]
+
+    @observe("v_model")
+    def _on_model_changed(self, change):
+        """React to v_model changes from Vue."""
+        pass
+
+    # Vue-callable methods — prefix with 'vue_'
+    def vue_add_item(self, item_name):
+        """Callable from Vue as this.add_item(...)."""
+        self.items = list(self.items) + [item_name]  # new list triggers sync
+```
+
+Inherit from `SepalWidget` alongside `v.VuetifyTemplate` to get visibility
+helpers (`hide()`, `show()`, `toggle_viz()`, `reset()`).
+
+## Vue Frontend
+
+```vue
+<template>
+  <v-card>
+    <v-card-title>{{ title }}</v-card-title>
+    <v-card-text>
+      <v-list>
+        <v-list-item v-for="(item, index) in items" :key="index">
+          <v-list-item-content>{{ item }}</v-list-item-content>
+        </v-list-item>
+      </v-list>
+      <v-btn @click="addItem" :loading="loading">Add Item</v-btn>
+    </v-card-text>
+  </v-card>
+</template>
+
+<script>
+export default {
+  name: "YourWidget",
+  props: {
+    title: { type: String, default: "Default Title" },
+    items: { type: Array, default: () => [] },
+    v_model: { type: Object, default: () => ({}) },
+    loading: { type: Boolean, default: false },
+  },
+  methods: {
+    addItem() {
+      // Call Python method — drop the vue_ prefix
+      this.add_item("New Item");
+    },
+  },
+};
+</script>
+```
+
+## Data Synchronization
+
+- Python properties with `.tag(sync=True)` auto-sync with Vue props.
+- **Always create new objects** to trigger sync:
+  `self.items = list(self.items) + [new_item]`
+- **Never mutate in place**: `self.items.append(...)` will NOT sync.
+
+## Event Handling
+
+### Vue → Python
+
+Python methods prefixed with `vue_` are callable from Vue (without the prefix):
+
+```python
+# Python
+def vue_handle_click(self, data):
+    pass
+```
+
+```vue
+<!-- Vue -->
+<v-btn @click="handle_click('save')">Save</v-btn>
+```
+
+### Python → Vue
+
+Use `self.send()` to call Vue methods (which must have a `jupyter_` prefix):
+
+```python
+# Python
+def notify_vue(self):
+    self.send({"method": "highlight", "args": ["success"]})
+```
+
+```vue
+<!-- Vue -->
+<script>
+export default {
+  methods: {
+    jupyter_highlight(type) {
+      this.showNotification(type);
+    },
+  },
+};
+</script>
+```
+
+### Python property observation
+
+Use `@observe` to react to property changes from Vue:
+
+```python
+@observe("v_model")
+def _on_model_changed(self, change):
+    new_value = change["new"]
+```
+
+## Component Composition (Embedding Widgets)
+
+VuetifyTemplate supports embedding other widgets via `Instance(DOMWidget)`.
+This is how `MapApp` embeds `ThemeToggle`, `RightPanel`, and step content.
+
+### Python side
+
+```python
+from ipywidgets import DOMWidget
+from ipywidgets.widgets.widget import widget_serialization
+from traitlets import Instance, List
+
+class ParentWidget(v.VuetifyTemplate):
+    # Single component — must still be a List
+    theme_toggle = List(Instance(DOMWidget)).tag(sync=True, **widget_serialization)
+
+    # Multiple components
+    panels = List(Instance(DOMWidget)).tag(sync=True, **widget_serialization)
+
+    def __init__(self, theme_toggle=None, **kwargs):
+        kwargs["theme_toggle"] = [theme_toggle] if theme_toggle else []
+        super().__init__(**kwargs)
+
+        # Parent-child communication: observe Python traits, not Vue events
+        if theme_toggle:
+            theme_toggle.observe(self._on_theme_change, "dark")
+```
+
+### Vue side
+
+```vue
+<template>
+  <v-app>
+    <!-- Always guard with length check -->
+    <jupyter-widget
+      v-if="theme_toggle && theme_toggle.length > 0"
+      :widget="theme_toggle[0]"
+    />
+  </v-app>
+</template>
+```
+
+### Rules
+
+1. **Always use Lists** — even single components: `[widget]`
+2. **Include `**widget_serialization`** on every `Instance(DOMWidget)` trait
+3. **Guard in Vue**: `v-if="prop && prop.length > 0"`
+4. **None handling**: `[component] if component else []`
+5. **Parent-child communication** uses Python `.observe()`, not Vue `$emit`
+   (Vue events do not cross `<jupyter-widget>` boundaries)
+
+## Troubleshooting
+
+### 1. `TypeError: n[o].bind is not a function`
+
+**Cause**: Object-style watchers on Python-synchronized props.
+
+```vue
+<!-- WRONG — object watcher causes binding error -->
+watch: { is_open: { immediate: true, handler(newValue) { this.internalOpen =
+newValue; } } }
+
+<!-- CORRECT — simple function watcher -->
+watch: { is_open(newValue) { this.internalOpen = newValue; } }
+```
+
+ipyvuetify's binding mechanism conflicts with Vue's object watcher syntax.
+**Never use `deep: true` or `immediate: true`** on Python-synced props.
+Use `mounted()` instead of `immediate: true` for initialization.
+
+### 2. Vue reactivity with object properties
+
+Vue 2 cannot detect property additions/deletions on objects. Use `$set`
+and `$delete`:
+
+```vue
+<!-- WRONG — no reactivity -->
+this.v_model[nextId] = { name: null };
+
+<!-- CORRECT -->
+this.$set(this.v_model, nextId, { name: null }); this.$delete(this.v_model,
+oldId);
+```
+
+### 3. Props not synchronizing
+
+Check:
+
+- Python property has `.tag(sync=True)`
+- Vue prop name matches Python property name exactly
+- You are creating new objects, not mutating in place
+
+### 4. Methods not available in Vue
+
+Check:
+
+- Python method is prefixed with `vue_`
+- Vue calls it without the prefix: `this.my_method()`
+- `on_event` is not available in VuetifyTemplate — use `vue_` methods
+
+### 5. Initial state wrong on mount
+
+**Problem**: Widget starts with wrong state (e.g. panel open when
+`is_open=False`).
+
+```vue
+<!-- WRONG — timing issue -->
+data() { return { internalOpen: this.is_open }; }
+
+<!-- CORRECT — safe default + mounted -->
+data() { return { internalOpen: false }; }, watch: { is_open(newValue) {
+this.internalOpen = newValue; } }, mounted() { this.internalOpen = this.is_open;
+}
+```
+
+### 6. `TypeError: this.send is not a function`
+
+`this.send()` is not available in Vue. Call Python methods directly instead:
+
+```vue
+<!-- WRONG -->
+this.send({ event: "action", data: payload });
+
+<!-- CORRECT — calls vue_handle_action in Python -->
+this.handle_action(payload);
+```
+
+### 7. Parent-child communication across `<jupyter-widget>`
+
+Vue `$emit` does **not** propagate across `<jupyter-widget>` boundaries.
+Use Python `.observe()` on the child's traitlets instead:
+
+```python
+# Child
+class RightPanel(v.VuetifyTemplate):
+    is_open = Bool(False).tag(sync=True)
+
+    def vue_panel_state_changed(self, state):
+        self.is_open = state  # triggers parent's observer
+
+# Parent
+class MapApp(v.VuetifyTemplate):
+    def __init__(self, **kwargs):
+        self.right_panel = RightPanel()
+        self.right_panel.observe(self._on_panel_change, "is_open")
+        super().__init__(**kwargs)
+
+    def _on_panel_change(self, change):
+        self.right_panel_open = change["new"]
+```

--- a/docs/guides/migration-notes-v3.4.md
+++ b/docs/guides/migration-notes-v3.4.md
@@ -1,0 +1,223 @@
+# pysepal Solara Component Changes (v3.4)
+
+Use this document to audit and update any pysepal-based Solara app that was
+scaffolded or written before these changes landed.
+
+## 1. Component Renames and Relocations
+
+Solara input components have moved from `pysepal.solara.components.aoi.*` and
+`pysepal.sepalwidgets.file_input` into a dedicated package:
+`pysepal.solara.components.inputs`.
+
+**Naming convention**: Solara components use `OriginalName + Component` suffix.
+
+| Old name / location                                               | New name                  | New import path                                    |
+| ----------------------------------------------------------------- | ------------------------- | -------------------------------------------------- |
+| `FileInputComponent` from `pysepal.sepalwidgets.file_input`       | `FileInputComponent`      | `pysepal.solara.components.inputs.file_input`      |
+| `AssetSelector` from `pysepal.solara.components.aoi.asset_method` | `AssetSelectComponent`    | `pysepal.solara.components.inputs.asset_select`    |
+| `PointsSelector` from `pysepal.solara.components.aoi.points`      | `PointsSelectorComponent` | `pysepal.solara.components.inputs.point_selector`  |
+| `ShapeSelector` from `pysepal.solara.components.aoi.shape`        | `VectorSelectorComponent` | `pysepal.solara.components.inputs.vector_selector` |
+
+**Shorthand import** — all four are re-exported from the package init:
+
+```python
+from pysepal.solara.components.inputs import (
+    FileInputComponent,
+    AssetSelectComponent,
+    PointsSelectorComponent,
+    VectorSelectorComponent,
+)
+```
+
+**Backward compatibility**:
+
+- `FileInputComponent` from `pysepal.sepalwidgets.file_input` still works but
+  emits a `DeprecationWarning`. Update the import.
+- The old names (`AssetSelector`, `PointsSelector`, `ShapeSelector`) no longer
+  exist at the old locations. These were new components with no external users,
+  so no deprecation shim was added.
+
+**What to do**: search your codebase for the old import paths and rename.
+
+## 2. Process Functions Stayed Put
+
+The AOI processing functions did not move. They remain in the `aoi` subpackage:
+
+```python
+from pysepal.solara.components.aoi import process_asset, process_points, process_shape
+```
+
+`asset_method.py` was renamed to `asset.py`:
+
+```python
+# Old
+from pysepal.solara.components.aoi.asset_method import process_asset
+# New
+from pysepal.solara.components.aoi.asset import process_asset
+```
+
+**What to do**: if you import `process_asset` from `aoi.asset_method`, update
+to `aoi.asset`.
+
+## 3. GEE Pattern Change: `prefer_threaded=False` and Direct Async
+
+The documented GEE pattern has changed. The previous pattern wrapped sync
+GEE methods with `asyncio.to_thread`:
+
+```python
+# OLD pattern — do not use for new code
+@solara.lab.use_task(dependencies=None, raise_error=False, prefer_threaded=True)
+async def gee_job(request):
+    result = await asyncio.to_thread(gee_interface.get_info, ee_object)
+```
+
+The new pattern uses `GEEInterface` async methods directly and keeps the
+coroutine on Solara's event loop:
+
+```python
+# NEW pattern
+@solara.lab.use_task(dependencies=None, raise_error=False, prefer_threaded=False)
+async def gee_job(request):
+    result = await gee_interface.get_info_async(ee_object)
+```
+
+**Key changes**:
+
+- `prefer_threaded=False` — keeps the task on Solara's event loop, avoiding
+  cross-loop `RuntimeError` with `EESession`'s asyncio primitives.
+- `await gee_interface.*_async(...)` — call the async GEE methods directly.
+- `asyncio.to_thread(...)` is now reserved for truly blocking non-GEE work
+  (local file I/O, CPU-heavy parsing, etc.).
+
+**What to do**:
+
+1. Change `prefer_threaded=True` to `prefer_threaded=False` on all
+   `use_task` hooks that call GEE.
+2. Replace `asyncio.to_thread(gee_interface.get_info, obj)` with
+   `await gee_interface.get_info_async(obj)` (and similarly for
+   `get_assets`, `get_asset`, `get_map_id`, `get_folder`, exports, etc.).
+3. Keep `asyncio.to_thread` only for non-GEE blocking calls.
+
+**Reference**: `docs/guides/solara-gee-patterns.md`
+
+## 4. `AssetSelectComponent` API Changes
+
+The component now:
+
+- Defaults to `types=["IMAGE", "TABLE"]` (was `["TABLE"]` only).
+- Exposes `loading` / `on_loading` parameters so the parent can disable
+  buttons while the component is loading assets, validating, or fetching
+  columns.
+- Only shows column/value selectors for TABLE assets.
+- Accepts an optional `gee_interface` parameter.
+- Output dict now includes a `type` key alongside `asset_id`, `column`,
+  `value`.
+
+```python
+AssetSelectComponent(
+    types=["IMAGE", "TABLE"],
+    value=asset_data,
+    loading=asset_loading,       # new — reactive bool
+    gee_interface=gee_interface, # new — optional, falls back to session
+)
+```
+
+**What to do**: if you use `AssetSelector` or `AssetSelectComponent`, check
+that you handle the new `type` key in the output dict and consider wiring
+`loading` to disable submit buttons.
+
+## 5. `AoiView` Internal Changes
+
+- Uses the new component names internally (`AssetSelectComponent`,
+  `PointsSelectorComponent`, `VectorSelectorComponent`).
+- The `add_ee_layer` call now runs inside `process_aoi` via
+  `asyncio.to_thread` (on a worker thread) instead of in
+  `handle_task_state` (on the event loop). This prevents the cross-loop
+  `RuntimeError` with `eeclient`'s HTTP/2 connections.
+- The "Select AOI" button is now disabled while `AssetSelectComponent` is
+  loading.
+
+**What to do**: if you override or extend `AoiView` behavior, verify your
+code is compatible with these changes. If you only use `AoiView` as a
+black box, no action needed.
+
+## 6. New Documentation
+
+- `docs/guides/ipyvuetify-widgets.md` — guide for creating custom
+  `v.VuetifyTemplate` widgets (Python + Vue structure, data sync, event
+  handling, component embedding, troubleshooting).
+
+## 7. Theme: `theme_toggle=` → `theme_state=`
+
+Theme source of truth moved from per-widget `ThemeToggle` observers to a
+session-scoped `ThemeState`. Fixes theme freezes after Solara re-renders.
+
+**Old pattern:**
+
+```python
+theme_toggle = ThemeToggle()
+theme_toggle.observe(lambda e: setattr(theme, "dark", e["new"]), "dark")
+
+SepalMap(gee_interface=gee_interface, theme_toggle=theme_toggle)
+MapApp.element(..., theme_toggle=[theme_toggle])
+```
+
+**New pattern:**
+
+```python
+from pysepal.solara import get_current_theme_state
+
+theme_state = get_current_theme_state()
+
+SepalMap(gee_interface=gee_interface, theme_state=theme_state)
+MapApp.element(..., theme_state=theme_state)
+```
+
+**Key points:**
+
+- `get_current_theme_state()` returns the session-scoped `ThemeState`; no
+  manual `ThemeToggle` or `theme.dark` observer needed. `MapApp` creates
+  its own toggle if none is supplied.
+- `SepalMap(theme_toggle=...)` still works but emits `DeprecationWarning`.
+- `ThemeState` exposes `.mode` (`"dark"` | `"light"` | `"auto"`) and `.dark`
+  (resolved boolean). Use `use_theme_dark()` to reactively observe from a
+  Solara component.
+- Auto mode now tracks system `prefers-color-scheme` live.
+
+**What to do**: remove `theme_toggle = ThemeToggle()` + `theme_toggle.observe(...)`
+boilerplate; swap `theme_toggle=` for `theme_state=` on `SepalMap` and `MapApp`.
+
+## Audit Checklist
+
+- [ ] Search for old import paths (`asset_method`, `AssetSelector`,
+      `PointsSelector`, `ShapeSelector`, `sepalwidgets.file_input.FileInputComponent`)
+      and update them.
+- [ ] Search for `prefer_threaded=True` on GEE-related `use_task` hooks
+      and change to `prefer_threaded=False`.
+- [ ] Search for `asyncio.to_thread(gee_interface.` and replace with
+      `await gee_interface.*_async(...)`.
+- [ ] If using `AssetSelectComponent`, handle the `type` key in the output
+      dict and wire the `loading` parameter.
+- [ ] Verify `add_ee_layer` calls are not made from sync `use_effect`
+      handlers — they must run from a thread or from inside an async task.
+- [ ] Remove manual `theme_toggle = ThemeToggle()` + `theme.observe(...)`
+      wiring; use `get_current_theme_state()` and pass `theme_state=` to
+      `SepalMap` / `MapApp` instead.
+
+## 8. MapApp → MapAppComponent
+
+The `pysepal.sepalwidgets.vue_app.MapApp` VuetifyTemplate is deprecated.
+Prefer `pysepal.solara.components.layout.MapAppComponent` (re-exported
+as `pysepal.solara.MapAppComponent`). The new component:
+
+- Is a `@solara.component` usable with `with MapAppComponent(...): ...`.
+- Exposes typed dataclass props: `StepConfig`, `PanelSection`,
+  `RightPanelConfig`, `StepAction`, `ExternalLink`.
+- Auto-wires `ThemeState` and `Translator` (no manual `ThemeToggle()`
+  construction needed).
+- Renders only the active step's content (lazy `content=` callables).
+- Preserves the visual design of `MapApp.vue` (drawer, narrow-mode
+  bottom sheet, dialog steps, right panel).
+
+See `docs/guides/solara-mapapp-component.md` for the migration map. The
+legacy class still works but emits a `DeprecationWarning`.

--- a/docs/guides/solara-app-builder.md
+++ b/docs/guides/solara-app-builder.md
@@ -1,0 +1,527 @@
+# Building Solara Apps with pysepal
+
+> **IMPORTANT**: Read this guide BEFORE creating a new SEPAL module with pysepal + Solara.
+> Every pattern here is grounded in working apps: `sepal_mgci`, `se.plan`, `sbae-design`.
+>
+> For new GEE-based Solara apps, use the `solara.reactive()` +
+> `solara.lab.use_task(prefer_threaded=False)` pattern in
+> [Solara GEE Patterns](./solara-gee-patterns.md) and await
+> `gee_interface.*_async(...)` directly.
+> User files in GEE/container apps must always be read, listed, created,
+> and written through the session `SepalClient`; never write user data to the
+> container filesystem.
+> For user-facing app status, mount `NotificationProvider()` once at the app
+> shell and follow [Solara Notifications](./solara-notifications.md).
+> The traitlets `create_task()` and `.observe()` flows are legacy patterns for
+> existing apps, not new scaffolds.
+
+## 1. Entry Point Pattern
+
+Every pysepal Solara app follows this exact initialization sequence in `solara_app.py`:
+
+```python
+import solara
+from pysepal.solara import (
+    setup_sessions,
+    setup_solara_server,
+    setup_theme_colors,
+    with_sepal_sessions,
+    get_current_gee_interface,
+    get_current_sepal_client,
+    get_current_drive_interface,
+)
+
+# 1. Server setup (module level, runs once)
+setup_solara_server(extra_asset_locations=[])
+
+# 2. Session setup (per kernel, runs on each new browser tab)
+@solara.lab.on_kernel_start
+def on_kernel_start():
+    return setup_sessions()
+
+# 3. Main component with session decorator
+@solara.component
+@with_sepal_sessions(module_name="my_module_name")
+def Page():
+    setup_theme_colors()
+
+    # 4. Get session interfaces (per-user, per-tab)
+    gee_interface = get_current_gee_interface()
+    sepal_client = get_current_sepal_client()
+
+    # 5. Pass interfaces to components/models
+    # ...your app here...
+```
+
+### Initialization order matters
+
+1. `setup_solara_server()` — module level, configures Solara (kernel timeout, assets)
+2. `setup_sessions()` — in `@solara.lab.on_kernel_start`, creates SessionManager
+3. `@with_sepal_sessions` — on `Page()`, waits for auth headers, creates per-user session
+4. `get_current_*()` — inside component, retrieves session-bound interfaces
+
+### The `@with_sepal_sessions` decorator
+
+This decorator is **required** on the main `Page()` component. It:
+
+- Waits for SEPAL auth headers (`solara.lab.headers`)
+- Creates a session with `GEEInterface`, `SepalClient`, `GDriveInterface` per user
+- Shows a loading screen while waiting
+- Handles auth errors gracefully
+
+```python
+@solara.component
+@with_sepal_sessions(module_name="sdg_indicators/15.4.2")
+def Page():
+    # This only renders after session is ready
+    gee_interface = get_current_gee_interface()  # Guaranteed to have sepal headers
+```
+
+## Notification Shell Pattern
+
+New pysepal Solara apps that perform async work should treat notifications as a
+first-class part of the app shell.
+
+Default rule:
+
+- mount `NotificationProvider()` once near the top of the app shell
+- let child pages, tiles, and widgets call `use_notifications()`
+- do not mount a separate provider in every subpage unless each page truly runs
+  in a separate kernel
+
+The notification bus is scoped to the current Solara kernel, not the route. If
+routes are rendered inside one live page, they share notification history. If
+an app launcher opens each route as a separate browser page load, each page gets
+its own kernel and its own notification history.
+
+For the full architecture and usage patterns, read
+[Solara Notifications](./solara-notifications.md).
+
+## Export Shell Pattern
+
+Apps that produce GEE-backed layers users might want to take out of the app
+should drop in `ExportLauncher`. It handles Earth Engine asset, Google Drive,
+and SEPAL workspace targets through one button, including folder creation
+and Drive-to-SEPAL staging. Declare one `ExportSource` per exportable layer
+and pass the tuple to `ExportLauncher(sources=...)`.
+
+For the full component API (sources, `ResolvedExport`, canonical file-format
+constants, `use_export_dialog` for custom layouts, and testing helpers),
+read [Solara Export](./solara-export.md).
+
+## 2. Session Interfaces
+
+Three interfaces are available per user session:
+
+| Interface         | Getter                          | Purpose                             |
+| ----------------- | ------------------------------- | ----------------------------------- |
+| `GEEInterface`    | `get_current_gee_interface()`   | Earth Engine API calls (async/sync) |
+| `SepalClient`     | `get_current_sepal_client()`    | SEPAL file/task operations          |
+| `GDriveInterface` | `get_current_drive_interface()` | Google Drive export/import          |
+
+### Getting interfaces
+
+Always call getters **inside the component**, never at module level:
+
+```python
+# WRONG — gets fallback without headers
+gee_interface = get_current_gee_interface()  # Module level!
+
+@solara.component
+def Page():
+    ...
+
+# CORRECT — gets session-bound interface with sepal headers
+@solara.component
+@with_sepal_sessions(module_name="my_app")
+def Page():
+    gee_interface = get_current_gee_interface()
+```
+
+### Passing interfaces to sub-components
+
+```python
+@solara.component
+@with_sepal_sessions(module_name="my_app")
+def Page():
+    gee_interface = get_current_gee_interface()
+    sepal_client = get_current_sepal_client()
+
+    # Pass to models
+    model = MyModel(gee_interface=gee_interface, sepal_client=sepal_client)
+
+    # Pass to map
+    sepal_map = solara.use_memo(
+        lambda: sm.SepalMap(gee=True, gee_interface=gee_interface),
+        [id(gee_interface)],
+    )
+
+    # Pass to tiles/widgets
+    MyTile(model=model, map_=sepal_map)
+```
+
+### User file boundary
+
+For GEE/container apps, `SepalClient` is the only runtime API for user files.
+This rule applies both in local development and after deployment behind the
+SEPAL app launcher. The container filesystem is for application code, Python
+packages, and bundled static assets; it is not a user workspace and should not
+receive user uploads, generated reports, CSVs, rasters, recipes, or temporary
+state.
+
+Do not use `pathlib.Path`, `os`, `shutil`, `glob`, `open()`, or library calls
+that walk/read/write server-local paths for user data. Those calls inspect the
+container, not the authenticated user's SEPAL workspace, and they can mix users
+or lose data when the container restarts.
+
+Use the session client instead:
+
+```python
+@solara.component
+@with_sepal_sessions(module_name="my_app")
+def Page():
+    sepal_client = get_current_sepal_client()
+
+    results_dir = sepal_client.get_remote_dir(
+        f"{sepal_client.results_path}/exports",
+        parents=True,
+    )
+    sepal_client.set_file(f"{results_dir}/summary.csv", csv_text, overwrite=True)
+    content = sepal_client.get_file(f"{results_dir}/summary.csv")
+    files = sepal_client.list_files(folder=str(results_dir))
+```
+
+Remote paths are POSIX-style strings relative to the user's SEPAL workspace, or
+absolute paths under `/home/sepal-user`. Do not branch on `DEPLOY_ENV` to fall
+back to local filesystem writes for a container app; keep the same
+`SepalClient` path in tests, local runs, and production.
+
+### GEEInterface async methods
+
+The session-bound `GEEInterface` returned by `get_current_gee_interface()`
+already exposes both sync and async methods. For new Solara apps, the async API
+is the default. There is no separate async getter.
+
+When you call those methods inside `solara.lab.use_task`, set
+`prefer_threaded=False` so the GEE coroutine stays on Solara's current event
+loop instead of hopping to a per-task thread loop.
+
+```python
+@solara.lab.use_task(
+    dependencies=None,
+    raise_error=False,
+    prefer_threaded=False,
+)
+async def load_stats(ee_object):
+    return await gee_interface.get_info_async(ee_object)
+
+
+# Fetch asset info
+info = await gee_interface.get_asset_async(asset_id)
+
+# List user's assets
+assets = await gee_interface.get_assets_async(folder)
+
+# Get computed value
+result = await gee_interface.get_info_async(ee_object)
+
+# Export to Drive or Assets
+await gee_interface.export_table_to_drive_async(collection, description, folder)
+await gee_interface.export_image_to_asset_async(image, asset_id=asset_id)
+```
+
+`gee_interface.create_task(...)` remains available for legacy code paths, but it
+is not the scaffold default for new Solara apps.
+
+## 3. Directory Structure
+
+```
+my_module/
+├── solara_app.py              # Entry point
+├── run_solara.sh              # Dev run script (sources .env)
+├── .env                       # Environment variables
+├── requirements.txt           # Dependencies
+├── Dockerfile                 # Container build
+├── docker-compose.yml         # SEPAL platform deployment
+├── docker-compose.override.yml # Local dev overrides
+├── supervisord.conf           # Process management
+├── logging_config.toml        # Logging configuration
+├── component/
+│   ├── model/                 # State management
+│   │   ├── __init__.py
+│   │   ├── app_model.py       # UI state (steps, active tab, etc.)
+│   │   └── state_manager.py   # AppState with solara.reactive() (or traitlets Model)
+│   ├── tile/                  # Major UI sections (dialogs, panels)
+│   │   ├── __init__.py
+│   │   ├── upload.py
+│   │   ├── export.py
+│   │   └── landing.py
+│   ├── widget/                # Reusable Solara components
+│   │   ├── __init__.py
+│   │   ├── map.py             # SepalMap extension
+│   │   └── custom_widgets.py
+│   ├── scripts/               # Pure Python logic (no UI)
+│   │   ├── __init__.py
+│   │   └── calculations.py
+│   └── parameter/             # Constants, paths, config
+│       ├── __init__.py
+│       └── directory.py       # Local/remote file management
+└── assets/                    # Static files (CSS, images)
+```
+
+## 4. State Management
+
+### Option A: AppState singleton with `solara.reactive()` (required for new apps)
+
+```python
+# component/model/state_manager.py
+import solara
+
+class AppState:
+    def __init__(self):
+        self.file_path = solara.reactive(None)
+        self.aoi_data = solara.reactive(None)
+        self.results = solara.reactive(None)
+        self.is_processing = solara.reactive(False)
+
+    def is_ready_for_calculation(self) -> bool:
+        return self.file_path.value is not None
+
+app_state = AppState()
+
+# Usage in components:
+# from component.model import app_state
+# app_state.file_path.value = "/path/to/file"
+```
+
+### Option B: traitlets Model (legacy only, used by sepal_mgci, se.plan)
+
+```python
+# component/model/model.py
+from pysepal.model import Model
+import traitlets as t
+
+class MyModel(Model):
+    file_path = t.Unicode(None, allow_none=True).tag(sync=True)
+    results = t.Dict({}).tag(sync=True)
+
+    def __init__(self, gee_interface=None, sepal_client=None, **kwargs):
+        self.gee_interface = gee_interface
+        self.sepal_client = sepal_client
+        super().__init__(**kwargs)
+```
+
+### When to use which
+
+| Pattern                          | Use when                                             |
+| -------------------------------- | ---------------------------------------------------- |
+| `AppState` + `solara.reactive()` | New apps, pure Solara components                     |
+| traitlets `Model`                | Existing apps, ipyvuetify widgets, need `.observe()` |
+
+## 5. Map Integration
+
+```python
+from pysepal import mapping as sm
+from pysepal.sepalwidgets.vue_app import MapApp
+from pysepal.solara import get_current_theme_state
+
+@solara.component
+def Page():
+    gee_interface = get_current_gee_interface()
+
+    # Session-scoped theme state (dark/light mode; auto follows system)
+    theme_state = get_current_theme_state()
+
+    # Create map with GEE support (memoized to avoid re-creation)
+    sepal_map = solara.use_memo(
+        lambda: sm.SepalMap(
+            gee=True,
+            gee_interface=gee_interface,
+            theme_state=theme_state,
+        ),
+        [id(gee_interface)],
+    )
+
+    # Use MapApp layout (map background + sidebar + right panel)
+    MapApp.element(
+        app_title="My App",
+        app_icon="mdi-earth",
+        main_map=[sepal_map.get_map_widget()],
+        theme_state=theme_state,
+        steps_data=[...],
+        right_panel_content=[...],
+    )
+```
+
+> `SepalMap(theme_toggle=...)` / `MapApp.element(theme_toggle=[...])` still
+> work but emit a `DeprecationWarning`. See `migration-notes-v3.4.md` § 7.
+
+## 6. Button & Icon Sizing
+
+The right panel and dialogs are narrow (~450 px). Use `small=True` on all
+buttons and chips inside them. Navigation drawer icons keep default size.
+
+| Context                                                      | Rule                                           |
+| ------------------------------------------------------------ | ---------------------------------------------- |
+| Buttons in right panel / sidebar content                     | `small=True` (add `block=True` for full-width) |
+| Icon-only buttons (close, edit, toolbar)                     | `icon=True, small=True`                        |
+| Chips (stats, tags, year selectors)                          | `small=True` (or `x_small=True` for inline)    |
+| Dialog action buttons (OK / Cancel)                          | `small=True`                                   |
+| Navigation drawer icons (`steps_data`, `right_panel_config`) | Default size — never `small=True`              |
+
+## 7. Deployment
+
+### `.env` file
+
+```bash
+SOLARA_TEST=true                    # Use get_sepal_headers_from_auth() for local dev
+DEPLOY_ENV=sepal_solara             # Marks SEPAL Solara mode; do not branch to local user-file I/O
+LOCAL_SEPAL_USER=admin              # Dev credentials
+LOCAL_SEPAL_PASSWORD=yourpassword
+SEPAL_HOST=yourinstance.sepal.io    # SEPAL platform host
+```
+
+### `run_solara.sh` (local dev)
+
+```bash
+#!/bin/bash
+SOLARA_FILE="${1:-solara_app.py}"
+PORT="${2:-8900}"
+
+# Source .env
+while IFS= read -r line; do
+  [[ $line =~ ^#.*$ || -z $line ]] && continue
+  if [[ $line =~ ^([^=]+)=(.*)$ ]]; then
+    export "${BASH_REMATCH[1]}=${BASH_REMATCH[2]}"
+  fi
+done < .env
+
+solara run "$SOLARA_FILE" --port $PORT --no-open
+```
+
+### `Dockerfile`
+
+```dockerfile
+FROM mambaorg/micromamba:latest
+
+USER root
+RUN apt-get update && apt-get install -y supervisor netcat-openbsd curl && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /usr/local/lib/myapp
+
+COPY requirements.txt .
+RUN micromamba create -n myapp python=3.10 pip -c conda-forge -y && \
+    micromamba run -n myapp pip install -r requirements.txt
+
+COPY . .
+COPY supervisord.conf /etc/supervisor/conf.d/supervisord.conf
+
+EXPOSE 8765
+CMD ["/usr/bin/supervisord", "-c", "/etc/supervisor/conf.d/supervisord.conf"]
+```
+
+### `supervisord.conf`
+
+```ini
+[supervisord]
+nodaemon=true
+
+[program:solara]
+command=bash -c "micromamba run -n myapp solara run solara_app.py --host=0.0.0.0 --root-path=/api/app-launcher/my_module --production --port=8765"
+autostart=true
+autorestart=true
+stderr_logfile=/dev/stderr
+stderr_logfile_maxbytes=0
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
+```
+
+### `docker-compose.yml`
+
+```yaml
+services:
+  myapp:
+    build: .
+    volumes:
+      - ${EE_CREDENTIALS_PATH:-${HOME}/.config/earthengine/credentials}:/root/.config/earthengine/credentials
+    environment:
+      FORWARDED_ALLOW_IPS: "*"
+      SEPAL_HOST: "${SEPAL_HOST}"
+      SOLARA_TEST: "${SOLARA_TEST:-false}"
+      LOCAL_SEPAL_USER: "${LOCAL_SEPAL_USER}"
+      LOCAL_SEPAL_PASSWORD: "${LOCAL_SEPAL_PASSWORD}"
+    ports:
+      - "8765:8765"
+    healthcheck:
+      test: ["CMD", "nc", "-z", "localhost", "8765"]
+      interval: 5s
+      timeout: 3s
+      retries: 5
+    restart: always
+    networks:
+      - sepal
+
+networks:
+  sepal:
+    external: true
+```
+
+## 8. Multi-User Session Flow
+
+```
+Browser Tab Opens
+    ↓
+Solara creates new kernel
+    ↓
+@solara.lab.on_kernel_start → setup_sessions() → SessionManager initialized
+    ↓
+Page() renders → @with_sepal_sessions waits for HTTP headers
+    ↓
+Headers arrive → SessionManager.create_session():
+    - Extracts username from SepalHeaders
+    - Creates EESession with user's credentials
+    - Creates GEEInterface(gee_session)
+    - Creates SepalClient(session_id, module_name)
+    - Creates GDriveInterface(sepal_headers)
+    - Stores all in _sessions[kernel_id]
+    ↓
+Page() re-renders → get_current_gee_interface() returns user's GEEInterface
+    ↓
+Components use authenticated interfaces for GEE/SEPAL/Drive operations
+    ↓
+Tab closes → kernel cleanup → SessionManager.cleanup_session(kernel_id)
+```
+
+Each browser tab = separate kernel = isolated session with its own credentials.
+
+## 9. Local Development vs SEPAL Deployment
+
+| Aspect               | Local Dev                                              | SEPAL Platform                                |
+| -------------------- | ------------------------------------------------------ | --------------------------------------------- |
+| Auth headers         | `get_sepal_headers_from_auth()` via `SOLARA_TEST=true` | Real HTTP headers from SEPAL proxy            |
+| User files           | `SepalClient` against `SEPAL_HOST`                     | `SepalClient` from session headers            |
+| Container filesystem | Code and static assets only                            | Code and static assets only                   |
+| GEE credentials      | `~/.config/earthengine/credentials`                    | SEPAL-provided per user                       |
+| URL                  | `http://localhost:8900`                                | `https://sepal.io/api/app-launcher/my_module` |
+| Run command          | `./run_solara.sh`                                      | `supervisord` in Docker                       |
+
+### Handling user files
+
+```python
+sepal_client = get_current_sepal_client()
+folder = sepal_client.get_remote_dir(
+    f"{sepal_client.results_path}/exports",
+    parents=True,
+)
+sepal_client.set_file(f"{folder}/result.json", json_text, overwrite=True)
+payload = sepal_client.get_file(f"{folder}/result.json", parse_json=True)
+```
+
+## 10. Reference Apps
+
+| App                   | Location                    | Key patterns                                                    |
+| --------------------- | --------------------------- | --------------------------------------------------------------- |
+| **sbae-design**       | `~/1_modules/sbae-design/`  | AppState singleton, MapApp layout, use_thread, strategy pattern |
+| **sepal_mgci**        | `~/1_modules/sepal_mgci/`   | traitlets Model, GEE async tasks, deferred calculations, Docker |
+| **se.plan**           | `~/1_modules/se.plan/`      | Recipe model, GEE interface injection, multi-panel layout       |
+| **pysepal templates** | `pysepal/templates/solara/` | Minimal examples (simple_app, map_app, aoi_app)                 |

--- a/docs/guides/solara-export.md
+++ b/docs/guides/solara-export.md
@@ -1,0 +1,419 @@
+# Solara Export with pysepal
+
+> Use this guide when a pysepal Solara app needs to let users export an
+> `ee.Image` or `ee.FeatureCollection` to an Earth Engine asset, Google Drive,
+> or the SEPAL workspace.
+
+## What the Export Component Is
+
+The export component is a single launcher button plus a modal dialog that
+drives an async submission engine. It is designed to be dropped into any
+pysepal Solara app that has GEE-produced layers users might want to take out
+of the app.
+
+It provides:
+
+- one `ExportLauncher` button that opens a dialog
+- a dialog that offers Earth Engine asset / Google Drive / SEPAL workspace as
+  destinations, with kind-appropriate options (image scale or table format)
+- an async engine that handles folder creation, task submission, Drive
+  staging for SEPAL targets, and cleanup
+- a controller hook (`use_export_dialog`) for when you need to drive the
+  dialog from a custom layout instead of the default launcher button
+- per-source deferred resolution so heavy `ee` computations only fire when
+  the user actually presses Export
+
+It does **not** provide:
+
+- `ee.ImageCollection` export — host apps must collapse to a single
+  `ee.Image` (e.g. with `.toBands()` or `.mosaic()`) before passing in
+- interactive visualization or symbology editing
+- a replacement for custom export flows that have their own UX
+  requirements — the controller hook is the extension point
+
+## Core Pieces
+
+The public surface lives in `pysepal.solara.components.export`:
+
+- `ExportLauncher` — the drop-in button + dialog component
+- `ExportSource` — dataclass declaring one exportable layer
+- `ResolvedExport` — dataclass returned by an `ExportSource.resolve()` call;
+  carries the concrete `ee` object and per-source defaults
+- `use_export_dialog(sources, …)` — controller hook (advanced layouts)
+- `ExportDialog` — the modal UI (used by `ExportLauncher`; also composable)
+- `submit_export_request(request, …)` — headless async submitter
+- `ExportResult` — structured return after a successful submission
+- `TABLE_FILE_FORMATS`, `DEFAULT_TABLE_FILE_FORMAT`,
+  `DEFAULT_IMAGE_FILE_FORMAT` — canonical file-format constants
+
+Conceptually:
+
+1. The parent declares a tuple of `ExportSource` objects.
+2. The parent renders `ExportLauncher(sources=...)`.
+3. The user clicks the button, picks an asset and destination, presses
+   Export.
+4. The engine submits the EE task and (for SEPAL targets) copies the
+   result file(s) from Drive into the workspace.
+5. A success/error toast is published through `NotificationProvider`.
+
+## Quickstart: One Source, One Button
+
+```python
+import ee
+import solara
+
+from pysepal.solara.components.export import ExportLauncher, ExportSource, ResolvedExport
+from pysepal.solara.notifications import NotificationProvider
+
+
+@solara.component
+def ExportsPanel(aoi: solara.Reactive[ee.Geometry]):
+    def _resolve_elevation() -> ResolvedExport:
+        dem = ee.Image("USGS/SRTMGL1_003").clip(aoi.value)
+        return ResolvedExport(
+            ee_object=dem,
+            default_name="SRTM_elevation",
+            region=aoi.value,
+            default_scale=30,
+        )
+
+    sources = (
+        ExportSource(
+            id="srtm-elevation",
+            label="SRTM elevation (m)",
+            kind="image",
+            resolve=_resolve_elevation,
+        ),
+    )
+
+    ExportLauncher(sources=sources, button_text=True)
+```
+
+Drop `NotificationProvider()` once in your app shell so the dialog has a
+place to publish success and error toasts. The notifications guide covers
+that pattern in full: see [`solara-notifications.md`](solara-notifications.md).
+
+## Declaring an `ExportSource`
+
+`ExportSource` is the parent-owned description of one exportable layer.
+
+```python
+ExportSource(
+    id="elevation",              # stable identifier, used as the Select value
+    label="SRTM elevation",       # user-visible label in the dropdown
+    kind="image",                 # "image" or "table" — must match what resolve() returns
+    resolve=_resolve_elevation,   # 0-arg callable, runs when user presses Export
+    description="",               # optional, currently unused in UI
+    disabled=False,               # greyed out in the Select when True
+    icon="",                       # optional mdi- icon name for future use
+)
+```
+
+Key rule: **`resolve` is called lazily**, not at mount. This is deliberate —
+your factory can stitch together `ee` objects that depend on the live AOI or
+other reactive state, and the computation only fires when the user commits
+to an export. Keep the factory pure-ish: it should return a `ResolvedExport`
+or raise on a clear error.
+
+If `resolve()` raises, the dialog surfaces the exception message via the
+notification system (falling back to an inline `solara.Warning` when no
+provider is mounted).
+
+## What `ResolvedExport` Carries
+
+`ResolvedExport` is the concrete payload the engine needs to submit the job.
+
+```python
+ResolvedExport(
+    ee_object=ee_object,             # ee.Image or ee.FeatureCollection
+    default_name="my_export",         # pre-fills the Export name field
+    region=aoi.value,                 # optional, used for image exports
+    default_scale=30,                 # optional, used for image exports
+    selectors=("ADM0_NAME",),          # optional, narrow table columns
+    gee_folder="my_module",           # optional, relative to user's asset root
+    drive_folder="",                  # optional, Drive folder name
+    sepal_folder="exports",           # optional, relative to module_results
+    table_file_format="SHP",         # canonical enum; see below
+    image_file_format="GEO_TIFF",    # canonical enum; see below
+    max_pixels=1_000_000_000,
+    max_vertices=None,
+    priority=None,
+    vis_params=None,                  # optional SEPAL viz to embed on image exports
+)
+```
+
+The user can override any destination-related field in the dialog. The
+`default_*` values just pre-fill the controls.
+
+## Carrying SEPAL Visualization Onto Exports
+
+When an app renders a styled `ee.Image` on the map and then exports the
+underlying classification (e.g. with `SepalMap.add_ee_layer(image, vis_params)`),
+the exported Earth Engine asset will not carry that styling — `vis_params`
+lives on the `EELayer`, not on the image. SEPAL's convention is to encode
+styling as image properties named `visualization_<index>_<key>`; SepalMap
+reads them on display, and Earth Engine asset exports preserve them, so any
+downstream consumer (another SEPAL recipe, the Code Editor) sees the styling
+automatically.
+
+Pass `vis_params` to `ResolvedExport` to opt into this:
+
+```python
+GFC_VIS_PARAMS = {
+    "name": "loss_year",
+    "type": "categorical",
+    "bands": ["classification"],
+    "palette": HEX_PALETTE,
+    "values": [*range(1, GFC_MAX_YEAR + 1), 30, 40, 50, 51],
+    "labels": ["loss 2001", ..., "non forest", "stable forest", "gain", "gain + loss"],
+}
+
+ExportSource(
+    id="gfc_classified",
+    label="GFC classified image",
+    kind="image",
+    resolve=lambda: ResolvedExport(
+        ee_object=classification,
+        default_name="gfc",
+        region=aoi.geometry(),
+        default_scale=30,
+        vis_params=GFC_VIS_PARAMS,
+    ),
+)
+```
+
+The dict shape mirrors the kwargs of
+`pysepal.mapping.visualization.set_viz_params` (the writer; inverse of
+`get_viz_params` used by SepalMap on display). Keys:
+
+| Key        | Type                                              | Notes                                                   |
+| ---------- | ------------------------------------------------- | ------------------------------------------------------- |
+| `name`     | `str`                                             | Logical name. Defaults to `"default"`.                  |
+| `type`     | `"continuous" \| "categorical" \| "rgb" \| "hsv"` | SepalMap infers from band count when omitted.           |
+| `bands`    | `Sequence[str]`                                   | One band for continuous/categorical; three for rgb/hsv. |
+| `min`      | scalar or `Sequence[float]`                       | Per-band minimum(s).                                    |
+| `max`      | scalar or `Sequence[float]`                       | Per-band maximum(s).                                    |
+| `palette`  | `Sequence[str]` or comma-joined string            | Hex colors.                                             |
+| `values`   | `Sequence[int]`                                   | Categorical class codes (palette[i] maps to values[i]). |
+| `labels`   | `Sequence[str]`                                   | Legend labels.                                          |
+| `inverted` | `Sequence[bool]`                                  | Per-band inversion flags.                               |
+
+Only applies to image-kind exports; ignored on table-kind sources. For
+multiple named visualizations on the same image, write them eagerly via
+`set_viz_params(image, ..., index=N)` before passing to `ResolvedExport`.
+
+## Destinations
+
+The dialog offers three destinations, each enabled based on runtime state:
+
+- **Earth Engine asset** (`gee`) — default. Submits
+  `projects.image.export` / `projects.table.export` to the user's EE project
+  asset root. The dialog shows a live preview hint:
+  `Will be exported as: projects/<user>/assets/<folder>/<name>`.
+- **Google Drive** (`drive`) — submits a Drive export task; no waiting for
+  completion inside the dialog.
+- **SEPAL workspace** (`sepal`) — requires a session-backed `SepalClient`.
+  Exports to Drive first, waits for completion, downloads the files, and
+  uploads them under `<module_results>/<sepal_folder>/`. Disabled (greyed
+  out) when `sepal_client` is None — i.e. when the app is not running
+  inside a SEPAL session.
+
+SEPAL workspace exports must stay on the `SepalClient` path. Do not stage,
+copy, or rewrite user export files in the container filesystem from host app
+code; let the export engine download bytes from Drive and upload them through
+`sepal_client.set_file(...)`.
+
+The engine creates any missing intermediate folders under the user's asset
+root before submitting an EE asset export.
+
+## File Formats: Use Canonical Enum Values
+
+ee-client's pydantic models validate file formats strictly. **Use the
+canonical REST-API enum strings**, not the human-friendly sepal_ui names:
+
+| What users see | What to store as `value` |
+| -------------- | ------------------------ |
+| GeoTIFF        | `"GEO_TIFF"`             |
+| GeoJSON        | `"GEO_JSON"`             |
+| Shapefile      | `"SHP"`                  |
+| CSV            | `"CSV"`                  |
+| KML / KMZ      | `"KML"` / `"KMZ"`        |
+
+The constants `DEFAULT_IMAGE_FILE_FORMAT = "GEO_TIFF"` and
+`DEFAULT_TABLE_FILE_FORMAT = "SHP"` already use the canonical values;
+`TABLE_FILE_FORMATS` maps friendly text labels to canonical values so users
+still see `"GeoJSON"` in the dropdown but the wire payload is `"GEO_JSON"`.
+
+Requires **ee-client >= 2.5.2** (enforced by pyproject.toml). 2.5.1 had a
+bug where the table→asset serializer emitted `driveExportOptions` for asset
+exports; 2.5.2 renamed it to `assetExportOptions`.
+
+## Multiple Sources
+
+Pass a tuple with more than one entry and the dialog groups them by kind in
+the Asset dropdown, with subheaders and a divider between `Images` and
+`Feature collections`:
+
+```python
+sources = (
+    ExportSource(id="dem",    label="Elevation (DEM)", kind="image", resolve=_resolve_dem),
+    ExportSource(id="slope",  label="Slope (degrees)",  kind="image", resolve=_resolve_slope),
+    ExportSource(id="aoi",    label="AOI polygons",      kind="table", resolve=_resolve_aoi),
+    ExportSource(id="points", label="Sample points",     kind="table", resolve=_resolve_points),
+)
+ExportLauncher(sources=sources, button_text=True)
+```
+
+When only one kind is present, the grouping and subheader are suppressed
+and the list renders flat — no need to do anything special for single-kind
+apps.
+
+To keep a layer visible but non-selectable (e.g., not ready yet), set
+`disabled=True` on that `ExportSource`.
+
+## The Dialog Body is Always Visible
+
+When no asset is selected, the Destination radio, Name field, and folder
+fields render but are disabled. The rationale is that users should see the
+structure of the form before committing to a selection — it telegraphs
+which options exist.
+
+Kind-specific widgets (image scale presets, table file format) only appear
+after a source is selected, because they are mutually exclusive — showing
+both would be misleading.
+
+The Export button stays disabled until a source is selected and the name
+field is non-empty.
+
+## Custom Layouts: `use_export_dialog`
+
+When the default `ExportLauncher` button doesn't fit — e.g., you want the
+trigger to live inside a toolbar menu, or you need to render the dialog
+from multiple trigger points — use the controller hook directly:
+
+```python
+from pysepal.solara.components.export import ExportDialog, use_export_dialog
+
+@solara.component
+def CustomExportsToolbar(sources):
+    controller = use_export_dialog(sources=sources)
+
+    solara.Button(
+        label="Export…",
+        icon_name="mdi-tray-arrow-down",
+        on_click=controller.open_dialog,
+    )
+    ExportDialog(controller=controller, title="Export layers")
+```
+
+`ExportDialogController` exposes everything you might want to drive from the
+outside:
+
+- `open` / `open_dialog()` / `close_dialog()` — dialog open state
+- `selected_target` / `selected_source_id` / `export_name` — reactive inputs
+- `task` — the underlying `solara.lab.use_task` handle (for pending/finished)
+- `result` — the last `ExportResult`
+- `submit_export()` / `cancel_export()` — programmatic controls
+- `sources` — the resolved tuple of `ExportSource`
+
+Keep the hook invocation unconditional at the top of the component — it
+registers solara reactives and effects per the usual rules of hooks.
+
+## Notifications and Timeouts
+
+On submission outcome the dialog publishes one toast through the notifier
+returned by `use_notifications()`:
+
+- success → `Notifier.success(message, timeout=EXPORT_SUCCESS_TOAST_TIMEOUT)`
+- error → `Notifier.error(exception_message)`
+- cancel → `Notifier.cancel("Export cancelled.")` (or a local-wait message
+  if the remote task is still running)
+
+The success toast uses a longer timeout (8s by default, vs the 3s global
+default) because it carries a copyable asset path or task id. Tune the
+constant in `pysepal/solara/components/export_hook.py:EXPORT_SUCCESS_TOAST_TIMEOUT`
+if your app wants a different duration.
+
+All `Notifier` methods accept an optional `timeout` kwarg for per-call
+control:
+
+```python
+notifications = use_notifications()
+notifications.success("Export submitted", timeout=12.0)
+notifications.warning("Almost done…")  # uses type default (3s)
+```
+
+When no `NotificationProvider` is mounted, the dialog falls back to an
+inline `solara.Success` / `solara.Error` / etc. rendered inside the card.
+
+## The Modal Stays Open After Success
+
+The dialog does NOT auto-close when the task completes. This is
+intentional: users often want to copy the resulting asset path, note the
+task id, or fire off a second export with slightly different options.
+Users close the dialog themselves.
+
+If your app needs the old auto-close behavior, set `controller.open.value = False`
+inside your own `use_effect` watching `controller.result.value`.
+
+## Testing Components That Render `ExportLauncher`
+
+Two test-side helpers live in `tests/test_solara/test_export_component.py`:
+
+```python
+def _render(factory, *args, **kwargs):
+    """Render a Solara widget with a running event loop so ``use_task`` can schedule."""
+    async def _runner():
+        return factory(*args, **kwargs)
+    return asyncio.run(_runner())
+
+
+def _render_preselected_dialog(source, *, target="gee"):
+    """Render ExportDialog with a source preselected and the dialog open."""
+    @solara.component
+    def _Harness():
+        controller = use_export_dialog(
+            sources=[source],
+            gee_interface=MagicMock(),
+            drive_interface=MagicMock(),
+        )
+        def _preselect():
+            controller.selected_source_id.set(source.id)
+            controller.selected_target.set(target)
+            controller.open.set(True)
+        solara.use_effect(_preselect, [])
+        return ExportDialog(controller=controller, title="Test")
+    async def _runner():
+        return _Harness.widget()
+    return asyncio.run(_runner())
+```
+
+Key points:
+
+- `.widget()` in a synchronous test fails with
+  `RuntimeError: no running event loop` because Solara's `use_task`
+  schedules via `asyncio.create_task`. Wrap the render in `asyncio.run` to
+  provide a loop during the mount.
+- Post-selection contracts (e.g. "destination is a RadioGroup", "image
+  scale uses BtnToggle not a Slider") require the dialog to be in a
+  selected state. The preselection harness drives the controller there
+  before the walk.
+
+## Wire Into the Default Scaffold
+
+When scaffolding a new pysepal Solara app that produces exportable GEE
+layers:
+
+- mount `NotificationProvider()` once in the app shell (see the
+  notifications guide)
+- collect the app's exportable layers into a tuple of `ExportSource`
+  objects, with `resolve` reading from your AppState or props
+- drop `ExportLauncher(sources=sources)` into the right side panel or
+  toolbar — use `button_text=True` inside collapsible panels where the
+  pysepal convention is `small=True, block=True`
+- avoid building a second custom export UX unless the dialog cannot cover
+  your requirements; in that case prefer the `use_export_dialog` hook over
+  re-implementing submission logic
+
+The reference integration lives at
+`pysepal/templates/solara/solara_map_app/aoi_all_methods_mapapp.py`.

--- a/docs/guides/solara-gee-patterns.md
+++ b/docs/guides/solara-gee-patterns.md
@@ -1,0 +1,543 @@
+# Solara GEE Patterns
+
+> New pysepal Solara apps must use `solara.reactive()` AppState state and
+> `solara.lab.use_task` for non-blocking Earth Engine work.
+> Do not scaffold new traitlets `.observe()` or `gee_interface.create_task()`
+> flows for new apps.
+
+## Session-Backed GEE Is the Default
+
+For new Solara apps, the default pysepal setup is:
+
+1. `@with_sepal_sessions` waits for SEPAL headers.
+2. `SessionManager` creates `EESession(sepal_headers=...)`.
+3. `SessionManager` wraps that session in `GEEInterface`.
+4. Components retrieve that same session-backed interface with
+   `get_current_gee_interface()`.
+
+That means new Solara apps should assume they are using the full async
+`ee-client` path backed by SEPAL headers.
+
+In that mode, `GEEInterface` exposes both sync and async methods, but they do
+not serve the same purpose:
+
+- The `*_async` methods are the primary API for new Solara apps.
+- The sync methods (`get_info`, `get_map_id`, `get_assets`, etc.) are bridge
+  methods for blocking or legacy code.
+- `GEEInterface`'s private event loop exists mainly to support those blocking
+  sync wrappers and `gee_interface.create_task()`.
+
+There is no separate public "async GEE getter". Use the regular
+`get_current_gee_interface()` and call its `*_async` methods.
+
+## Why `use_task` over `use_thread`
+
+`solara.use_thread` works well for simple synchronous worker functions, but new
+pysepal GEE apps should prefer `solara.lab.use_task` because it:
+
+- Supports `async def` task functions, which matches the session-backed
+  `GEEInterface` API.
+- Returns a stable task object across renders with `.pending`, `.finished`,
+  `.error`, `.exception`, `.value`, `.cancel()`, and `.is_current()`.
+- Supports `dependencies=None`, which gives a clean button-triggered pattern
+  instead of a reactive boolean trigger.
+- Lets you opt out of thread-per-task execution with `prefer_threaded=False`,
+  which is the right setting for GEE-bound coroutine tasks.
+
+Use `use_thread` only for genuinely synchronous local work.
+
+## Event Loop Rule for GEE
+
+The important event-loop detail is not `GEEInterface`'s private loop. In the
+session-backed path, `gee_interface.get_info_async(...)` delegates directly to
+`ee-client` awaitables.
+
+The real Solara risk is `use_task(prefer_threaded=True)`. Solara can run a
+coroutine task in a separate thread with its own event loop. At the same time,
+`EESession` owns asyncio coordination primitives such as locks and semaphores.
+Those primitives bind lazily to the first event loop that needs them.
+
+Two consequences follow:
+
+- Light testing can look fine. If a lock or semaphore is never contended, the
+  code may appear to work across loops.
+- Under contention, or once waiters are created, asyncio can raise
+  `RuntimeError: ... is bound to a different event loop`.
+
+**The rule for new Solara GEE apps:**
+
+- Use `await gee_interface.*_async(...)` directly for Earth Engine calls.
+- When those calls live inside `solara.lab.use_task`, set
+  `prefer_threaded=False` so the coroutine stays on Solara's current event
+  loop.
+- Use `asyncio.to_thread()` only for truly blocking local work, not for the
+  normal SessionManager-backed GEE path.
+
+```python
+# CORRECT — session-backed Solara GEE call
+result = await gee_interface.get_info_async(ee_object)
+
+# CORRECT — keep GEE coroutine tasks on Solara's loop
+@solara.lab.use_task(dependencies=None, raise_error=False, prefer_threaded=False)
+async def gee_job(request):
+    return await gee_interface.get_info_async(request.ee_object)
+
+# NOT THE DEFAULT FOR NEW SOLARA GEE APPS
+result = await asyncio.to_thread(gee_interface.get_info, ee_object)
+```
+
+## Canonical Pattern
+
+When a page already retrieved `gee_interface = get_current_gee_interface()`, pass that same object down into `SepalMap` and any GEE-aware child components instead of inventing a parallel `async_gee_interface` path. This keeps one SessionManager-backed interface flowing through the tree.
+
+The standard pattern for new apps is:
+
+1. Keep request inputs, loading state, error state, result state, and submitted
+   background task metadata in an `AppState` singleton built from
+   `solara.reactive()`.
+2. Get `gee_interface = get_current_gee_interface()` inside the Solara
+   component.
+3. Define a `@solara.lab.use_task(dependencies=None, raise_error=False, prefer_threaded=False)` task in the component.
+4. On button click, build an immutable request snapshot and call the task
+   manually with that snapshot.
+5. Let the task return a small outcome object instead of mutating AppState
+   directly.
+6. Mirror the task state back into AppState in `solara.use_effect`.
+
+Three rules matter:
+
+- Await the session-backed `GEEInterface` async methods directly.
+- Never read live reactive inputs inside a long-running task after it starts.
+  Snapshot inputs first and pass them as task arguments.
+- Pass the shared `gee_interface` to every helper that accepts one. Functions
+  like `process_admin(gee_interface=...)` fall back to `GEEInterface()` when
+  no interface is provided, which creates a throwaway instance with its own
+  event loop and daemon thread on every call. This wastes resources and
+  produces spurious "Closing GEEInterface" log spam on cancel/retry cycles.
+
+## Loading, Error, and Result State in AppState
+
+For a scaffolded app, AppState should usually contain at least:
+
+- The current user inputs.
+- `loading`: `bool`
+- `error_message`: `str | None`
+- `result`: computed direct result or `None`
+- `submitted_task`: background task metadata or `None`
+
+The task itself is not the source of truth for business state. The task is the
+execution engine; AppState is the UI state.
+
+This split keeps the pattern predictable:
+
+- Button click clears stale result state and starts the task.
+- `use_task` handles background execution.
+- `use_effect` copies the finished/error state into AppState.
+- The UI renders only from AppState.
+
+## Direct Computation vs Background Submission
+
+Use direct computation (via `await gee_interface.get_info_async(...)`) when:
+
+- The result is small enough to render directly in the UI.
+- The call usually finishes in a few seconds.
+- You need an immediate value such as statistics, map bounds, map ids, or asset
+  metadata.
+
+Use background submission (via `await gee_interface.export_*_async(...)`) when:
+
+- The work produces a file or asset instead of a small in-memory result.
+- The reducer is large enough that timeout or memory errors are plausible.
+- The user can continue working while Earth Engine finishes the job remotely.
+
+Use `asyncio.to_thread(...)` only when a non-GEE step is actually blocking,
+for example:
+
+- local file I/O through a synchronous library
+- CPU-heavy parsing or preprocessing
+- legacy synchronous APIs that have no async equivalent
+
+## Minimal Working Example
+
+This example shows the full scaffold pattern in one file. It uses direct async
+GEE calls on the session-backed interface.
+
+```python
+from dataclasses import dataclass
+from typing import Any
+
+import ee
+import solara
+
+from pysepal.solara import (
+    get_current_gee_interface,
+    setup_sessions,
+    setup_solara_server,
+    setup_theme_colors,
+    with_sepal_sessions,
+)
+from pysepal.solara.components.task_button import TaskButtonComponent, use_task_button
+
+setup_solara_server(extra_asset_locations=[])
+
+
+@solara.lab.on_kernel_start
+def on_kernel_start():
+    return setup_sessions()
+
+
+class AppState:
+    def __init__(self):
+        self.asset_id = solara.reactive("USGS/SRTMGL1_003")
+        self.scale = solara.reactive(90)
+        self.loading = solara.reactive(False)
+        self.error_message = solara.reactive(None)
+        self.result = solara.reactive(None)
+
+
+app_state = AppState()
+
+
+@dataclass(frozen=True, slots=True)
+class StatsRequest:
+    asset_id: str
+    scale: int
+
+
+async def run_stats_request(gee_interface, request: StatsRequest) -> dict[str, Any]:
+    image = ee.Image(request.asset_id).select(0)
+    region = ee.Geometry.BBox(-123.6, 37.0, -121.8, 38.4)
+
+    stats_object = image.reduceRegion(
+        reducer=ee.Reducer.mean().combine(
+            reducer2=ee.Reducer.minMax(),
+            sharedInputs=True,
+        ),
+        geometry=region,
+        scale=request.scale,
+        maxPixels=1_000_000_000,
+    )
+
+    return await gee_interface.get_info_async(stats_object)
+
+
+@solara.component
+def StatsPanel():
+    gee_interface = get_current_gee_interface()
+
+    @solara.lab.use_task(
+        dependencies=None,
+        raise_error=False,
+        prefer_threaded=False,
+    )
+    async def gee_job(request: StatsRequest) -> dict[str, Any]:
+        return await run_stats_request(gee_interface, request)
+
+    def sync_task_state():
+        app_state.loading.value = gee_job.pending
+
+        if gee_job.pending or gee_job.cancelled:
+            return
+
+        if gee_job.error:
+            app_state.error_message.value = str(gee_job.exception)
+            app_state.result.value = None
+            return
+
+        if gee_job.finished:
+            app_state.error_message.value = None
+            app_state.result.value = gee_job.value
+
+    solara.use_effect(
+        sync_task_state,
+        [
+            gee_job.pending,
+            gee_job.cancelled,
+            gee_job.finished,
+            gee_job.error,
+            gee_job.value,
+            gee_job.exception,
+        ],
+    )
+
+    def start_run():
+        request = StatsRequest(
+            asset_id=app_state.asset_id.value,
+            scale=app_state.scale.value,
+        )
+        app_state.loading.value = True
+        app_state.error_message.value = None
+        app_state.result.value = None
+        gee_job(request)
+
+    with solara.Column():
+        solara.InputText("Image asset id", value=app_state.asset_id)
+        solara.InputInt("Scale", value=app_state.scale)
+        btn_props = use_task_button(gee_job, on_start=start_run)
+        TaskButtonComponent(label="Run", **btn_props, small=True)
+
+        if app_state.loading.value:
+            solara.Info("Running Earth Engine request...")
+            solara.ProgressLinear(value=True)
+
+        if app_state.error_message.value:
+            solara.Error(app_state.error_message.value)
+        elif app_state.result.value is not None:
+            solara.Success(f"Direct result: {app_state.result.value}")
+
+
+@solara.component
+@with_sepal_sessions(module_name="my_solara_app")
+def Page():
+    setup_theme_colors()
+    StatsPanel()
+```
+
+## Notes on the Example
+
+- `dependencies=None` makes the task manual. It only runs when the user clicks a
+  button.
+- The request snapshot is a frozen dataclass. The task always runs against the
+  exact inputs that were visible when the user clicked.
+- The task returns a value. It does not mutate AppState directly.
+- `sync_task_state()` is the only place that copies task state into AppState.
+- `prefer_threaded=False` is deliberate. For session-backed GEE coroutines, we
+  want one stable event loop, not a per-task thread loop.
+
+## Recommended Scaffold Boilerplate
+
+For new apps, the scaffolder should generate:
+
+- An `AppState` with `loading`, `error_message`, `result`, and any
+  background-submission metadata the workflow needs.
+- A request dataclass and, when useful, an outcome dataclass.
+- A `use_task(dependencies=None, raise_error=False, prefer_threaded=False)`
+  hook inside the page or main feature component.
+- A `solara.use_effect` block that mirrors the task state into AppState.
+- A pure async function in `component/scripts/` that receives
+  `gee_interface` plus the request snapshot and awaits `gee_interface.*_async`
+  methods directly.
+
+## Blocking I/O in Solara Components
+
+`use_effect` runs synchronously on the render thread. Blocking I/O in a
+`use_effect` freezes the UI. Solara recommends `use_task` or `use_thread`
+for anything over ~100 ms.
+
+For GEE/container apps, user-file I/O is not local filesystem I/O. Always read,
+write, list, and create user files through the session `SepalClient`. Do not
+wrap `Path.open`, `Path.write_text`, `os.listdir`, `os.walk`, `glob`, or
+server-local `gpd.read_file(path)` calls in `asyncio.to_thread()` for user
+workspace data; that only moves an unsafe container-filesystem access off the
+render thread. If a library accepts bytes or a file-like object, first load the
+user's file with `sepal_client.get_file(...)` and pass an in-memory object. If
+the library only accepts local paths, do not wire that workflow into a
+GEE/container app until there is a remote-aware pysepal adapter for it.
+
+**For async task functions** that read user files, keep the file access through
+`SepalClient` and move the synchronous HTTP/parsing work off the render thread:
+
+```python
+import io
+
+async def load_user_csv(sepal_client, remote_path: str):
+    payload = await asyncio.to_thread(sepal_client.get_file, remote_path)
+    return await asyncio.to_thread(pd.read_csv, io.BytesIO(payload))
+```
+
+**For component-internal loading** (column lists, metadata), use `use_task`
+instead of doing the read directly in `use_effect`:
+
+```python
+async def _load_columns(sepal_client, remote_path: str):
+    payload = await asyncio.to_thread(sepal_client.get_file, remote_path)
+    frame = await asyncio.to_thread(pd.read_csv, io.BytesIO(payload), nrows=0)
+    return list(frame.columns)
+
+column_task = solara.lab.use_task(
+    _load_columns, dependencies=None, raise_error=False, prefer_threaded=False,
+)
+
+def on_file_change():
+    if remote_path.value:
+        column_task(sepal_client, remote_path.value)
+
+solara.use_effect(on_file_change, [remote_path.value])
+```
+
+The `use_effect` triggers the task (instant), the task uses `SepalClient` and
+does parsing in a thread (non-blocking), and a second `use_effect` mirrors the result into
+reactive state.
+
+## AOI Method Restrictions
+
+AoiView's `methods` parameter controls which selection methods are available.
+Not all methods are safe in all deployment contexts.
+
+| Method       | Requires              | Safe in GEE/container apps          | Safe in local/Voila    |
+| ------------ | --------------------- | ----------------------------------- | ---------------------- |
+| `ADMIN0/1/2` | GEE (GAUL) or GADM    | Yes                                 | Yes                    |
+| `DRAW`       | Map + DrawControl     | Yes                                 | Yes                    |
+| `ASSET`      | GEE asset access      | Yes                                 | Yes (with credentials) |
+| `SHAPE`      | Local filesystem read | **No** — assumes server-local paths | Yes                    |
+| `POINTS`     | Local filesystem read | **No** — same as SHAPE              | Yes                    |
+
+### GEE / Container apps (multi-user, Docker)
+
+Restrict to methods that don't read local files:
+
+```python
+AoiView(
+    value=aoi_data,
+    methods=["-SHAPE", "-POINTS"],  # exclude file-based methods
+    gee=True,
+    map_=sepal_map,
+)
+```
+
+Or explicitly include only what you need:
+
+```python
+AoiView(
+    value=aoi_data,
+    methods=["ADMIN0", "ADMIN1", "ADMIN2", "DRAW", "ASSET"],
+    gee=True,
+    map_=sepal_map,
+)
+```
+
+SHAPE and POINTS read files with `gpd.read_file` / `pd.read_csv` via
+`asyncio.to_thread`. While this no longer blocks the event loop, the file
+paths are server-local and may not resolve to the user's intended files in
+a multi-user container. Use ASSET for GEE-backed vector data instead.
+
+### Local / Voila apps (single-user)
+
+All methods are safe:
+
+```python
+AoiView(
+    value=aoi_data,
+    methods="ALL",
+    gee=False,
+    map_=sepal_map,
+)
+```
+
+## Async Button Convention
+
+All buttons that trigger async work must use `TaskButtonComponent` — a single
+toggle button that switches between action and cancel states. Do not render a
+separate cancel button below the action button.
+
+```python
+from pysepal.solara.components.task_button import TaskButtonComponent, use_task_button
+
+task = solara.lab.use_task(
+    my_async_fn, dependencies=None, raise_error=False, prefer_threaded=False,
+)
+cancel_reason = solara.use_ref(None)
+
+# Effect mirrors task state → app state (always use full dependency set)
+def handle_task_state():
+    if task.pending:
+        app_state.loading.value = True
+        return
+    app_state.loading.value = False
+    if task.finished and task.value is not None:
+        app_state.result.value = task.value
+    elif task.error:
+        app_state.error_message.value = str(task.exception)
+    elif task.cancelled:
+        if cancel_reason.current == "user":
+            app_state.error_message.value = "Cancelled"
+        cancel_reason.current = None
+
+solara.use_effect(
+    handle_task_state,
+    [task.pending, task.finished, task.error, task.cancelled],
+)
+
+def start():
+    cancel_reason.current = None
+    app_state.loading.value = True
+    task(StatsRequest(asset_id=app_state.asset_id.value, scale=app_state.scale.value))
+
+btn_props = use_task_button(task, on_start=start, cancel_reason_ref=cancel_reason)
+TaskButtonComponent(label="Run", **btn_props, small=True, block=True)
+```
+
+### Rules
+
+1. Task functions return outcomes — never mutate reactive state directly.
+2. Build an immutable request snapshot at click time.
+3. Single toggle button — no separate cancel button. Ever.
+4. `prefer_threaded=False` for GEE coroutines.
+5. `task.value is not None` — never use bare truthiness (DataFrames can be falsey).
+6. Idempotent map operations — use stable layer keys, replace not accumulate.
+7. Full effect dependencies — `[task.pending, task.finished, task.error, task.cancelled]`.
+
+### Non-GEE blocking I/O
+
+Wrap sync functions that do CPU-heavy work or read packaged, non-user assets
+with `asyncio.to_thread` inside the `use_task` async function. The button
+wiring is identical:
+
+```python
+async def compute_summary(request):
+    result = await asyncio.to_thread(build_summary_table, request.records)
+    return SummaryOutcome(rows=result)
+
+task = solara.lab.use_task(compute_summary, dependencies=None, raise_error=False, prefer_threaded=False)
+btn_props = use_task_button(task, on_start=lambda: task(snapshot))
+TaskButtonComponent(label="Compute", **btn_props, block=True)
+```
+
+### Cancel semantics
+
+| Task type                           | What `task.cancel()` does                                               |
+| ----------------------------------- | ----------------------------------------------------------------------- |
+| GEE async (`get_info_async`, etc.)  | Stops the local coroutine                                               |
+| Remote EE export (`export_*_async`) | Stops local wait — does **not** cancel the remote job                   |
+| `asyncio.to_thread(sync_fn)`        | Cancels the async wrapper; thread keeps running but result is discarded |
+
+## When `asyncio.to_thread()` Is Still Appropriate
+
+`asyncio.to_thread()` is still valid in Solara apps. It is just not the default
+pattern for SessionManager-backed GEE calls.
+
+Use it for:
+
+- blocking reads of packaged app assets or archive libraries that are not user
+  workspace files
+- CPU-heavy synchronous transformations
+- legacy sync-only helpers that are unrelated to the session-backed GEE path
+- intentionally using the local single-user `GEEInterface` sync bridge outside
+  the standard SEPAL-header Solara architecture
+
+## `GEEInterface` Notes
+
+No functional `GEEInterface` changes are required for this pattern.
+
+The existing async API surface is sufficient for new Solara apps. The sync API
+surface remains useful for notebooks, local scripts, and legacy code. The main
+documentation requirement is to describe the intended Solara usage correctly:
+new session-backed apps should be async-first.
+
+## Notifications for Async Work
+
+When a task is user-visible, pair `solara.lab.use_task` with the pysepal
+notification system instead of inventing a separate alert flow.
+
+Default pattern:
+
+1. Mount `NotificationProvider()` once in the page or shared layout.
+2. Call `use_notifications()` inside the component that owns the task.
+3. Wrap the async body in `with notifications.track(...):`.
+4. Publish final success, error, or cancel feedback after the task settles.
+
+Use notifications for UX, not persistence. The notification bus is kernel-scoped
+and in-memory.
+
+For detailed shell placement, route/kernel scope, and fallback behavior, read
+[Solara Notifications](./solara-notifications.md).

--- a/docs/guides/solara-mapapp-component.md
+++ b/docs/guides/solara-mapapp-component.md
@@ -1,0 +1,146 @@
+# MapAppComponent — Solara-native MapApp layout
+
+`MapAppComponent` is a first-class Solara component that replaces the
+legacy `MapApp(v.VuetifyTemplate)`. It is usable with `with` syntax,
+exposes typed dataclass props, auto-wires `ThemeState` / `Translator`,
+and preserves the visual design of the original `MapApp.vue`
+(drawer, narrow-mode bottom sheet, dialog steps, right panel).
+
+```{warning}
+The legacy `pysepal.sepalwidgets.vue_app.MapApp` still works but emits a
+`DeprecationWarning`. Migrate to `MapAppComponent` for new code.
+```
+
+## Quick start
+
+```python
+import solara
+
+from pysepal.solara import (
+    MapAppComponent,
+    NotificationProvider,
+    get_current_theme_state,
+)
+from pysepal.solara.components.layout import (
+    ExternalLink,
+    PanelSection,
+    RightPanelConfig,
+    StepConfig,
+)
+
+
+@solara.component
+def AoiStep():
+    solara.Markdown("AOI selector goes here")
+
+
+@solara.component
+def LayerControls():
+    solara.Markdown("Layer toggles go here")
+
+
+@solara.component
+def Page():
+    NotificationProvider()
+    theme_state = get_current_theme_state()
+    sepal_map = use_sepal_map(theme_state=theme_state)  # your own factory
+
+    with MapAppComponent(
+        app_title="My App",
+        app_icon="mdi-earth",
+        sepal_map=sepal_map,
+        theme_state=theme_state,
+        steps=[
+            StepConfig(id=1, name="AOI", icon="mdi-map", content=AoiStep),
+        ],
+        right_panel_config=RightPanelConfig(title="Tools", width=400),
+        right_panel_content=[
+            PanelSection(title="Layers", icon="mdi-layers", content=LayerControls),
+        ],
+        external_links=[ExternalLink("Docs", "https://docs.example")],
+    ):
+        # Optional children — rendered in a slot above the main map.
+        MapToolbar()
+```
+
+## Typed props
+
+| Prop                    | Type                              | Purpose                                       |
+| ----------------------- | --------------------------------- | --------------------------------------------- |
+| `app_title`             | `str`                             | Drawer header text.                           |
+| `app_icon`              | `str`                             | Drawer header MDI icon.                       |
+| `sepal_map`             | `Optional[Widget]`                | Map widget rendered in the main area.         |
+| `steps`                 | `Sequence[StepConfig]`            | Left-drawer step entries.                     |
+| `right_panel_config`    | `Optional[RightPanelConfig]`      | Display config for the right panel chrome.    |
+| `right_panel_content`   | `Sequence[PanelSection]`          | Section list rendered inside the right panel. |
+| `right_panel_open`      | `bool` or `solara.Reactive[bool]` | Controlled open/close state.                  |
+| `current_step`          | `Optional[int]` reactive          | Controlled active step id.                    |
+| `initial_step`          | `Optional[int]`                   | Step auto-activated on first mount.           |
+| `theme_state`           | `Optional[ThemeState]`            | Defaults to `get_current_theme_state()`.      |
+| `translator`            | `Optional[Translator]`            | Drives the locale selector when provided.     |
+| `external_links`        | `Sequence[ExternalLink]`          | Drawer footer link tiles.                     |
+| `repo_url` / `docs_url` | `str`                             | Auto-derived Source / Docs / Bug links.       |
+| `dialog_width`          | `int`                             | Default width for `display="dialog"` steps.   |
+| `dialog_fullscreen`     | `bool`                            | Force dialog steps to render full-screen.     |
+| `on_step_action`        | `Callable[[int, str], None]`      | Fires when a dialog footer button is clicked. |
+| `on_right_panel_toggle` | `Callable[[bool], None]`          | Fires when the right panel opens/closes.      |
+
+### `StepConfig.content` is a Solara render function
+
+```python
+@solara.component
+def AoiStep():
+    solara.Markdown("AOI selector goes here")
+
+StepConfig(id=1, name="AOI", content=AoiStep)
+```
+
+`content` is invoked only while the step is active. The previous
+content's hooks are torn down on deactivation, so resource-heavy
+components (maps, GEE asset loaders) do not stay mounted in the
+background.
+
+### Right panel sections
+
+```python
+PanelSection(
+    title="Legend",
+    icon="mdi-format-list-bulleted",
+    content=LegendComponent,   # @solara.component
+    divider=True,
+    description="Color ramps for each active layer",
+)
+```
+
+A section's `content` is always mounted (so its state survives panel
+open/close cycles). Use `right_panel_open` if you need to gate work on
+panel visibility.
+
+## Migration from the legacy MapApp
+
+| Legacy                                                   | New                                                                                    |
+| -------------------------------------------------------- | -------------------------------------------------------------------------------------- |
+| `MapApp.element(main_map=[w], theme_toggle=[t])`         | `MapAppComponent(sepal_map=w, theme_state=state)`                                      |
+| `steps_data=[{"id": 1, "name": "...", ...}]`             | `steps=[StepConfig(id=1, name="...", ...)]`                                            |
+| `right_panel=[RightPanel(config=..., content_data=...)]` | `right_panel_config=RightPanelConfig(...)` + `right_panel_content=[PanelSection(...)]` |
+| `right_panel_content=[{"title": ..., "content": [W]}]`   | `right_panel_content=[PanelSection(title=..., content=fn)]`                            |
+| Eager widget construction                                | `content=` is a Solara render function (lazy)                                          |
+| Manual `theme_toggle=ThemeToggle(...)` wiring            | Auto: pass `theme_state=` (or omit; falls back to session state)                       |
+| Manual `language_selector=LocaleSelect(translator=...)`  | Auto: pass `translator=` (or omit)                                                     |
+| `model=HasTraits()` auto-link                            | Use `solara.Reactive` props (`current_step=`, `right_panel_open=`)                     |
+
+## Notifications
+
+Mount `NotificationProvider()` at the page root before the
+`MapAppComponent`. Notification UI is automatically positioned to track
+the right panel via the CSS variable
+`--sepal-notification-right-offset` that the shell publishes.
+
+```python
+@solara.component
+def Page():
+    NotificationProvider()
+    MapAppComponent(...)
+```
+
+See `docs/guides/solara-notifications.md` for the full notification API.

--- a/docs/guides/solara-migration.md
+++ b/docs/guides/solara-migration.md
@@ -1,0 +1,529 @@
+# Solara Migration Guide
+
+> **IMPORTANT**: Read this guide BEFORE converting any ipyvuetify widget to Solara.
+> Every pattern here is grounded in working code already in this repo.
+
+## 1. Conversion Mapping Table
+
+| ipyvuetify / traitlets                   | Solara equivalent                                                | Notes                                                                                         |
+| ---------------------------------------- | ---------------------------------------------------------------- | --------------------------------------------------------------------------------------------- |
+| `class MyWidget(v.Btn, SepalWidget):`    | `@solara.component def MyWidget():`                              | Functions, not classes                                                                        |
+| `t.Unicode("").tag(sync=True)`           | `solara.reactive("")` or function param                          | Module-level for shared state, param for component state                                      |
+| `t.Bool(False).tag(sync=True)`           | `solara.reactive(False)` or `solara.use_state(False)`            | `use_state` for component-local                                                               |
+| `@observe("trait_name")`                 | `solara.use_effect(fn, [dep])`                                   | Effect runs when dependency changes                                                           |
+| `self.observe(handler, "trait")`         | `solara.use_effect(handler, [reactive.value])`                   | Same pattern                                                                                  |
+| `link((w1, "v_model"), (w2, "v_model"))` | Shared `solara.reactive()` passed to both                        | No explicit linking needed                                                                    |
+| `v.Btn(children=[...])`                  | `solara.Button(label=..., on_click=...)`                         | Solara has dedicated wrappers                                                                 |
+| `v.Card(children=[...])`                 | `with solara.Card("title"):`                                     | Context manager pattern                                                                       |
+| `v.Column(children=[...])`               | `with solara.Column():`                                          | Context manager pattern                                                                       |
+| `v.Row(children=[...])`                  | `with solara.Row():`                                             | Context manager pattern                                                                       |
+| `v.TextField(v_model=...)`               | `solara.InputText(value=...)` or `rv.TextField(v_model=...)`     | `rv` = `reacton.ipyvuetify`                                                                   |
+| `v.Select(items=..., v_model=...)`       | `rv.Select(items=..., v_model=..., on_v_model=...)`              | Prefer `rv.Select` — `solara.Select` has different API and can't handle headers/grouped items |
+| `v.Dialog(v_model=...)`                  | `v.Dialog(v_model=..., on_v_model=...)` via `reacton.ipyvuetify` | No native Solara Dialog yet                                                                   |
+| `widget.hide()` / `widget.show()`        | Conditional rendering: `if visible:`                             | Don't render what shouldn't be shown                                                          |
+| `toggle_loading()`                       | Reactive bool: `loading = solara.use_reactive(False)`            | Bind to `loading=loading.value`                                                               |
+| `__init__(self, **kwargs)`               | Function params: `def MyWidget(value=None, on_value=None):`      | `value/on_value` is the standard interface                                                    |
+| `self.children = [...]`                  | Return Solara elements from component body                       | Declarative, not imperative                                                                   |
+| `VuetifyTemplate` + `.vue` file          | `reacton.ipyvuetify` or pure Solara components                   | Prefer pure Solara; use `rv` for complex vuetify                                              |
+
+### When to use `reacton.ipyvuetify` (`rv`)
+
+Use `import reacton.ipyvuetify as rv` when:
+
+- Solara has no native equivalent (Dialog, Tabs, Menu, Snackbar)
+- You need low-level vuetify control (custom slots, complex layouts)
+- Wrapping existing Vue templates during incremental migration
+
+Always prefer native Solara components when available.
+
+### GEE + SessionManager Migration Rule
+
+When migrating an ipywidgets or traitlets component that talks to Earth
+Engine, assume the Solara target will use `@with_sepal_sessions` and the
+session-bound `get_current_gee_interface()`.
+
+For that architecture:
+
+- Do not introduce a separate async GEE getter.
+- Do not default to `asyncio.to_thread(gee_interface.get_info, ...)`.
+- Do not scaffold new `gee_interface.create_task()` flows.
+- Use `await gee_interface.*_async(...)` directly.
+- If the GEE work is wrapped in `solara.lab.use_task`, set
+  `prefer_threaded=False`.
+
+```python
+@solara.component
+@with_sepal_sessions(module_name="my_app")
+def Page():
+    gee_interface = get_current_gee_interface()
+
+    @solara.lab.use_task(
+        dependencies=None,
+        raise_error=False,
+        prefer_threaded=False,
+    )
+    async def load_result(ee_object):
+        return await gee_interface.get_info_async(ee_object)
+```
+
+Reserve `asyncio.to_thread()` for genuinely blocking local work such as file
+I/O, archive handling, or CPU-heavy sync preprocessing.
+
+## 2. Component Signature Pattern
+
+Every converted component MUST follow this pattern:
+
+```python
+import solara
+from typing import Callable, Optional, Union
+
+@solara.component
+def MyComponent(
+    value: Union[str, solara.Reactive[str]] = "",
+    on_value: Optional[Callable[[str], None]] = None,
+    loading: Union[bool, solara.Reactive[bool]] = False,
+    on_loading: Optional[Callable[[bool], None]] = None,
+):
+    """Component docstring (Google convention).
+
+    Args:
+        value: The current value. Can be reactive.
+        on_value: Callback when value changes.
+        loading: Whether the component is loading.
+        on_loading: Callback when loading state changes.
+    """
+    # Wrap value/on_value into a single reactive — this is the standard idiom
+    reactive_value = solara.use_reactive(value, on_value)
+    reactive_loading = solara.use_reactive(loading, on_loading)
+    del value, on_value, loading, on_loading  # Prevent accidental use of raw params
+
+    # Component logic here...
+
+    # Render
+    with solara.Column():
+        solara.Text(f"Value: {reactive_value.value}")
+```
+
+**Why `del value, on_value`?** Prevents accidentally using the raw parameter instead of the reactive wrapper. This is the pattern used in `AoiView` and `AdminLevelSelector`.
+
+**Why `value/on_value`?** This is Solara's controlled component pattern. It lets the parent either:
+
+- Pass a plain value (component manages its own state)
+- Pass a `solara.Reactive` (parent controls the state)
+- Pass an `on_value` callback (parent reacts to changes)
+
+## 3. Hook Rules
+
+**THE RULE: Hooks must be called in the same order on every render.**
+
+Hooks: `use_state`, `use_effect`, `use_memo`, `use_ref`, `use_thread`, `use_reactive`, `use_task`.
+
+### Pattern 1: NO hooks inside conditionals
+
+```python
+# WRONG
+@solara.component
+def MyComponent(data):
+    if data:
+        count, set_count = solara.use_state(0)  # BREAKS: hook inside conditional
+
+# CORRECT
+@solara.component
+def MyComponent(data):
+    count, set_count = solara.use_state(0)  # Always called
+    # Use data conditionally AFTER hooks
+    if data:
+        solara.Text(f"Count: {count}")
+```
+
+### Pattern 2: NO hooks after early returns
+
+```python
+# WRONG
+@solara.component
+def MyComponent(data):
+    if not data:
+        return solara.Text("No data")  # Skips hooks below!
+    value = solara.use_memo(lambda: expensive(data), [data])
+
+# CORRECT
+@solara.component
+def MyComponent(data):
+    value = solara.use_memo(lambda: expensive(data) if data else None, [data])
+    if not data:
+        return solara.Text("No data")  # Safe: hooks already called
+    solara.Text(f"Result: {value}")
+```
+
+### Pattern 2b: State resets from remounts
+
+When the parent conditionally inserts/removes siblings BEFORE a stateful child, the child gets **remounted** (state reset), not just re-rendered.
+
+```python
+# WRONG — Child remounts when data changes (sibling count changes)
+@solara.component
+def Page():
+    data = solara.use_reactive(None)
+    with solara.Column():
+        if data.value is None:
+            solara.Info("No data")
+        else:
+            solara.Success("Data set")
+            solara.Markdown("Extra UI")  # Changes sibling count!
+        Child()  # Gets remounted, loses state
+
+# CORRECT — Wrap conditional siblings in a stable container
+@solara.component
+def Page():
+    data = solara.use_reactive(None)
+    with solara.Column():
+        with solara.Card("Status"):  # Stable wrapper
+            if data.value is None:
+                solara.Info("No data")
+            else:
+                solara.Success("Data set")
+                solara.Markdown("Extra UI")
+        Child()  # Same slot, state preserved
+```
+
+**Rule of thumb**: Never change the number/order of siblings before stateful components. Use stable wrappers.
+
+### Pattern 3: NO hooks in different branches
+
+```python
+# WRONG
+@solara.component
+def MyComponent(data):
+    if len(data) > 0:
+        avg, set_avg = solara.use_state(0)  # Different hook count per branch!
+    else:
+        pass
+
+# CORRECT
+@solara.component
+def MyComponent(data):
+    avg, set_avg = solara.use_state(None)  # Always called
+    def _update():
+        set_avg(calc_avg(data) if data else None)
+    solara.use_effect(_update, [data])
+```
+
+### Pattern 4: NO hooks inside loops
+
+```python
+# WRONG
+@solara.component
+def MyComponent(items):
+    for item in items:
+        count = solara.use_state(0)  # Variable hook count!
+
+# CORRECT — use a single state dict or child components
+@solara.component
+def MyComponent(items):
+    counts = solara.use_state({})
+    for item in items:
+        ItemChild(item)  # Each child manages its own hooks
+```
+
+### Hook Checklist
+
+Before submitting any Solara component, verify:
+
+- [ ] All `use_*` calls are at the TOP of the component function
+- [ ] All `use_*` calls happen in the SAME ORDER every render
+- [ ] NO `use_*` calls inside `if/else` blocks
+- [ ] NO `use_*` calls inside loops with variable iterations
+- [ ] NO `use_*` calls AFTER early `return` statements
+- [ ] NO `use_*` calls in `try/except` where try might skip hooks
+- [ ] Conditional logic is INSIDE hook callbacks, not around hook calls
+- [ ] Conditional rendering happens AFTER all hooks
+
+## 4. State Management Patterns
+
+### Module-level reactive (shared/app-wide state)
+
+```python
+# At module level — shared across all component instances
+selected_method = solara.reactive("")
+is_loading = solara.reactive(False)
+
+@solara.component
+def MyComponent():
+    # Read: selected_method.value
+    # Write: selected_method.value = "new" or selected_method.set("new")
+    solara.Text(f"Method: {selected_method.value}")
+```
+
+### AppState singleton (complex apps)
+
+For apps with many reactive variables, use a state class (pattern from sbae-design):
+
+```python
+class AppState:
+    def __init__(self):
+        self.file_path = solara.reactive(None)
+        self.is_processing = solara.reactive(False)
+        self.results = solara.reactive(None)
+        self.class_areas = solara.reactive({})
+
+    def is_ready_for_calculation(self) -> bool:
+        """Validation helper — checks all preconditions before allowing computation."""
+        return self.file_path.value is not None and not self.is_processing.value
+
+    def update_class_areas(self, class_id: str, area: float):
+        """Always replace with a new object — never mutate .value in place."""
+        updated = self.class_areas.value.copy()
+        updated[class_id] = area
+        self.class_areas.value = updated  # New object triggers re-render
+
+app_state = AppState()  # Singleton
+```
+
+### Component-local state
+
+```python
+@solara.component
+def MyComponent():
+    # use_state: simple local state (returns value + setter)
+    count, set_count = solara.use_state(0)
+
+    # use_reactive: local reactive (returns Reactive object)
+    # Preferred when passing state to child components
+    method = solara.use_reactive("ADMIN0")
+
+    # use_ref: mutable value that does NOT trigger re-renders
+    # Useful for breaking sync loops or tracking previous values
+    prev_method = solara.use_ref(method.value)
+    if prev_method.current != method.value:
+        # Method changed — do something
+        prev_method.current = method.value
+```
+
+### When to use which
+
+| Pattern                             | When to use                                                                |
+| ----------------------------------- | -------------------------------------------------------------------------- |
+| `solara.reactive()` at module level | App-wide state shared across components                                    |
+| `AppState` singleton                | Many related reactive variables                                            |
+| `solara.use_state()`                | Simple component-local state (value + setter)                              |
+| `solara.use_reactive()`             | Component-local state passed to children                                   |
+| `solara.use_ref()`                  | Mutable value that should NOT trigger re-renders (prev values, sync flags) |
+| `value/on_value` params             | Component inputs controlled by parent                                      |
+
+## 5. Threading and Async Patterns
+
+### `solara.lab.use_task` (preferred for new code)
+
+```python
+@solara.component
+def MyComponent():
+    async def fetch_data():
+        result = await some_async_operation()
+        return result
+
+    task = solara.lab.use_task(
+        fetch_data,
+        dependencies=None,  # None = manual trigger via task()
+        raise_error=False,
+    )
+
+    solara.Button("Fetch", on_click=task, disabled=task.pending)
+
+    if task.pending:
+        solara.ProgressLinear(indeterminate=True)
+    elif task.finished:
+        solara.Success(f"Done: {task.value}")
+    elif task.error:
+        solara.Error(f"Error: {task.exception}")
+```
+
+### `solara.use_thread` (legacy, still works)
+
+```python
+@solara.component
+def MyComponent():
+    # cancel parameter is OPTIONAL — only needed for cooperative cancellation
+    # Workers can also be simple no-arg functions: def worker(): ...
+    def worker(cancel: threading.Event):
+        for i in range(100):
+            if cancel.is_set():
+                return None
+            time.sleep(0.1)
+        return "done"
+
+    result = solara.use_thread(worker, dependencies=[], intrusive_cancel=False)
+
+    if result.state == solara.ResultState.RUNNING:
+        solara.ProgressLinear(indeterminate=True)
+    elif result.state == solara.ResultState.FINISHED:
+        solara.Success(f"Result: {result.value}")
+    elif result.state == solara.ResultState.ERROR:
+        solara.Error(f"Error: {result.error}")
+```
+
+### `use_task` vs `use_thread` API differences
+
+These two hooks have **different return types** — don't confuse them:
+
+| Attribute            | `use_thread` (returns `Result`)        | `use_task` (returns `Task`)  |
+| -------------------- | -------------------------------------- | ---------------------------- |
+| The exception object | `result.error` (Exception)             | `task.exception` (Exception) |
+| Error check          | `result.state == ResultState.ERROR`    | `task.error` (bool)          |
+| Running check        | `result.state == ResultState.RUNNING`  | `task.pending` (bool)        |
+| Done check           | `result.state == ResultState.FINISHED` | `task.finished` (bool)       |
+| Cancel               | `result.cancel()`                      | `task.cancel()`              |
+
+### Key rules
+
+- **Always provide `dependencies`** — omitting runs on every render
+- **`dependencies=[]`** — runs once on mount
+- **`dependencies=None`** — manual trigger only (for `use_task`)
+- **Prefer `use_task`** over `use_thread` for new code (better performance, async support)
+- **Check cancellation** in long loops when using `use_thread`
+- **Batch state updates** — don't call `set_state` on every iteration
+
+### Effects for reactive calculations
+
+```python
+@solara.component
+def MyComponent():
+    result = solara.use_reactive(None)
+
+    def auto_calculate():
+        if app_state.is_ready_for_calculation():
+            result.set(compute(app_state.file_path.value))
+
+    solara.use_effect(auto_calculate, [
+        app_state.target_error.value,
+        app_state.confidence_level.value,
+    ])
+```
+
+## 6. Anti-Patterns
+
+### Mutating reactive values in place
+
+```python
+# WRONG — Solara won't detect the change
+my_list = solara.reactive([1, 2, 3])
+my_list.value.append(4)  # Mutation, no re-render!
+
+# CORRECT — Replace with a new object
+my_list.value = [*my_list.value, 4]
+```
+
+### Returning different root widgets per state
+
+```python
+# WRONG — Solara keeps the first root alive
+@solara.component
+def MyComponent(has_data):
+    if has_data:
+        return solara.Card("Data view")  # Different root!
+    else:
+        return solara.Text("No data")    # Different root!
+
+# CORRECT — Stable root, swap children
+@solara.component
+def MyComponent(has_data):
+    with solara.Column():  # Stable root
+        if has_data:
+            solara.Card("Data view")
+        else:
+            solara.Text("No data")
+```
+
+### Hot reload masking bugs
+
+Hot reloads rebuild the widget tree from scratch and can hide structural issues. If a reactive value changes but the component doesn't re-render, the fix is to ensure a stable root element — not to rely on hot reload.
+
+### Imperative widget manipulation
+
+```python
+# WRONG — ipyvuetify thinking
+widget.children = [new_child]
+widget.hide()
+widget.disabled = True
+
+# CORRECT — Solara thinking (declarative)
+@solara.component
+def MyComponent():
+    visible = solara.use_reactive(True)
+    if visible.value:
+        solara.Button("Click", disabled=not ready)
+```
+
+## 7. Conversion Checklist
+
+For each ipyvuetify widget being converted:
+
+### Preparation
+
+- [ ] Read the original widget source completely
+- [ ] Identify all traitlets (traits with `.tag(sync=True)`)
+- [ ] Identify all `@observe` handlers
+- [ ] Identify all bidirectional links (`link()`, `directional_link()`)
+- [ ] Identify Vue templates if any (`template_file`, `.vue` files)
+- [ ] Identify the public API (methods users call)
+
+### Conversion
+
+- [ ] Create `@solara.component` function with `value/on_value` signature
+- [ ] Map traitlets to reactive state (`use_reactive`, `use_state`, or params)
+- [ ] Convert `@observe` handlers to `use_effect` with explicit dependencies
+- [ ] Convert imperative show/hide to conditional rendering
+- [ ] Convert `children` manipulation to declarative Solara elements
+- [ ] Replace Vue templates with Solara components or `reacton.ipyvuetify`
+
+### Verification
+
+- [ ] All hooks at the top, same order every render (see Hook Checklist)
+- [ ] Stable root element (no conditional root returns)
+- [ ] No in-place mutation of reactive values
+- [ ] `del value, on_value` after `use_reactive` wrapping
+- [ ] Google-convention docstring with Args section
+- [ ] No early returns before hooks
+
+## 8. Reference Examples
+
+### Simple conversion: AdminButton
+
+**Location**: `pysepal/solara/components/admin.py`
+
+Shows: `use_state` for local state, `reacton.ipyvuetify` for Dialog/Tabs, conditional rendering instead of show/hide. Note: does not use `value/on_value` pattern because it has no parent-controlled state — it's a self-contained admin panel.
+
+### Complex conversion: AoiView
+
+**Location**: `pysepal/solara/components/aoi/aoi_view.py`
+
+Shows: `value/on_value` pattern, `use_reactive` + `del`, `use_effect` for side effects, `use_task` for async processing, stable render tree, cleanup on unmount.
+
+### Full app reference: sbae-design
+
+**Location**: `~/1_modules/sbae-design/`
+
+Shows: AppState singleton, MapApp layout, `use_thread` for long operations, `use_effect` for reactive calculations, modal/dialog management, strategy pattern.
+
+## 9. Widget Conversion Status
+
+### Already converted (Solara-native)
+
+- `AdminButton` → `pysepal/solara/components/admin.py`
+- `AoiView` → `pysepal/solara/components/aoi/aoi_view.py`
+- `AoiResult` → `pysepal/solara/components/aoi/aoi_result.py`
+
+### Bridge wrappers (ipyvuetify widget exposed via Solara, not truly converted)
+
+- `FileInputComponent` → `pysepal/sepalwidgets/file_input.py` (wraps the ipyvuetify `FileInput` via `.element()` with manual state sync — not a Solara-native component)
+
+### Pending conversion (in `pysepal/sepalwidgets/`)
+
+- `Btn`, `DownloadBtn`, `TaskButton` (btn.py)
+- `Alert`, `StateBar`, `Banner`, `Divider` (alert.py)
+- `DatePicker`, `FileInput`, `AssetSelect`, `NumberField`, `SimpleSlider` (inputs.py)
+- `Tile`, `TileAbout`, `TileDisclaimer` (tile.py)
+- `Radio`, `RadioGroup` (radio.py)
+- `Markdown`, `CopyToClip`, `StateIcon` (widget.py)
+- `Dialog`, `Tooltip` (sepalwidget.py)
+- `MapApp`, `ThemeToggle`, `RightPanel` (vue_app.py) — already work with Solara via Vue templates
+- `App`, `AppBar`, `NavDrawer`, `DrawerItem`, `Footer` (app.py) — legacy layout, MapApp is the replacement

--- a/docs/guides/solara-notifications.md
+++ b/docs/guides/solara-notifications.md
@@ -1,0 +1,240 @@
+# Solara Notifications with pysepal
+
+> Use this guide when a pysepal Solara app needs user-facing toast notifications,
+> running-task status, or a shared floating notification UI.
+
+## What the Notification System Is
+
+The pysepal notification system is a kernel-scoped, in-memory UI notification
+layer for Solara apps.
+
+It provides:
+
+- toast notifications for success, info, warning, error, and cancel states
+- a floating task pill for active work
+- a task log derived from tracked task history
+- a Vue-backed overlay that integrates with `MapApp`
+
+It does **not** provide:
+
+- durable event storage
+- cross-kernel or cross-process messaging
+- audit logging
+- guaranteed delivery after kernel restart
+
+Use it for live app UX, not for backend workflow persistence.
+
+## Core Pieces
+
+The main API lives in `pysepal.solara.notifications`:
+
+- `NotificationProvider` — mounts the notification UI and owns the kernel-scoped bus
+- `use_notifications()` — returns a `Notifier` bound to the current kernel bus
+- `notify()` and `track_task()` — global escape hatches for non-component code
+- `Notifier.track(...)` — returns a `TaskTracker` context manager for long-running work
+
+Conceptually:
+
+1. `NotificationProvider()` mounts once at app-shell level.
+2. Components call `use_notifications()`.
+3. Components publish toasts or tracked tasks.
+4. The notification UI reacts to the shared bus state.
+
+## Scope Rules
+
+The isolation boundary is the Solara kernel, not the route.
+
+- One browser page connection usually maps to one Solara virtual kernel.
+- The notification bus is keyed by kernel id.
+- Routes inside the same live page share the same notification history.
+- Separate browser page loads get separate kernels and therefore separate histories.
+
+This means:
+
+- mount one provider per app shell
+- allow many consumers to call `use_notifications()`
+- do not assume route changes create isolated notification buses
+
+If an app launcher opens `/fcdm` and `/basin-rivers` as separate pages, each app
+gets its own history. If those are route transitions inside one live page, they
+share the same history.
+
+## Mounting Pattern
+
+Mount `NotificationProvider()` once near the top of the app shell.
+
+### Single-page app
+
+```python
+@solara.component
+@with_sepal_sessions(module_name="my_app")
+def Page():
+    setup_theme_colors()
+    NotificationProvider()
+    AppContent()
+```
+
+### Multipage app with shared layout
+
+If all routes should share one notification surface, mount the provider in the
+shared layout instead of inside each page.
+
+```python
+@solara.component
+def Layout(children=[]):
+    NotificationProvider()
+    solara.Column(children=children)
+```
+
+### What not to do
+
+Do not mount a separate provider in every page if those pages can coexist in the
+same kernel. The bus is shared anyway, and multiple providers can render
+multiple overlays against the same state.
+
+## Using `use_notifications()` Inside Components
+
+The normal component pattern is:
+
+```python
+from pysepal.solara.notifications import NotificationProvider, use_notifications
+
+@solara.component
+def ResultsPanel():
+    notifications = use_notifications()
+
+    def handle_ready():
+        notifications.success("Results loaded")
+```
+
+Toast methods:
+
+- `success(message)`
+- `info(message)`
+- `warning(message)`
+- `error(message)`
+- `cancel(message)`
+- `dismiss(toast_id)`
+
+If no provider is mounted, `use_notifications()` returns a `NoopNotifier`.
+That means toast calls are silently dropped unless the component provides its own
+fallback UX.
+
+## Tracking Long-Running Tasks
+
+Use `notifications.track(...)` together with `solara.lab.use_task` for
+non-blocking work.
+
+```python
+@solara.component
+def StatsPanel():
+    notifications = use_notifications()
+    gee_interface = get_current_gee_interface()
+
+    @solara.lab.use_task(
+        dependencies=None,
+        raise_error=False,
+        prefer_threaded=False,
+    )
+    async def run_job(request):
+        with notifications.track("Loading statistics", total_steps=3) as task:
+            task.step("Validating input")
+            task.step("Querying Earth Engine")
+            result = await gee_interface.get_info_async(request.ee_object)
+            task.step("Formatting result")
+            return result
+```
+
+Use task tracking when:
+
+- the work is async or long-running
+- the user benefits from a visible running-state indicator
+- you want a task log instead of only final toasts
+
+Use plain toasts when:
+
+- the event is immediate
+- there is no meaningful progress to report
+
+## Recommended Async Pattern
+
+For new GEE-based Solara apps:
+
+- use `solara.reactive()` AppState
+- use `solara.lab.use_task(..., prefer_threaded=False)`
+- snapshot request inputs before starting work
+- use `notifications.track(...)` inside the task body
+- mirror task results back into AppState in `solara.use_effect`
+
+This matches the current session-backed async GEE path and avoids loop-hopping
+problems.
+
+## Fallback UX When No Provider Exists
+
+If a component can be used inside or outside a shell that mounts
+`NotificationProvider()`, do not assume the notifier is active.
+
+Preferred fallback pattern:
+
+- detect whether `use_notifications()` returned a `NoopNotifier`
+- still surface success/error/cancel inline if the provider is absent
+- reserve silent no-op behavior for utility-level code where inline feedback is
+  impossible
+
+The AOI Solara component is the reference example for this pattern.
+
+## Global Escape Hatches
+
+Use these only when you cannot conveniently call `use_notifications()` from a
+component:
+
+- `notify(message, type_="info")`
+- `track_task(title, total_steps=None)`
+
+Caveats:
+
+- they still resolve the current kernel bus
+- if no provider is mounted, `notify()` logs a warning and drops the toast
+- if no provider is mounted, `track_task()` returns a no-op tracker
+
+Prefer component-local `use_notifications()` whenever possible.
+
+## MapApp Integration
+
+The notification UI is designed to coexist with `MapApp`.
+
+`MapApp.vue` publishes CSS custom properties such as
+`--sepal-notification-right-offset`, and the Vue notification UI uses them to
+position the task pill relative to the right panel.
+
+Practical rule:
+
+- if the app uses `MapApp`, mount `NotificationProvider()` in the same page or
+  shell so the overlay can consume the active layout variables
+
+## Safety and Limits
+
+The notification system is safe for live, per-kernel app UX.
+
+It is not a replacement for durable logs or event infrastructure.
+
+Important limits:
+
+- state is in-memory only
+- restart the kernel and history is lost
+- identical toasts are deduplicated within a short time window
+- only the newest error toast is retained in the toast queue
+- only the newest few toasts are visible in the overlay
+- finished task history is capped and older finished tasks are pruned
+
+## Default Scaffold Rule
+
+When building a new pysepal Solara app that has async work or user-visible
+status transitions:
+
+- mount `NotificationProvider()` once in the app shell
+- use `use_notifications()` inside pages and major tiles
+- use `notifications.track(...)` for long-running jobs
+- use final success/error/cancel toasts for task completion state
+- do not build a second custom alert system unless the app has a very specific
+  UX reason


### PR DESCRIPTION
## Summary
- Commit the `docs/guides/*.md` files referenced by `skills/pysepal/SKILL.md` (published in #983). They were previously gitignored, so the skill's `docs/guides/...` references resolved to nothing for anyone cloning the repo.
- Scope the existing `guides/` ignore to top-level only (`/guides/`) so `docs/guides/` is tracked.

## Files added
- `ipecharts.md`, `ipyvuetify-widgets.md`, `migration-notes-v3.4.md`
- `solara-app-builder.md`, `solara-export.md`, `solara-gee-patterns.md`
- `solara-mapapp-component.md`, `solara-migration.md`, `solara-notifications.md`

## Test plan
- [ ] Verify `git check-ignore docs/guides/ipecharts.md` returns empty
- [ ] Verify top-level `guides/` is still ignored
- [ ] Skill paths in `skills/pysepal/SKILL.md` now resolve to real files