### PR TITLE
ci: trigger release on 'published' instead of 'created'

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,8 @@ name: Upload Python Package
 
 on:
   release:
-    types: [created]
+    types: [published]
+  workflow_dispatch:
 
 jobs:
   deploy:


### PR DESCRIPTION
## Summary

Align this repo's release trigger with ee-client and pysepal-api:

- `release: types: [created]` -> `[published]` — draft releases no longer fire the publish workflow
- Add `workflow_dispatch` — lets us manually retry without deleting and recreating a release

No other changes; OIDC publishing is unchanged.