### PR TITLE
ci: switch PyPI release to OIDC trusted publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,22 +7,25 @@ on:
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    environment: pypi
+    permissions:
+      id-token: write # OIDC for trusted publishing to PyPI
+      contents: write # merge-branch step pushes to the release branch
 
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
 
-      - name: Install dependencies
-        run: pip install setuptools wheel twine build
+      - name: Install build tooling
+        run: pip install build
 
-      - name: Build and publish
-        env:
-          TWINE_USERNAME: __token__
-          TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
-        run: |
-          python -m build
-          twine upload dist/* --verbose
+      - name: Build distribution
+        run: python -m build
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
+        # Auth via OIDC trusted publisher; no PYPI_PASSWORD needed.
 
       - name: merge in release
         uses: devmasx/merge-branch@854d3ac71ed1e9deb668e0074781b81fdd6e771f # v1.4.0


### PR DESCRIPTION
## Summary

Replace the long-lived \`PYPI_PASSWORD\` secret with PyPI's OIDC trusted publisher flow via \`pypa/gh-action-pypi-publish\`. Publishing now happens through a short-lived token minted at release time, scoped to this repo + workflow + environment.

The deploy job runs in the \`pypi\` GitHub Environment (which PyPI's trusted publisher matches against) and requires \`id-token: write\` plus \`contents: write\` (the latter for the existing \`devmasx/merge-branch\` step that pushes to the release branch).

(Originally bundled with PR #988 but landed after that PR merged; extracted into its own PR.)

## Why this is also urgent

The v3.6.0 release just failed with:

\`\`\`
ERROR InvalidDistribution: Invalid distribution metadata: unrecognized or
malformed field 'license-file'
\`\`\`

That's caused by the old \`twine\` version installed by the current release workflow not recognizing Core Metadata 2.4 fields emitted by current setuptools/hatchling. \`pypa/gh-action-pypi-publish\` bundles a current \`twine\` that handles the field, so this PR fixes the v3.6.0 publish failure as a side effect.

## Prerequisites already met

- Trusted publisher already configured on PyPI for \`pysepal\`
- \`pypi\` GitHub Environment already exists in this repo

## After merging

Re-create the v3.6.0 release on GitHub (delete the current release record, recreate from the same tag) to re-trigger \`release.yml\` with the new flow. PyPI didn't accept any files for v3.6.0 (twine errored client-side before sending), so the version number is still available.

Once the publish succeeds, delete the \`PYPI_PASSWORD\` secret from this repo's settings.