### PR TITLE
feat(solara/export): Asset ID field + required/root/conflict checks

### DIFF
--- a/pysepal/solara/components/export.py
+++ b/pysepal/solara/components/export.py
@@ -37,6 +37,7 @@ from .export_models import (
     resolve_asset_folder,
     resolve_sepal_folder,
     sanitize_export_name,
+    validate_asset_id_under_root,
 )
 
 
@@ -159,4 +160,5 @@ __all__ = [
     "sanitize_export_name",
     "submit_export_request",
     "use_export_dialog",
+    "validate_asset_id_under_root",
 ]

--- a/pysepal/solara/components/export_dialog.py
+++ b/pysepal/solara/components/export_dialog.py
@@ -14,11 +14,7 @@ from .export_hook import (
     get_source_items,
     get_target_items,
 )
-from .export_models import (
-    TABLE_FILE_FORMATS,
-    resolve_asset_folder,
-    sanitize_export_name,
-)
+from .export_models import TABLE_FILE_FORMATS, validate_asset_id_under_root
 
 IMAGE_SCALE_PRESETS = [10, 15, 20, 30, 60, 100]
 
@@ -30,13 +26,6 @@ def _hint_props(hint: str) -> dict[str, object]:
         "hint": hint,
         "persistent_hint": True,
     }
-
-
-def _build_gee_asset_hint(asset_root: str, requested_folder: str, export_name: str) -> str:
-    """Return a humane preview of the resolved Earth Engine asset path."""
-    resolved_folder = resolve_asset_folder(asset_root, requested_folder)
-    asset_name = sanitize_export_name(export_name) if export_name.strip() else "<name>"
-    return f"Will be exported as: {resolved_folder}/{asset_name}"
 
 
 @solara.component
@@ -121,14 +110,33 @@ def ExportDialog(
     )
     has_usable_sources = any(not source.disabled for source in controller.sources)
     fields_disabled = active_source is None
-    name_error = "" if fields_disabled or controller.export_name.value.strip() else "Name required"
+    gee_target_selected = controller.selected_target.value == "gee"
+    gee_asset_conflict = gee_target_selected and state.gee_asset_conflict.value
+
+    if gee_target_selected:
+        identifier_error = (
+            "" if fields_disabled or state.gee_asset_id.value.strip() else "Asset ID required"
+        )
+        asset_root_error = (
+            validate_asset_id_under_root(state.gee_asset_id.value, state.asset_root.value)
+            if not fields_disabled
+            else None
+        )
+    else:
+        identifier_error = (
+            "" if fields_disabled or controller.export_name.value.strip() else "Name required"
+        )
+        asset_root_error = None
+
     submit_disabled = (
         not has_usable_sources
         or active_source is None
         or resolved_export is None
         or export_kind is None
         or bool(resolve_error)
-        or bool(name_error)
+        or bool(identifier_error)
+        or bool(asset_root_error)
+        or gee_asset_conflict
     )
 
     target_items = get_target_items(state.sepal_client)
