### PR TITLE
ci: add CODEOWNERS for sensitive paths

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,12 @@
+# Reviews on these paths require @dfguerrerom even if other reviewers
+# already approved the PR. Enforced via branch protection's "Require review
+# from Code Owners" toggle.
+#
+# Rationale: workflows run with secrets (EE, PyPI publishing), pyproject
+# declares the dep tree (pip install runs setup.py as root in CI),
+# conftest/noxfile execute on every test run.
+
+/.github/                       @dfguerrerom
+/pyproject.toml                 @dfguerrerom
+/noxfile.py                     @dfguerrerom
+/tests/conftest.py              @dfguerrerom


### PR DESCRIPTION
## Summary

Add a CODEOWNERS file declaring @dfguerrerom as the required reviewer for paths whose modification has RCE-equivalent reach during CI:

- \`.github/\` — workflows run with EE/PyPI secrets
- \`pyproject.toml\` — dep declarations (pip install runs setup.py)
- \`noxfile.py\` — drives test session installs and execution
- \`tests/conftest.py\` — runs on every test session

## Activation

This file is dormant until the branch protection rule on \`main\` enables **Require review from Code Owners**. Until then, GitHub will auto-request code owners as reviewers but won't block merges.