### PR TITLE
docs: note MapAppComponent/layout API is not yet shipped

### DIFF
--- a/docs/guides/migration-notes-v3.4.md
+++ b/docs/guides/migration-notes-v3.4.md
@@ -206,9 +206,17 @@ boilerplate; swap `theme_toggle=` for `theme_state=` on `SepalMap` and `MapApp`.
 
 ## 8. MapApp → MapAppComponent
 
-The `pysepal.sepalwidgets.vue_app.MapApp` VuetifyTemplate is deprecated.
-Prefer `pysepal.solara.components.layout.MapAppComponent` (re-exported
-as `pysepal.solara.MapAppComponent`). The new component:
+```{important}
+**Not yet available** (as of pysepal 3.6.1): `MapAppComponent` and
+`pysepal.solara.components.layout` are not in the released package — the module
+is empty and the imports raise `ImportError`. Keep using `MapApp.element`
+(reacton renders `@solara.component` tiles passed as `content`). The guidance
+below describes the **planned target**, not the current state.
+```
+
+Once it ships, prefer `pysepal.solara.components.layout.MapAppComponent`
+(re-exported as `pysepal.solara.MapAppComponent`) over the
+`pysepal.sepalwidgets.vue_app.MapApp` VuetifyTemplate. The new component:
 
 - Is a `@solara.component` usable with `with MapAppComponent(...): ...`.
 - Exposes typed dataclass props: `StepConfig`, `PanelSection`,

--- a/docs/guides/solara-mapapp-component.md
+++ b/docs/guides/solara-mapapp-component.md
@@ -6,9 +6,20 @@ exposes typed dataclass props, auto-wires `ThemeState` / `Translator`,
 and preserves the visual design of the original `MapApp.vue`
 (drawer, narrow-mode bottom sheet, dialog steps, right panel).
 
-```{warning}
-The legacy `pysepal.sepalwidgets.vue_app.MapApp` still works but emits a
-`DeprecationWarning`. Migrate to `MapAppComponent` for new code.
+```{important}
+**Availability — not yet shipped.** As of pysepal 3.6.1, `MapAppComponent` and
+the `pysepal.solara.components.layout` package are **not present in the released
+package**: the `layout` module is empty and `from pysepal.solara import
+MapAppComponent` (along with the dataclasses below) raises `ImportError`. The
+API documented here is the **planned target** — verify availability with
+`python -c "from pysepal.solara import MapAppComponent"` before relying on it.
+
+Until it lands, build the shell with the shipped
+`pysepal.sepalwidgets.vue_app.MapApp.element(...)`. Reacton renders nested
+Solara elements before they reach `MapApp`'s `List(Instance(DOMWidget))` traits,
+so modern `@solara.component` tiles can be passed straight through as step /
+panel `content`. The legacy `MapApp` is therefore **not** effectively deprecated
+yet — it remains the supported shell until `MapAppComponent` ships.
 ```
 
 ## Quick start


### PR DESCRIPTION
The guides present `MapAppComponent` + `pysepal.solara.components.layout` as the current shell, but they aren't shipped in 3.6.1 (layout package empty; imports raise `ImportError`). Add an availability note in `solara-mapapp-component.md` and `migration-notes-v3.4.md` §8 pointing to `MapApp.element` until it lands. Docs only.