### PR TITLE
fix(aoi): avoid 2M-edge dissolve in AOI bounds computation

### DIFF
--- a/pysepal/aoi/aoi_model.py
+++ b/pysepal/aoi/aoi_model.py
@@ -532,10 +532,7 @@ class AoiModel(Model):
             raise ValueError(ms.aoi_sel.exception.no_gdf)
 
         if self.gee:
-            coords = self.gee_interface.get_info(
-                self.feature_collection.geometry().bounds().coordinates().get(0)
-            )
-            bounds = [coords[0][0], coords[0][1], coords[2][0], coords[2][1]]
+            bounds = list(self.gee_interface.get_bounds(self.feature_collection))
         else:
             bounds = self.gdf.total_bounds.tolist()
 

--- a/pysepal/mapping/aoi_control.py
+++ b/pysepal/mapping/aoi_control.py
@@ -81,12 +81,7 @@ class AoiControl(MenuControl):
             item: the item to use to compute the bounds. It need to be a shapely geometry or an ee object.
         """
         if isinstance(item, ee.ComputedObject):
-            # extract bounds from ee_object
-            ee_geometry = item if isinstance(item, ee.Geometry) else item.geometry()
-            bl, br, tr, tl, _ = self.map_.gee_interface.get_info(
-                ee_geometry.bounds().coordinates().get(0)
-            )
-            bounds = (*bl, *tr)
+            bounds = self.map_.gee_interface.get_bounds(item)
 
         elif isinstance(item, sg.base.BaseGeometry):
             bounds = item.bounds

--- a/pysepal/mapping/sepal_map.py
+++ b/pysepal/mapping/sepal_map.py
@@ -352,14 +352,10 @@ class SepalMap(ipl.Map):
             item: the geometry to zoom on
             zoom_out: Zoom out the bounding zoom
         """
-        # type check the given object
-        ee_geometry = item if isinstance(item, ee.Geometry) else item.geometry()
-
-        # extract bounds from ee_object
-        coords = self.gee_interface.get_info(ee_geometry.bounds().coordinates().get(0))
+        bounds = self.gee_interface.get_bounds(item)
 
         # zoom on these bounds