@@ -143,6 +151,11 @@ def ExportDialog(
         controller.export_name.set(value)
         if not controller.name_dirty.value and value != state.last_default_name.value:
             controller.name_dirty.set(True)
+
+    def _handle_asset_id_change(value: str) -> None:
+        state.gee_asset_id.set(value)
+        if not state.gee_asset_id_dirty.value and value != state.last_default_gee_asset_id.value:
+            state.gee_asset_id_dirty.set(True)
 
     with v.Dialog(
         v_model=controller.open.value,
@@ -189,37 +202,53 @@ def ExportDialog(
                                 disabled=bool(item.get("disabled", False)) or fields_disabled,
                             )
 
-                    with rv.TextField(
-                        label="Export name",
-                        v_model=controller.export_name.value,
-                        on_v_model=_handle_name_change,
-                        dense=True,
-                        error=bool(name_error),
-                        error_messages=name_error or None,
-                        hide_details="auto",
-                        disabled=fields_disabled,
-                    ):
-                        pass
+                    if gee_target_selected:
+                        if identifier_error:
+                            asset_id_kwargs: dict[str, object] = {
+                                "error": True,
+                                "error_messages": identifier_error,
+                                "hide_details": "auto",
+                            }
+                        elif asset_root_error:
+                            asset_id_kwargs = {
+                                "error": True,
+                                "error_messages": asset_root_error,
+                                "hide_details": False,
+                            }
+                        elif gee_asset_conflict:
+                            asset_id_kwargs = {
+                                "error": True,
+                                "error_messages": (
+                                    "An asset with this id already exists. "
+                                    "Edit the id or pick a different path."
+                                ),
+                                "hide_details": False,
+                            }
+                        else:
+                            asset_id_kwargs = {"hide_details": True}
 
-                    if controller.selected_target.value == "gee":
-                        asset_root_placeholder = state.asset_root.value
-                        gee_asset_hint = _build_gee_asset_hint(
-                            state.asset_root.value,
-                            state.gee_folder.value,
-                            controller.export_name.value,
-                        )
                         with rv.TextField(
-                            label="Earth Engine folder",
-                            v_model=state.gee_folder.value,
-                            on_v_model=state.gee_folder.set,
+                            label="Asset ID",
+                            v_model=state.gee_asset_id.value,
+                            on_v_model=_handle_asset_id_change,
                             dense=True,
-                            placeholder=asset_root_placeholder,
                             disabled=fields_disabled,
-                            **_hint_props(gee_asset_hint),
+                            **asset_id_kwargs,
+                        ):
+                            pass
+                    else:
+                        with rv.TextField(
+                            label="Export name",
+                            v_model=controller.export_name.value,
+                            on_v_model=_handle_name_change,
+                            dense=True,
+                            error=bool(identifier_error),
+                            error_messages=identifier_error or None,
+                            hide_details="auto",
+                            disabled=fields_disabled,
                         ):
                             pass
 
-                    if controller.selected_target.value in {"drive", "sepal"}:
                         with rv.TextField(
                             label="Google Drive folder",
                             v_model=state.drive_folder.value,

--- a/pysepal/solara/components/export_engine.py
+++ b/pysepal/solara/components/export_engine.py
@@ -25,8 +25,8 @@ from .export_models import (
     extract_task_id,
     get_task_state_name,
     matches_drive_export_prefix,
-    resolve_asset_folder,
     resolve_sepal_folder,
+    validate_asset_id_under_root,
 )
 
 StatusCallback = Optional[Callable[[str], None]]
@@ -300,10 +300,24 @@ async def submit_export_request(
 
     if request.target == "gee":
         _notify(on_step, "Preparing Earth Engine destination")
+        asset_id = (request.gee_asset_id or "").strip()
+        if not asset_id:
+            raise ValueError("Earth Engine export requires an asset id.")
+
         root_folder = await gee_interface.get_folder_async()
-        asset_folder = resolve_asset_folder(root_folder, request.gee_folder)
+        root_error = validate_asset_id_under_root(asset_id, str(root_folder or ""))
+        if root_error:
+            raise ValueError(root_error)
+
+        existing = await gee_interface.get_asset_async(asset_id, not_exists_ok=True)
+        if existing is not None:
+            raise FileExistsError(
+                f"An Earth Engine asset already exists at `{asset_id}`. "
+                "Edit the asset id or pick a different path."
+            )
+
+        asset_folder = str(PurePosixPath(asset_id).parent)
         await _ensure_asset_folder_exists(gee_interface, asset_folder)
-        asset_id = str(PurePosixPath(asset_folder) / request.name)
 
         _notify(on_step, "Submitting Earth Engine export")
         submission = await _submit_export(gee_interface, request, asset_id=asset_id)

--- a/pysepal/solara/components/export_hook.py
+++ b/pysepal/solara/components/export_hook.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
+import asyncio
 from dataclasses import dataclass, field
+from pathlib import PurePosixPath
 from typing import Any, Callable, Optional, Sequence
 
 import solara
@@ -31,6 +33,7 @@ from .export_models import (
     ResolvedExport,
     infer_export_kind,
     sanitize_export_name,
+    validate_asset_id_under_root,
 )
 
 # Success toast carries an asset path / task id the user often wants to copy,
@@ -38,18 +41,27 @@ from .export_models import (
 # lingers annoyingly.
 EXPORT_SUCCESS_TOAST_TIMEOUT = 8.0
 
+# Debounce window for the live GEE asset-existence check. The Solara hook
+# cancels the previous task invocation when dependencies change, so as long
+# as the user keeps typing the sleep never completes and no API call fires.
+GEE_ASSET_CONFLICT_CHECK_DELAY = 0.35
+
 
 @dataclass(frozen=True, slots=True)
 class _ExportDialogState:
     scale: solara.Reactive[int]
     asset_root: solara.Reactive[str]
-    gee_folder: solara.Reactive[str]
+    gee_asset_id: solara.Reactive[str]
+    gee_asset_id_dirty: solara.Reactive[bool]
+    last_default_gee_asset_id: solara.Reactive[str]
     drive_folder: solara.Reactive[str]
     sepal_folder: solara.Reactive[str]
     table_file_format: solara.Reactive[str]
     inline_message: solara.Reactive[str]
     inline_level: solara.Reactive[str]
     last_default_name: solara.Reactive[str]
+    gee_asset_conflict: solara.Reactive[bool]
+    gee_asset_conflict_path: solara.Reactive[str]
     gee_interface: GEEInterface
     drive_interface: GDriveInterface
     sepal_client: SepalClient | None
@@ -228,6 +240,69 @@ def _default_gee_folder(sepal_client: SepalClient | None) -> str:
     return "pysepal_exports"
 
 
+async def _resolve_gee_asset_conflict(
+    *,
+    target: ExportTarget,
+    has_active_source: bool,
+    asset_id: str,
+    gee_interface: GEEInterface,
+    debounce_seconds: float = GEE_ASSET_CONFLICT_CHECK_DELAY,
+) -> tuple[bool, str]:
+    """Probe Earth Engine for a name collision against the resolved asset id.
+
+    Returns ``(conflict, candidate_path)``. ``conflict`` is ``True`` only when
+    Earth Engine confirms an asset already lives at ``asset_id``. The probe
+    runs for the auto-filled default as well as user edits — many SEPAL apps
+    reuse the same module folder + name across sessions, so the default itself
+    is the most common collision. Lookup failures (permissions, network, the
+    known eeclient cross-loop httpx race) are treated as ``(False, "")`` — the
+    engine-side guard remains the authoritative check at submit time.
+    """
+    candidate = (asset_id or "").strip()
+    if target != "gee" or not has_active_source or not candidate:
+        return False, ""
+
+    if debounce_seconds > 0:
+        await asyncio.sleep(debounce_seconds)
+
+    try:
+        existing = await gee_interface.get_asset_async(candidate, not_exists_ok=True)
+    except Exception:
+        return False, ""
+
+    if existing is None:
+        return False, ""
+    return True, candidate
+
+
+def _build_default_gee_asset_id(
+    asset_root: str,
+    resolved_export: ResolvedExport,
+    sepal_client: SepalClient | None,
+) -> str:
+    """Pre-fill a sensible GEE asset path from the user's asset root + source.
+
+    Composes ``{asset_root}/{resolved.gee_folder or module}/{sanitized_name}``.
+    When ``resolved.gee_folder`` is an absolute path (starts with ``projects/``)
+    the asset root is ignored. Returns ``""`` when the asset root has not
+    finished loading yet (still contains the ``{project}`` placeholder), so
+    callers can wait before overwriting user input.
+    """
+    if not asset_root or "{project}" in asset_root:
+        return ""
+
+    name = sanitize_export_name(resolved_export.default_name) or "export"
+    folder = (resolved_export.gee_folder or _default_gee_folder(sepal_client) or "").strip("/")
+
+    if folder.startswith("projects/"):
+        return f"{folder.rstrip('/')}/{name}"
+
+    root = asset_root.rstrip("/")
+    if not folder:
+        return f"{root}/{name}"
+    return f"{root}/{folder}/{name}"
+
+
 def _source_defaults_signature(
     resolved_export: ResolvedExport | None,
     export_kind: ExportKind | None,
@@ -280,13 +355,17 @@ def use_export_dialog(
     state = _ExportDialogState(
         scale=solara.use_reactive(30),
         asset_root=solara.use_reactive("projects/{project}/assets"),
-        gee_folder=solara.use_reactive(""),
+        gee_asset_id=solara.use_reactive(""),
+        gee_asset_id_dirty=solara.use_reactive(False),
+        last_default_gee_asset_id=solara.use_reactive(""),
         drive_folder=solara.use_reactive(""),
         sepal_folder=solara.use_reactive(""),
         table_file_format=solara.use_reactive(DEFAULT_TABLE_FILE_FORMAT),
         inline_message=solara.use_reactive(""),
         inline_level=solara.use_reactive("info"),
         last_default_name=solara.use_reactive(""),
+        gee_asset_conflict=solara.use_reactive(False),
+        gee_asset_conflict_path=solara.use_reactive(""),
         gee_interface=gee_interface,
         drive_interface=drive_interface,
         sepal_client=sepal_client,
@@ -366,12 +445,41 @@ def use_export_dialog(
         prefer_threaded=False,
     )
 
+    async def _check_gee_asset_conflict() -> None:
+        # Skip the probe for structurally invalid paths — the visible "must
+        # live under <root>/" error is the gate. Probing a path the user
+        # cannot write to would just produce a 404 or permission error.
+        if validate_asset_id_under_root(state.gee_asset_id.value, state.asset_root.value):
+            state.gee_asset_conflict.set(False)
+            state.gee_asset_conflict_path.set("")
+            return
+
+        conflict, candidate = await _resolve_gee_asset_conflict(
+            target=selected_target.value,
+            has_active_source=active_source is not None,
+            asset_id=state.gee_asset_id.value,
+            gee_interface=state.gee_interface,
+        )
+        state.gee_asset_conflict.set(conflict)
+        state.gee_asset_conflict_path.set(candidate)
+
+    solara.lab.use_task(
+        _check_gee_asset_conflict,
+        dependencies=[
+            selected_target.value,
+            state.gee_asset_id.value,
+            state.asset_root.value,
+            active_source_id,
+        ],
+        raise_error=False,
+        prefer_threaded=False,
+    )
+
     def _sync_source_defaults() -> None:
         if resolved_export is None:
             return
 
         state.scale.set(int(resolved_export.default_scale or 30))
-        state.gee_folder.set(resolved_export.gee_folder or _default_gee_folder(state.sepal_client))
         state.drive_folder.set(resolved_export.drive_folder or "")
         state.sepal_folder.set(resolved_export.sepal_folder or "")
         state.table_file_format.set(resolved_export.table_file_format or DEFAULT_TABLE_FILE_FORMAT)
@@ -387,6 +495,34 @@ def use_export_dialog(
             export_name.set(default_name)
 
     solara.use_effect(_sync_default_name, [active_source_id, default_name, name_dirty.value])
+
+    def _sync_default_gee_asset_id() -> None:
+        if state.gee_asset_id_dirty.value:
+            return
+        if resolved_export is None:
+            return
+
+        default = _build_default_gee_asset_id(
+            state.asset_root.value,
+            resolved_export,
+            state.sepal_client,
+        )
+        if not default:
+            return  # Asset root still loading.
+
+        if default != state.last_default_gee_asset_id.value:
+            state.last_default_gee_asset_id.set(default)
+            state.gee_asset_id.set(default)
+
+    solara.use_effect(
+        _sync_default_gee_asset_id,
+        [
+            active_source_id,
+            state.asset_root.value,
+            state.gee_asset_id_dirty.value,
+            source_defaults_signature,
+        ],
+    )
 
     def _handle_resolve_error() -> None:
         if not resolve_error:
@@ -414,21 +550,28 @@ def use_export_dialog(
                 "SEPAL export requires a session-backed SepalClient. "
                 "Use @with_sepal_sessions in the host page."
             )
-        if not export_name.value.strip():
-            raise ValueError("Name required")
 
-        sanitized_name = sanitize_export_name(export_name.value)
-        export_name.set(sanitized_name)
+        if selected_target.value == "gee":
+            asset_id = state.gee_asset_id.value.strip()
+            if not asset_id:
+                raise ValueError("Asset ID required")
+            description = PurePosixPath(asset_id).name or "export"
+        else:
+            if not export_name.value.strip():
+                raise ValueError("Name required")
+            description = sanitize_export_name(export_name.value)
+            export_name.set(description)
+            asset_id = None
 
         selectors = resolved_export.selectors
         return ExportRequest(
             ee_object=resolved_export.ee_object,
             export_kind=export_kind,
             target=selected_target.value,
-            name=sanitized_name,
+            name=description,
             region=resolved_export.region,
             scale=state.scale.value if export_kind == "image" else None,
-            gee_folder=state.gee_folder.value.strip() or None,
+            gee_asset_id=asset_id,
             drive_folder=state.drive_folder.value.strip() or None,
             sepal_folder=state.sepal_folder.value.strip() or None,
             table_file_format=state.table_file_format.value,
@@ -524,11 +667,15 @@ def use_export_dialog(
         export_name.set("")
         name_dirty.set(False)
         state.last_default_name.set("")
+        state.gee_asset_id.set("")
+        state.gee_asset_id_dirty.set(False)
+        state.last_default_gee_asset_id.set("")
         open_state.set(True)
 
     def close_dialog() -> None:
         _clear_inline()
         name_dirty.set(False)
+        state.gee_asset_id_dirty.set(False)
         open_state.set(False)
 
     def submit_export() -> None:

--- a/pysepal/solara/components/export_models.py
+++ b/pysepal/solara/components/export_models.py
@@ -94,7 +94,7 @@ class ExportRequest:
     name: str
     region: object = None
     scale: Optional[int] = None
-    gee_folder: Optional[str] = None
+    gee_asset_id: Optional[str] = None
     drive_folder: Optional[str] = None
     sepal_folder: Optional[str] = None
     table_file_format: str = DEFAULT_TABLE_FILE_FORMAT
@@ -193,6 +193,40 @@ def resolve_sepal_folder(
     return base_results / requested_path
 
 
+def validate_asset_id_under_root(asset_id: str, asset_root: str) -> Optional[str]:
+    """Return an error message if ``asset_id`` does not live under ``asset_root``.
+
+    Earth Engine only lets a user write to assets beneath their own asset root
+    (``projects/<project>/assets/``). This guards the dialog (live UI hint)
+    and the engine (submit-time validation) with one shared rule.
+
+    Returns ``None`` when:
+    - ``asset_root`` is empty or still the ``{project}`` placeholder — the UI
+      can defer validation until ``_load_asset_root`` finishes.
+    - ``asset_id`` is empty — empty is a separate "required" error that the
+      caller already surfaces.
+
+    Returns an error string otherwise: when the path does not start under the
+    root, or when only the root is given with no asset name beneath it.
+    """
+    if not asset_root or "{project}" in asset_root:
+        return None
+
+    normalized_id = (asset_id or "").strip()
+    if not normalized_id:
+        return None
+
+    expected_root = asset_root.rstrip("/") + "/"
+    if not normalized_id.startswith(expected_root):
+        return f"Asset id must live under `{expected_root}`."
+
+    leaf = normalized_id[len(expected_root) :].strip("/")
+    if not leaf:
+        return f"Asset id must include a name segment under `{expected_root}`."
+
+    return None
+
+
 def matches_drive_export_prefix(filename: str, prefix: str) -> bool:
     """Return ``True`` when a Drive filename belongs to an export prefix."""
     return (
@@ -288,4 +322,5 @@ __all__ = [
     "resolve_asset_folder",
     "resolve_sepal_folder",
     "sanitize_export_name",
+    "validate_asset_id_under_root",
 ]

--- a/pysepal/templates/solara/solara_map_app/aoi_all_methods_mapapp.py
+++ b/pysepal/templates/solara/solara_map_app/aoi_all_methods_mapapp.py
@@ -262,11 +262,13 @@ def ProcessStep(aoi_data, processed_datasets, sepal_map):
         run_process,
         dependencies=None,
         raise_error=False,
+        prefer_threaded=False,
     )
     failing_task = solara.lab.use_task(
         run_failing_process,
         dependencies=None,
         raise_error=False,
+        prefer_threaded=False,
     )
 
     def start_process():

--- a/tests/test_solara/test_export_component.py
+++ b/tests/test_solara/test_export_component.py
@@ -25,8 +25,9 @@ from pysepal.solara.components.export import (
     resolve_sepal_folder,
     sanitize_export_name,
     submit_export_request,
+    validate_asset_id_under_root,
 )
-from pysepal.solara.components.export_dialog import ExportDialog, _build_gee_asset_hint
+from pysepal.solara.components.export_dialog import ExportDialog
 from pysepal.solara.components.export_hook import get_active_source, use_export_dialog
 
 
@@ -57,12 +58,27 @@ def _render(factory, *args, **kwargs):
     return asyncio.run(_runner())
 
 
-def _render_preselected_dialog(source, *, target="gee"):
+def _render_preselected_dialog(
+    source,
+    *,
+    target="gee",
+    force_conflict_path=None,
+    force_asset_root=None,
+    force_asset_id=None,
+):
     """Render ``ExportDialog`` with a source preselected and the dialog open.
 
     The production UX hides the dialog body until the user picks an asset, so
     assertions about post-selection widgets (destination radio, scale presets,
     folder fields) must drive the controller into the selected state first.
+
+    Pass ``force_conflict_path`` to additionally seed ``gee_asset_conflict``
+    state — useful for asserting the conflict UI without driving the live
+    debounced check.
+
+    Pass ``force_asset_root`` / ``force_asset_id`` to drive root + asset-id
+    state directly — useful for asserting the root-validation UI without
+    waiting on ``_load_asset_root`` (which fails silently against MagicMock).
     """
 
     @solara.component
@@ -77,6 +93,20 @@ def _render_preselected_dialog(source, *, target="gee"):
             controller.selected_source_id.set(source.id)
             controller.selected_target.set(target)
             controller.open.set(True)
+            if force_asset_root is not None:
+                controller._state.asset_root.set(force_asset_root)
+            if force_asset_id is not None:
+                controller._state.gee_asset_id.set(force_asset_id)
+                controller._state.gee_asset_id_dirty.set(True)
+            if force_conflict_path is not None:
+                # Seed a non-empty asset id (and mark dirty) so the live
+                # conflict-check task hits its debounce sleep — which is
+                # cancelled when asyncio.run() tears down the loop — instead
+                # of running to completion and clobbering the forced state.
+                controller._state.gee_asset_id.set(force_conflict_path)
+                controller._state.gee_asset_id_dirty.set(True)
+                controller._state.gee_asset_conflict.set(True)
+                controller._state.gee_asset_conflict_path.set(force_conflict_path)
 
         solara.use_effect(_preselect, [])
         return ExportDialog(controller=controller, title="Test")
@@ -132,14 +162,57 @@ def test_resolve_asset_folder_keeps_absolute_paths():
     assert resolve_asset_folder("projects/my-project/assets", absolute) == absolute
 
 
-def test_build_gee_asset_hint_uses_resolved_folder_and_sanitized_name():
-    hint = _build_gee_asset_hint(
-        "projects/my-project/assets",
-        "exports/final",
-        "My export",
+def test_validate_asset_id_under_root_accepts_path_under_root():
+    assert (
+        validate_asset_id_under_root(
+            "projects/my-project/assets/exports/my_data",
+            "projects/my-project/assets",
+        )
+        is None
     )
 
-    assert hint == ("Will be exported as: projects/my-project/assets/exports/final/My_export")
+
+def test_validate_asset_id_under_root_rejects_different_project():
+    error = validate_asset_id_under_root(
+        "projects/other-project/assets/exports/my_data",
+        "projects/my-project/assets",
+    )
+    assert error is not None
+    assert "projects/my-project/assets/" in error
+
+
+def test_validate_asset_id_under_root_rejects_path_outside_assets():
+    error = validate_asset_id_under_root(
+        "users/somebody/my_data",
+        "projects/my-project/assets",
+    )
+    assert error is not None
+
+
+def test_validate_asset_id_under_root_rejects_root_with_no_name():
+    error = validate_asset_id_under_root(
+        "projects/my-project/assets/",
+        "projects/my-project/assets",
+    )
+    assert error is not None
+    assert "name" in error.lower()
+
+
+def test_validate_asset_id_under_root_defers_when_root_unloaded():
+    """Placeholder root means asset_root hasn't loaded yet — defer validation."""
+    assert (
+        validate_asset_id_under_root(
+            "projects/my-project/assets/foo",
+            "projects/{project}/assets",
+        )
+        is None
+    )
+
+
+def test_validate_asset_id_under_root_lets_empty_pass_through():
+    """Empty asset_id is a separate 'required' error handled elsewhere."""
+    assert validate_asset_id_under_root("", "projects/my-project/assets") is None
+    assert validate_asset_id_under_root("   ", "projects/my-project/assets") is None
 
 
 def test_get_active_source_requires_explicit_selection():
@@ -455,7 +528,7 @@ def test_submit_export_request_builds_gee_asset_result():
         export_kind="table",
         target="gee",
         name="demo_export",
-        gee_folder="reports/2026",
+        gee_asset_id="projects/demo/assets/reports/2026/demo_export",
     )
 
     result = asyncio.run(
@@ -600,9 +673,6 @@ def test_build_request_drops_vis_params_for_table_exports():
         vis_params={"palette": ["#000"]},
     )
 
-    # Mimic the relevant subset of build_request's behavior: the hook clears
-    # vis_params for table kind. We assert by constructing the request directly
-    # the same way the hook does.
     request = ExportRequest(
         ee_object=resolved.ee_object,
         export_kind="table",
@@ -611,6 +681,445 @@ def test_build_request_drops_vis_params_for_table_exports():
         vis_params=resolved.vis_params if "table" == "image" else None,
     )
     assert request.vis_params is None
+
+
+class _FakeGeeInterfaceWithExistingAsset(_FakeGeeInterface):
+    """Variant whose ``get_asset_async`` reports the target asset as existing."""
+
+    def __init__(self):
+        super().__init__()
+        self.checked_asset_ids: list[str] = []
+
+    async def get_asset_async(self, asset_id, not_exists_ok=False):
+        self.checked_asset_ids.append(asset_id)
+        return {"id": asset_id, "type": "TABLE"}
+
+
+def test_submit_export_request_refuses_to_overwrite_existing_gee_asset():
+    gee_interface = _FakeGeeInterfaceWithExistingAsset()
+
+    request = ExportRequest(
+        ee_object=_FakeTable(),
+        export_kind="table",
+        target="gee",
+        name="demo_export",
+        gee_asset_id="projects/demo/assets/reports/2026/demo_export",
+    )
+
+    try:
+        asyncio.run(
+            submit_export_request(
+                request,
+                gee_interface=gee_interface,
+                drive_interface=MagicMock(),
+                sepal_client=None,
+            )
+        )
+    except FileExistsError as exc:
+        assert "projects/demo/assets/reports/2026/demo_export" in str(exc)
+        assert gee_interface.checked_asset_ids == ["projects/demo/assets/reports/2026/demo_export"]
+        # The existence check must run *before* folder creation so a conflict
+        # does not leave empty folders behind.
+        assert gee_interface.created_folders == []
+        assert gee_interface.asset_exports == []
+    else:
+        raise AssertionError("submit_export_request must raise on existing GEE asset")
+
+
+def test_submit_export_request_rejects_empty_gee_asset_id():
+    """Engine validates `gee_asset_id` is non-empty for GEE target."""
+    gee_interface = _FakeGeeInterface()
+
+    request = ExportRequest(
+        ee_object=_FakeTable(),
+        export_kind="table",
+        target="gee",
+        name="demo_export",
+        gee_asset_id="",
+    )
+
+    try:
+        asyncio.run(
+            submit_export_request(
+                request,
+                gee_interface=gee_interface,
+                drive_interface=MagicMock(),
+                sepal_client=None,
+            )
+        )
+    except ValueError as exc:
+        assert "asset id" in str(exc).lower()
+    else:
+        raise AssertionError("Empty gee_asset_id must raise ValueError")
+
+
+def test_submit_export_request_rejects_asset_id_outside_user_root():
+    """Engine refuses an asset_id that does not live under the user's asset root."""
+    gee_interface = _FakeGeeInterface()
+
+    request = ExportRequest(
+        ee_object=_FakeTable(),
+        export_kind="table",
+        target="gee",
+        name="demo_export",
+        gee_asset_id="projects/someone-else/assets/exports/my_data",
+    )
+
+    try:
+        asyncio.run(
+            submit_export_request(
+                request,
+                gee_interface=gee_interface,
+                drive_interface=MagicMock(),
+                sepal_client=None,
+            )
+        )
+    except ValueError as exc:
+        assert "projects/demo/assets/" in str(exc)
+        # Existence check must not run for a path the user cannot write to.
+        assert gee_interface.created_folders == []
+        assert gee_interface.asset_exports == []
+    else:
+        raise AssertionError("Engine must refuse asset ids outside the user's root")
+
+
+class _DriveCheckTrackingGeeInterface(_FakeGeeInterface):
+    """Tracks ``get_asset_async`` calls so we can assert non-GEE targets skip it."""
+
+    def __init__(self):
+        super().__init__()
+        self.checked_asset_ids: list[str] = []
+
+    async def get_asset_async(self, asset_id, not_exists_ok=False):
+        self.checked_asset_ids.append(asset_id)
+        return None
+
+    async def export_table_to_drive_async(self, **_kwargs):
+        return {"id": "drive-task"}
+
+
+def test_submit_export_request_skips_existence_check_for_drive_target():
+    gee_interface = _DriveCheckTrackingGeeInterface()
+
+    request = ExportRequest(
+        ee_object=_FakeTable(),
+        export_kind="table",
+        target="drive",
+        name="demo_export",
+        drive_folder="exports",
+    )
+
+    asyncio.run(
+        submit_export_request(
+            request,
+            gee_interface=gee_interface,
+            drive_interface=MagicMock(),
+            sepal_client=None,
+        )
+    )
+
+    assert gee_interface.checked_asset_ids == []
+
+
+# ---------------------------------------------------------------------------
+# Layer 2: dialog live conflict hint
+# ---------------------------------------------------------------------------
+
+
+class _ConflictProbeGeeInterface:
+    """Records ``get_asset_async`` calls; returns whatever was preconfigured."""
+
+    def __init__(self, existing_asset=None, raises: Exception | None = None):
+        self.existing_asset = existing_asset
+        self.raises = raises
+        self.checked_asset_ids: list[str] = []
+
+    async def get_asset_async(self, asset_id, not_exists_ok=False):
+        self.checked_asset_ids.append(asset_id)
+        if self.raises is not None:
+            raise self.raises
+        return self.existing_asset
+
+
+def test_resolve_gee_asset_conflict_short_circuits_when_target_not_gee():
+    gee_interface = _ConflictProbeGeeInterface(existing_asset={"id": "ignored"})
+
+    conflict, path = asyncio.run(
+        export_hook_module._resolve_gee_asset_conflict(
+            target="drive",
+            has_active_source=True,
+            asset_id="projects/demo/assets/reports/my_export",
+            gee_interface=gee_interface,
+            debounce_seconds=0,
+        )
+    )
+
+    assert conflict is False
+    assert path == ""
+    # Never touches the network for non-GEE targets.
+    assert gee_interface.checked_asset_ids == []
+
+
+def test_resolve_gee_asset_conflict_short_circuits_when_asset_id_empty():
+    gee_interface = _ConflictProbeGeeInterface(existing_asset={"id": "ignored"})
+
+    conflict, path = asyncio.run(
+        export_hook_module._resolve_gee_asset_conflict(
+            target="gee",
+            has_active_source=True,
+            asset_id="   ",
+            gee_interface=gee_interface,
+            debounce_seconds=0,
+        )
+    )
+
+    assert conflict is False
+    assert path == ""
+    assert gee_interface.checked_asset_ids == []
+
+
+def test_resolve_gee_asset_conflict_short_circuits_when_no_active_source():
+    gee_interface = _ConflictProbeGeeInterface(existing_asset={"id": "ignored"})
+
+    conflict, path = asyncio.run(
+        export_hook_module._resolve_gee_asset_conflict(
+            target="gee",
+            has_active_source=False,
+            asset_id="projects/demo/assets/reports/my_export",
+            gee_interface=gee_interface,
+            debounce_seconds=0,
+        )
+    )
+
+    assert conflict is False
+    assert path == ""
+    assert gee_interface.checked_asset_ids == []
+
+
+def test_resolve_gee_asset_conflict_returns_no_conflict_when_asset_absent():
+    gee_interface = _ConflictProbeGeeInterface(existing_asset=None)
+
+    conflict, path = asyncio.run(
+        export_hook_module._resolve_gee_asset_conflict(
+            target="gee",
+            has_active_source=True,
+            asset_id="projects/demo/assets/reports/my_export",
+            gee_interface=gee_interface,
+            debounce_seconds=0,
+        )
+    )
+
+    assert conflict is False
+    assert path == ""
+    assert gee_interface.checked_asset_ids == ["projects/demo/assets/reports/my_export"]
+
+
+def test_resolve_gee_asset_conflict_flags_conflict_when_asset_exists():
+    gee_interface = _ConflictProbeGeeInterface(
+        existing_asset={"id": "projects/demo/assets/reports/My_export"},
+    )
+
+    conflict, path = asyncio.run(
+        export_hook_module._resolve_gee_asset_conflict(
+            target="gee",
+            has_active_source=True,
+            asset_id="projects/demo/assets/reports/My_export",
+            gee_interface=gee_interface,
+            debounce_seconds=0,
+        )
+    )
+
+    assert conflict is True
+    assert path == "projects/demo/assets/reports/My_export"
+    assert gee_interface.checked_asset_ids == ["projects/demo/assets/reports/My_export"]
+
+
+def test_resolve_gee_asset_conflict_swallows_lookup_errors():
+    gee_interface = _ConflictProbeGeeInterface(raises=RuntimeError("transient network blip"))
+
+    conflict, path = asyncio.run(
+        export_hook_module._resolve_gee_asset_conflict(
+            target="gee",
+            has_active_source=True,
+            asset_id="projects/demo/assets/reports/my_export",
+            gee_interface=gee_interface,
+            debounce_seconds=0,
+        )
+    )
+
+    # Lookup failures must not block the user; engine guard remains authoritative.
+    assert conflict is False
+    assert path == ""
+    assert gee_interface.checked_asset_ids == ["projects/demo/assets/reports/my_export"]
+
+
+def test_build_default_gee_asset_id_uses_asset_root_and_module_folder():
+    resolved = ResolvedExport(ee_object=_FakeTable(), default_name="My export")
+    sepal_client = SimpleNamespace(module_name="aoi_all_methods")
+
+    asset_id = export_hook_module._build_default_gee_asset_id(
+        "projects/demo/assets",
+        resolved,
+        sepal_client,
+    )
+
+    assert asset_id == "projects/demo/assets/aoi_all_methods/My_export"
+
+
+def test_build_default_gee_asset_id_respects_absolute_resolved_folder():
+    resolved = ResolvedExport(
+        ee_object=_FakeTable(),
+        default_name="data",
+        gee_folder="projects/other/assets/exports/2026",
+    )
+
+    asset_id = export_hook_module._build_default_gee_asset_id(
+        "projects/demo/assets",
+        resolved,
+        None,
+    )
+
+    assert asset_id == "projects/other/assets/exports/2026/data"
+
+
+def test_build_default_gee_asset_id_returns_empty_until_asset_root_loads():
+    resolved = ResolvedExport(ee_object=_FakeTable(), default_name="data")
+
+    asset_id = export_hook_module._build_default_gee_asset_id(
+        "projects/{project}/assets",
+        resolved,
+        None,
+    )
+
+    assert asset_id == ""
+
+
+def test_export_dialog_renders_single_asset_id_field_for_gee_target():
+    """GEE target collapses Export name + EE folder into one Asset ID field."""
+    source = ExportSource(
+        id="demo",
+        label="Demo layer",
+        kind="table",
+        resolve=lambda: ResolvedExport(
+            ee_object=_FakeTable(),
+            default_name="demo_export",
+        ),
+    )
+    element = _render_preselected_dialog(source=source, target="gee")
+
+    def _walk(widget):
+        yield widget
+        for child in getattr(widget, "children", ()) or ():
+            yield from _walk(child)
+
+    text_fields = [widget for widget in _walk(element) if widget.__class__.__name__ == "TextField"]
+    labels = [getattr(widget, "label", None) for widget in text_fields]
+
+    assert "Asset ID" in labels, "GEE target must render an Asset ID field"
+    assert "Earth Engine folder" not in labels
+    assert "Export name" not in labels
+
+
+def test_export_dialog_marks_asset_id_field_with_error_on_conflict():
+    source = ExportSource(
+        id="demo",
+        label="Demo layer",
+        kind="table",
+        resolve=lambda: ResolvedExport(
+            ee_object=_FakeTable(),
+            default_name="demo_export",
+        ),
+    )
+    element = _render_preselected_dialog(
+        source=source,
+        target="gee",
+        force_conflict_path="projects/demo/assets/reports/demo_export",
+    )
+
+    def _walk(widget):
+        yield widget
+        for child in getattr(widget, "children", ()) or ():
+            yield from _walk(child)
+
+    asset_id_fields = [
+        widget
+        for widget in _walk(element)
+        if widget.__class__.__name__ == "TextField" and getattr(widget, "label", None) == "Asset ID"
+    ]
+
+    assert asset_id_fields, "Asset ID field must be rendered"
+    field = asset_id_fields[0]
+    assert getattr(field, "error", False) is True
+    error_messages = str(getattr(field, "error_messages", ""))
+    assert "already exists" in error_messages.lower()
+    # Path should NOT be repeated in the message — the field already shows it.
+    assert "projects/demo/assets/reports/demo_export" not in error_messages
+
+
+def test_export_dialog_marks_asset_id_field_with_error_when_outside_root():
+    """User-edited asset_id outside the user's GEE asset root surfaces inline."""
+    source = ExportSource(
+        id="demo",
+        label="Demo layer",
+        kind="table",
+        resolve=lambda: ResolvedExport(
+            ee_object=_FakeTable(),
+            default_name="demo_export",
+        ),
+    )
+    element = _render_preselected_dialog(
+        source=source,
+        target="gee",
+        force_asset_root="projects/my-project/assets",
+        force_asset_id="projects/someone-else/assets/exports/my_data",
+    )
+
+    def _walk(widget):
+        yield widget
+        for child in getattr(widget, "children", ()) or ():
+            yield from _walk(child)
+
+    asset_id_fields = [
+        widget
+        for widget in _walk(element)
+        if widget.__class__.__name__ == "TextField" and getattr(widget, "label", None) == "Asset ID"
+    ]
+
+    assert asset_id_fields, "Asset ID field must be rendered"
+    field = asset_id_fields[0]
+    assert getattr(field, "error", False) is True
+    error_messages = str(getattr(field, "error_messages", ""))
+    assert "projects/my-project/assets/" in error_messages
+    assert "must live under" in error_messages.lower()
+
+
+def test_export_dialog_renders_export_name_and_drive_folder_for_drive_target():
+    """Drive/SEPAL targets keep the existing Export name + Drive folder UX."""
+    source = ExportSource(
+        id="demo",
+        label="Demo layer",
+        kind="table",
+        resolve=lambda: ResolvedExport(
+            ee_object=_FakeTable(),
+            default_name="demo_export",
+        ),
+    )
+    element = _render_preselected_dialog(source=source, target="drive")
+
+    def _walk(widget):
+        yield widget
+        for child in getattr(widget, "children", ()) or ():
+            yield from _walk(child)
+
+    labels = [
+        getattr(widget, "label", None)
+        for widget in _walk(element)
+        if widget.__class__.__name__ == "TextField"
+    ]
+
+    assert "Export name" in labels
+    assert "Google Drive folder" in labels
+    assert "Asset ID" not in labels
 
 
 class _FakeRestSession:

--- a/tests/test_solara/test_export_component.py
+++ b/tests/test_solara/test_export_component.py
@@ -607,7 +607,7 @@ def test_submit_export_request_embeds_vis_params_on_image_for_gee_asset(monkeypa
         export_kind="image",
         target="gee",
         name="styled_export",
-        gee_folder="gfc",
+        gee_asset_id="projects/demo/assets/gfc/styled_export",
         vis_params=vis_params,
     )
 
@@ -648,7 +648,7 @@ def test_submit_export_request_skips_viz_embed_when_vis_params_missing(monkeypat
         export_kind="image",
         target="gee",
         name="plain_export",
-        gee_folder="demo",
+        gee_asset_id="projects/demo/assets/demo/plain_export",
     )
 
     asyncio.run(


### PR DESCRIPTION
## Summary

- Replace `Export name` + `Earth Engine folder` with one editable `Asset ID` field for the GEE target. Pre-filled with the full path; Drive/SEPAL UX unchanged.
- `ExportRequest.gee_folder` → `ExportRequest.gee_asset_id`. `ResolvedExport.gee_folder` stays as the default-folder hint feeding the pre-fill.
- Three guards on the asset id, surfaced inline + re-enforced by the engine at submit: **required**, **root** (must live under `projects/<project>/assets/`, shared `validate_asset_id_under_root` helper), and **conflict** (debounced `get_asset_async` probe; `FileExistsError` at submit as the authoritative guard).
- Also pins two `use_task` hooks in the `aoi_all_methods_mapapp` template with `prefer_threaded=False` so EE session primitives stay on the kernel loop across start/cancel cycles (separate commit).

## Test plan

- [x] `nox -s test -- tests/test_solara/test_export_component.py` (49 tests, 8 new)
- [x] Pre-commit clean (black, ruff, prettier, codespell, commitizen)
- [ ] Smoke test in the `aoi_all_methods_mapapp` template: open dialog → observe auto-filled `projects/<project>/assets/<module>/<name>` → try editing outside the root → try a known-existing asset → try empty
- [ ] Verify the engine catches conflicts / wrong-root submissions when the dialog's live check has missed them (clicked Export before the 350 ms debounce settled)