### PR TITLE
fix(sepalwidgets): read VectorField property names server-side to avoid pulling geometry

### DIFF
--- a/pysepal/sepalwidgets/inputs.py
+++ b/pysepal/sepalwidgets/inputs.py
@@ -631,7 +631,7 @@ class LoadTableField(v.Col, SepalWidget):
         return self
 
     def _set_v_model(self, key: str, value: Any) -> None:
-        """set the v_model from an external function to trigger the change event.
+        """Set the v_model from an external function to trigger the change event.
 
         Args:
             key: the column name
@@ -1196,7 +1196,9 @@ class VectorField(v.Col, SepalWidget):
 
         elif isinstance(self.w_file, AssetSelect):
             self.feature_collection = ee.FeatureCollection(change["new"])
-            columns = self.gee_interface.get_info(self.feature_collection.first())["properties"]
+            # read only the property names server-side to avoid pulling geometry
+            first = ee.Feature(self.feature_collection.first())
+            columns = self.gee_interface.get_info(first.propertyNames())
             columns = [str(col) for col in columns if col not in ["system:index", "Shape_Area"]]
 
         # update the columns


### PR DESCRIPTION
## What

In `VectorField`, when the file selector is an `AssetSelect`, the column list was built by pulling the whole `.first()` feature client-side and reading its `["properties"]`. That drags the feature's geometry to the client just to discard it.

## Change

Request only the property names server-side via `ee.Feature(...).propertyNames()`, avoiding the geometry transfer. Also fixes a docstring capitalization in `_set_v_model`.

Scope: `pysepal/sepalwidgets/inputs.py` only.