-        return self.zoom_bounds((*coords[0], *coords[2]), zoom_out)
+        return self.zoom_bounds(bounds, zoom_out)
 
     def zoom_raster(self, layer: ipl.LocalTileLayer, zoom_out: int = 1) -> Self:
         """Adapt the zoom to the given LocalLayer.
@@ -638,11 +634,7 @@ class SepalMap(ipl.Map):
 
         if autocenter:
             try:
-                ee_geometry = (
-                    ee_object if isinstance(ee_object, ee.Geometry) else ee_object.geometry()
-                )
-                bounds = self.gee_interface.get_info(ee_geometry.bounds().coordinates().get(0))
-                self.zoom_bounds((*bounds[0], *bounds[2]))
+                self.zoom_bounds(self.gee_interface.get_bounds(ee_object))
             except Exception:
                 log.debug("autocenter skipped: unable to compute bounds (unbounded image?)")
 
@@ -713,13 +705,7 @@ class SepalMap(ipl.Map):
 
         if autocenter:
             try:
-                ee_geometry = (
-                    ee_object if isinstance(ee_object, ee.Geometry) else ee_object.geometry()
-                )
-                bounds = await self.gee_interface.get_info_async(
-                    ee_geometry.bounds().coordinates().get(0)
-                )
-                self.zoom_bounds((*bounds[0], *bounds[2]))
+                self.zoom_bounds(await self.gee_interface.get_bounds_async(ee_object))
             except Exception:
                 log.debug("autocenter skipped: unable to compute bounds (unbounded image?)")
 

--- a/pysepal/scripts/gee_interface.py
+++ b/pysepal/scripts/gee_interface.py
@@ -4,7 +4,7 @@ import asyncio
 import threading
 import traceback
 from pathlib import PurePosixPath
-from typing import Any, Callable, Coroutine, Dict, List, Optional, Union
+from typing import Any, Callable, Coroutine, Dict, List, Optional, Tuple, Union
 
 import ee
 from eeclient.client import EESession
@@ -55,6 +55,34 @@ def _resolve_create_folder_paths(asset_root: str, folder_path: str) -> tuple[str
     relative_parts = absolute_parts[len(root_parts) :]
     relative_path = str(PurePosixPath(*relative_parts)) if relative_parts else ""
     return relative_path, absolute_path
+
+
+def _bbox_geometry(item: ee.ComputedObject) -> ee.Geometry:
+    """Build the bounding-box geometry of an Earth Engine object without dissolving.
+
+    ``ee.FeatureCollection.geometry()`` unions every feature into a single
+    geometry, which trips Earth Engine's hard 2M-edge limit on dense
+    collections. Reducing each feature to its own bounding box *first* yields an
+    identical extent while keeping every intermediate geometry tiny (#996).
+
+    Assumes no single feature on its own exceeds the 2M-edge limit.
+
+    Args:
+        item: an ``ee.Geometry``, ``ee.Feature``, ``ee.FeatureCollection`` or
+            ``ee.Image`` (or subclass).
+
+    Returns:
+        the bounding-box geometry of ``item``.
+    """
+    if isinstance(item, ee.Geometry):
+        geom = item
+    elif isinstance(item, ee.FeatureCollection):
+        # reduce each feature to its bbox before unioning (avoids the dissolve)
+        geom = item.map(lambda f: ee.Feature(f.geometry().bounds())).geometry()
+    else:
+        # ee.Image / ee.Feature: a single geometry, no collection to dissolve
+        geom = item.geometry()
+    return geom.bounds()
 
 
 class GEEInterface:
@@ -186,6 +214,23 @@ class GEEInterface:
     ) -> List:
         """Synchronously get info for multiple Earth Engine objects in batch."""
         return self._run_async_blocking(self.get_info_batch_async(ee_objects), timeout)
+
+    async def get_bounds_async(self, item: ee.ComputedObject) -> Tuple[float, float, float, float]:
+        """Asynchronously compute the extent of an Earth Engine object.
+
+        Dense feature collections are reduced per-feature to avoid Earth Engine's
+        2M-edge limit on ``FeatureCollection.geometry()`` (issue #996).
+
+        Args:
+            item: an ``ee.Geometry``, ``ee.Feature``, ``ee.FeatureCollection`` or
+                ``ee.Image``.
+
+        Returns:
+            the bounding box as ``(minx, miny, maxx, maxy)``.
+        """
+        ring = _bbox_geometry(item).coordinates().get(0)
+        coords = await self.get_info_async(ring)
+        return (coords[0][0], coords[0][1], coords[2][0], coords[2][1])
 
     async def get_map_id_async(
         self,
@@ -460,6 +505,24 @@ class GEEInterface:
         return self._run_async_blocking(
             self.get_info_async(ee_object, tag, serialized_object=serialized_object), timeout
         )
+
+    def get_bounds(
+        self, item: ee.ComputedObject, timeout: Optional[float] = None
+    ) -> Tuple[float, float, float, float]:
+        """Compute the extent of an Earth Engine object, blocking until done.
+
+        Dense feature collections are reduced per-feature to avoid Earth Engine's
+        2M-edge limit on ``FeatureCollection.geometry()`` (issue #996).
+
+        Args:
+            item: an ``ee.Geometry``, ``ee.Feature``, ``ee.FeatureCollection`` or
+                ``ee.Image``.
+            timeout: optional seconds to wait for the blocking call.
+
+        Returns:
+            the bounding box as ``(minx, miny, maxx, maxy)``.
+        """
+        return self._run_async_blocking(self.get_bounds_async(item), timeout)
 
     def get_map_id(
         self,

--- a/tests/test_aoi/test_AoiModel.py
+++ b/tests/test_aoi/test_AoiModel.py
@@ -225,6 +225,28 @@ def test_total_bounds(test_model: aoi.AoiModel, data_regression) -> None:
 
 @pytest.mark.gee
 @pytest.mark.skipif(not ee.data.is_initialized(), reason="GEE is not set")
+def test_total_bounds_dense_aoi(gee_dir: Path) -> None:
+    """total_bounds must not dissolve a dense AOI past Earth Engine's 2M-edge limit.
+
+    Regression for #996: GAUL 2024 Indonesia (~2.4M edges across 4 features)
+    overflowed ``feature_collection.geometry()``. total_bounds now reduces each
+    feature to its bbox first, so the extent comes back without dissolving.
+
+    Args:
+        gee_dir: the session directory where assets are saved
+    """
+    # GAUL 2024 Indonesia — dense enough that the naive dissolve hits the limit
+    model = aoi.AoiModel(admin="241", folder=gee_dir)
+
+    bounds = model.total_bounds()
+
+    assert bounds == pytest.approx([95.0108, -11.0076, 141.0194, 6.0769], abs=0.05)
+
+    return
+
+
+@pytest.mark.gee
+@pytest.mark.skipif(not ee.data.is_initialized(), reason="GEE is not set")
 def test_clear_output(test_model: aoi.AoiModel, aoi_model_outputs: List[str]) -> None:
     """Clear all output from a AoiModel.
 

--- a/tests/test_mapping/test_SepalMap.py
+++ b/tests/test_mapping/test_SepalMap.py
@@ -581,12 +581,8 @@ def test_add_ee_layer_autocenter_sync() -> None:
     m = sm.SepalMap()
     ee_object = ee.Geometry.Rectangle([-180, -90, 180, 90])
 
-    # Mock the bounds coordinates that would be returned by EE
-    # bounds().coordinates().get(0) returns [[minx, miny], [minx, maxy], [maxx, maxy], [maxx, miny], [minx, miny]]
-    mock_bounds = [[-180, -90], [-180, 90], [180, 90], [180, -90], [-180, -90]]
-
-    # Mock gee_interface methods
-    m.gee_interface.get_info = MagicMock(return_value=mock_bounds)
+    # Mock the extent get_bounds computes for the object (per-feature-bbox, #996)
+    m.gee_interface.get_bounds = MagicMock(return_value=(-180, -90, 180, 90))
     m.gee_interface.get_map_id = MagicMock(
         return_value={"tile_fetcher": MagicMock(url_format="http://test")}
     )
@@ -611,12 +607,8 @@ async def test_add_ee_layer_autocenter_async() -> None:
     m = sm.SepalMap()
     ee_object = ee.Geometry.Rectangle([-180, -90, 180, 90])
 
-    # Mock the bounds coordinates that would be returned by EE
-    # bounds().coordinates().get(0) returns [[minx, miny], [minx, maxy], [maxx, maxy], [maxx, miny], [minx, miny]]
-    mock_bounds = [[-180, -90], [-180, 90], [180, 90], [180, -90], [-180, -90]]
-
-    # Mock gee_interface async methods
-    m.gee_interface.get_info_async = AsyncMock(return_value=mock_bounds)
+    # Mock the extent get_bounds_async computes for the object (per-feature-bbox, #996)
+    m.gee_interface.get_bounds_async = AsyncMock(return_value=(-180, -90, 180, 90))
     m.gee_interface.get_map_id_async = AsyncMock(
         return_value={"tile_fetcher": MagicMock(url_format="http://test")}
     )

--- a/tests/test_scripts/test_gee_interface.py
+++ b/tests/test_scripts/test_gee_interface.py
@@ -449,3 +449,50 @@ def test_get_map_id_with_sepal(
     assert "tile_fetcher" in map_id or "mapid" in map_id
 
     return
+
+
+@pytest.mark.gee
+@pytest.mark.skipif(not ee.data.is_initialized(), reason="GEE is not set")
+def test_get_bounds_geometry(gee_interface: GEEInterface) -> None:
+    """get_bounds returns the extent of a plain ee.Geometry.
+
+    Args:
+        gee_interface: the GEEInterface fixture
+    """
+    bounds = gee_interface.get_bounds(ee.Geometry.BBox(1.0, 2.0, 3.0, 4.0))
+
+    assert len(bounds) == 4
+    assert list(bounds) == pytest.approx([1.0, 2.0, 3.0, 4.0], abs=1e-4)
+
+    return
+
+
+@pytest.mark.gee
+@pytest.mark.skipif(not ee.data.is_initialized(), reason="GEE is not set")
+def test_get_bounds_dense_aoi(gee_interface: GEEInterface) -> None:
+    """get_bounds avoids FeatureCollection.geometry()'s 2M-edge limit on dense AOIs.
+
+    Regression for #996: GAUL 2024 Indonesia is ~2.4M edges across 4 features,
+    so the naive ``fc.geometry().bounds()`` dissolve overflows Earth Engine's
+    hard 2M-edge limit. get_bounds reduces each feature to its own bbox before
+    unioning, so the extent comes back without dissolving.
+
+    Args:
+        gee_interface: the GEEInterface fixture
+    """
+    pygaul = pytest.importorskip("pygaul")
+    indonesia = pygaul.Items(admin="241")  # GAUL 2024 Indonesia
+
+    # the naive dissolve must fail — this is exactly the bug being fixed
+    with pytest.raises(ee.EEException, match="too many edges"):
+        indonesia.geometry().bounds().getInfo()
+
+    # get_bounds must succeed and return Indonesia's extent
+    minx, miny, maxx, maxy = gee_interface.get_bounds(indonesia)
+
+    assert minx == pytest.approx(95.0108, abs=0.05)
+    assert miny == pytest.approx(-11.0076, abs=0.05)
+    assert maxx == pytest.approx(141.0194, abs=0.05)
+    assert maxy == pytest.approx(6.0769, abs=0.05)
+
+    return


### PR DESCRIPTION
## Problem

`AoiModel.total_bounds()` and the `SepalMap` zoom/autocenter helpers compute extents via `FeatureCollection.geometry()`, which unions every feature into one geometry. On dense boundaries (GAUL 2024 Indonesia, ~2.4M edges) this overflows Earth Engine's hard 2M-edge limit:

```
Collection.geometry: Geometry has too many edges (2447944 > 2000000)
```

## Fix

Add `GEEInterface.get_bounds()` / `get_bounds_async()`, which reduce each feature to its bounding box **before** unioning — identical extent, no dissolve. Routed through it:

- `AoiModel.total_bounds()`
- `SepalMap.zoom_ee_object` (= `centerObject`)
- `SepalMap.add_ee_layer` / `add_ee_layer_async` autocenter (fixes the Solara `AoiView` GEE path)
- `AoiControl.add_aoi`

## Tests

- `test_get_bounds_dense_aoi`: asserts the naive dissolve raises and the new path returns Indonesia's extent.
- `test_total_bounds_dense_aoi`: end-to-end on a dense admin AOI.
- Vatican `total_bounds` confirmed byte-identical (no change for normal AOIs).

Fixes #996.
