### PR TITLE
feat(export): add band selection to export dialog

### DIFF
--- a/docs/guides/solara-export.md
+++ b/docs/guides/solara-export.md
@@ -130,7 +130,9 @@ ResolvedExport(
                                        # or the Export name field (Drive/SEPAL)
     region=aoi.value,                 # optional, used for image exports
     default_scale=30,                 # optional, used for image exports
-    selectors=("ADM0_NAME",),          # optional, narrow table columns
+    selectors=("ADM0_NAME",),          # optional, pre-baked subset (bypasses the picker)
+    bands=("B4", "B3", "B2"),          # optional catalog; renders the picker (see below)
+    default_bands=("B4", "B3"),       # optional initial selection; defaults to all bands
     gee_folder="my_module",           # optional folder segment under the user's
                                        # asset root; feeds the auto-filled Asset ID
                                        # (e.g. projects/<project>/assets/my_module/<name>).
@@ -149,6 +151,111 @@ ResolvedExport(
 
 The user can override any destination-related field in the dialog. The
 `default_*` values just pre-fill the controls.
+
+## Band Selection
+
+Every **image** export gets a band picker automatically: when a source
+does not declare a catalog, the dialog fetches the image's band names
+from Earth Engine (`image.bandNames()`) and renders the multi-select
+picker regardless of band count — a spinner stands in while the names
+load. Apps that want a specific order, a subset, or a non-default initial
+selection can still declare a catalog explicitly (see below); a declared
+catalog skips discovery. **Tables** never auto-discover — declare a
+catalog to expose a property picker.
+
+The user-selected subset is threaded through `ExportRequest.selectors`
+and applied by the engine:
+
+- **Images** → `image.select(selectors)` is applied to the EE object
+  before submission (the image-export endpoints do not accept a
+  `selectors` parameter, so it has to be baked into the image).
+- **Tables** → `selectors=` is passed straight through to
+  `Export.table.toAsset` / `Export.table.toDrive`, which is how Earth
+  Engine selects feature properties.
+
+Declare the catalog on the source:
+
+```python
+ExportSource(
+    id="landsat_composite",
+    label="Landsat composite",
+    kind="image",
+    resolve=lambda: ResolvedExport(
+        ee_object=composite,
+        default_name="landsat_composite",
+        region=aoi.geometry(),
+        default_scale=30,
+        bands=("B4", "B3", "B2", "B5", "B6", "B7"),    # full catalog
+        default_bands=("B4", "B3", "B2"),               # initial selection
+    ),
+)
+```
+
+Rules:
+
+- `bands=None` (the default) auto-discovers the catalog for **image**
+  sources (the picker always renders, 1 band or many) and hides the
+  picker for **table** sources. A failed discovery (permissions, network)
+  degrades to no picker and exports the full image.
+- `bands=(...)` renders the picker labelled **Bands** for images,
+  **Properties** for tables, and skips auto-discovery.
+- `default_bands` is optional; when omitted, every band is selected by
+  default. Entries that are not in `bands` are dropped silently.
+- The picker preserves catalog order — even if the user clicks them in
+  a different order, the submitted `selectors` come back ordered by
+  `bands`.
+- Empty selection is rejected (Submit stays disabled; trying to call
+  `submit_export` programmatically raises `ValueError`).
+- Pre-baked `selectors=(...)` is the legacy escape hatch for apps that
+  manage band selection outside the dialog. When `bands` is declared,
+  the picker overrides `selectors`.
+
+### Auto-discovery cost
+
+Discovery calls `image.bandNames().getInfo()` once per selected source
+(the result is cached per source for the life of the dialog). This reads
+the image's **band schema, not its pixels**, so it is independent of how
+spatially large, high-resolution, or deeply chained the image is —
+`select`, `rename`, `addBands`, arithmetic, `mosaic`, and reducers all
+propagate band names structurally. In practice it is a single metadata
+round-trip to Earth Engine (typically sub-second; occasionally 1–2s of
+network latency). The cost tracks _schema_ complexity, not pixel volume,
+so a "huge" image is not a problem.
+
+The one operation that can be slow is `imageCollection.toBands()`, whose
+output band count is `images × bands-per-image` — Earth Engine has to
+enumerate the whole collection to name the bands. Raw `ee.ImageCollection`
+inputs are rejected by the export anyway, so this only bites if a source
+hands in a `toBands()` result over a large collection. Plain `mosaic()` /
+reducers are fine (fixed schema).
+
+While discovery is in flight:
+
+- The picker shows a spinner and the **Export button is disabled**
+  (`bands_loading`), so a slow `bandNames()` delays _Export_, not the
+  dialog opening.
+- Any failure (permissions, network) is swallowed — the picker is hidden
+  and the full image is exported unchanged.
+
+To skip the round-trip entirely — for a known band set, or a source where
+`bandNames()` would be expensive — **declare `bands=(...)`** on the
+`ResolvedExport`. A declared catalog renders instantly and never calls
+Earth Engine.
+
+Discovery is cached per source id, not per resolved image (`resolve()`
+returns a fresh object every render, so caching on the object would refetch
+constantly). A source whose `resolve()` changes its **band set** under the
+same id — unusual, since `clip`/`filter`/AOI changes preserve band names —
+therefore keeps its first-discovered catalog. If a source genuinely swaps
+its bands under one id, give it a distinct id per variant or declare
+`bands=(...)` so the picker tracks the change.
+
+Heads-up on visualization: if you set both `vis_params` and `bands`, the
+viz dict can reference bands the user deselects. The engine applies
+`set_viz_params` first and then `image.select(...)`, so the embedded
+visualization properties may point at bands missing from the exported
+asset. Apps that mix the two should keep `vis_params.bands` inside the
+band catalog or warn users in the source description.
 
 ## Carrying SEPAL Visualization Onto Exports
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -132,6 +132,7 @@ pysepal = [
     "frontend/**/*",
     "templates/**/*",
     "**/*.vue",
+    "**/*.css",
     "solara/common/assets/*",
     "templates/**/.*"
 ]

--- a/pysepal/solara/components/Legend.vue
+++ b/pysepal/solara/components/Legend.vue
@@ -8,13 +8,8 @@
       'sepal-legend--light': !isDark,
     }"
   >
-    <!-- Collapsed state: icon pill -->
-    <div v-if="isCollapsed" class="sepal-legend__pill" @click="toggleCollapse">
-      <v-icon small :dark="isDark" :light="!isDark">mdi-map-legend</v-icon>
-    </div>
-
-    <!-- Expanded state -->
-    <div v-else class="sepal-legend__body">
+    <!-- Expanded body -->
+    <div v-if="!isCollapsed" class="sepal-legend__body">
       <!-- Gradient sections -->
       <div
         v-for="(grad, gi) in parsedGradients"
@@ -49,13 +44,26 @@
           <span class="sepal-legend__label">{{ item.label }}</span>
         </div>
       </div>
+    </div>
 
-      <!-- Collapse toggle -->
-      <button class="sepal-legend__toggle" @click="toggleCollapse">
-        <v-icon x-small :dark="isDark" :light="!isDark"
-          >mdi-chevron-down</v-icon
-        >
-      </button>
+    <!-- Toggle bar: always rendered in the same spot (bottom-center of the
+         legend), so the same click target both opens and closes it. Exposed as
+         a real button to the a11y tree — focusable and Enter/Space operable. -->
+    <div
+      class="sepal-legend__bar"
+      role="button"
+      tabindex="0"
+      @click="toggleCollapse"
+      @keydown.enter="toggleCollapse"
+      @keydown.space.prevent="toggleCollapse"
+      :title="isCollapsed ? 'Show legend' : 'Hide legend'"
+      :aria-label="isCollapsed ? 'Show legend' : 'Hide legend'"
+      :aria-expanded="String(!isCollapsed)"
+    >
+      <v-icon small :dark="isDark" :light="!isDark">mdi-map-legend</v-icon>
+      <v-icon x-small :dark="isDark" :light="!isDark">{{
+        isCollapsed ? "mdi-chevron-up" : "mdi-chevron-down"
+      }}</v-icon>
     </div>
   </div>
 </template>
@@ -153,19 +161,18 @@ module.exports = {
   z-index: 1000;
   pointer-events: auto;
   font-family: Roboto, sans-serif;
-}
-
-.sepal-legend__pill,
-.sepal-legend__body {
-  backdrop-filter: blur(4px);
-}
-
-.sepal-legend__pill {
-  border-radius: 16px;
-  padding: 6px 12px;
-  cursor: pointer;
-  display: inline-flex;
+  /* Stack body over the toggle bar and keep everything centered. Because the
+     element is bottom-anchored, the bar (last child) stays fixed at the bottom
+     whether or not the body is shown. */
+  display: flex;
+  flex-direction: column;
   align-items: center;
+  gap: 4px;
+}
+
+.sepal-legend__body,
+.sepal-legend__bar {
+  backdrop-filter: blur(4px);
 }
 
 .sepal-legend__body {
@@ -174,21 +181,30 @@ module.exports = {
   font-size: 12px;
   display: flex;
   flex-direction: column;
+  align-items: center;
   gap: 6px;
-  max-width: 90vw;
-  position: relative;
+  max-width: min(380px, 92vw);
+}
+
+.sepal-legend__bar {
+  border-radius: 16px;
+  padding: 2px 10px;
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
 }
 
 /* --- Dark theme --- */
-.sepal-legend--dark .sepal-legend__pill,
-.sepal-legend--dark .sepal-legend__body {
+.sepal-legend--dark .sepal-legend__body,
+.sepal-legend--dark .sepal-legend__bar {
   background: rgba(33, 33, 33, 0.85);
   color: #fff;
 }
 
 /* --- Light theme --- */
-.sepal-legend--light .sepal-legend__pill,
-.sepal-legend--light .sepal-legend__body {
+.sepal-legend--light .sepal-legend__body,
+.sepal-legend--light .sepal-legend__bar {
   background: rgba(255, 255, 255, 0.9);
   color: rgba(0, 0, 0, 0.87);
   box-shadow: 0 1px 3px rgba(0, 0, 0, 0.12), 0 1px 2px rgba(0, 0, 0, 0.08);
@@ -199,6 +215,7 @@ module.exports = {
   display: flex;
   flex-direction: column;
   gap: 2px;
+  align-self: stretch;
 }
 
 .sepal-legend__gradient-title {
@@ -226,6 +243,7 @@ module.exports = {
   flex-wrap: wrap;
   gap: 4px 12px;
   align-items: center;
+  justify-content: center;
 }
 
 .sepal-legend__item {
@@ -252,23 +270,6 @@ module.exports = {
 .sepal-legend__label {
   white-space: nowrap;
   font-size: 12px;
-}
-
-/* --- Toggle --- */
-.sepal-legend__toggle {
-  position: absolute;
-  top: 4px;
-  right: 4px;
-  background: none;
-  border: none;
-  cursor: pointer;
-  opacity: 0.6;
-  padding: 2px;
-  line-height: 1;
-}
-
-.sepal-legend__toggle:hover {
-  opacity: 1;
 }
 </style>
 

--- a/pysepal/solara/components/export_dialog.css
+++ b/pysepal/solara/components/export_dialog.css
@@ -1,0 +1,80 @@
+/* Styling for the export dialog fields. Loaded once from ExportDialog via
+   solara.Style so the component bodies stay free of inline style strings. */
+
+/* Body rhythm: solara.Column supplies the single 16px gap between fields; this
+   just adds top breathing room and zeroes Vuetify's extra top spacing (radio
+   groups add margin-top:16px + padding-top:4px) so the gap is the ONLY spacing
+   between fields. Every input uses hide_details=True, so heights are fixed. */
+.sepal-export-body {
+  padding-top: 8px;
+}
+
+.sepal-export-body .v-input--selection-controls {
+  margin-top: 0 !important;
+  padding-top: 0 !important;
+}
+
+/* Field wrapper: title stacked over its control. */
+.sepal-export-field {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+/* Shared field title (Bands / Scale / Destination) — identical across fields. */
+.sepal-export-field-title {
+  font-size: 0.875rem;
+  font-weight: 500;
+}
+
+/* Single validation row at the bottom, always rendered with a fixed height so
+   showing/clearing the message never resizes the modal. Right-aligned toward
+   the Export button. */
+.sepal-export-message {
+  min-height: 20px;
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+}
+
+.sepal-export-error {
+  color: var(--v-error-base, #ff5252);
+  font-size: 0.8125rem;
+  /* Match the reserved row height exactly so a single-line message fills it
+     without growing the modal. */
+  line-height: 20px;
+}
+
+/* Band control slot: no frame, but a fixed min-height so the discovery spinner
+   and the rendered toggles occupy the same space (no resize on layer switch). */
+.sepal-band-slot {
+  min-height: 36px;
+  display: flex;
+  align-items: center;
+}
+
+/* --- Band / Scale toggles --- */
+
+/* Selected buttons carry the fill via `color="secondary"`; the group only
+   needs to wrap and stay transparent so it blends into the dialog. */
+.sepal-band-toggle,
+.sepal-scale-toggle {
+  flex-wrap: wrap;
+  background: transparent !important;
+}
+
+.sepal-scale-toggle {
+  width: fit-content;
+}
+
+.sepal-scale-row {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  flex-wrap: nowrap;
+  width: 100%;
+}
+
+.sepal-scale-custom {
+  max-width: 128px;
+}

--- a/pysepal/solara/components/export_dialog.py
+++ b/pysepal/solara/components/export_dialog.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from pathlib import Path
+
 import reacton.ipyvuetify as rv
 import reacton.ipyvuetify as v
 import solara
@@ -10,22 +12,61 @@ from pysepal.solara.components.task_button import TaskButtonComponent, use_task_
 
 from .export_hook import (
     ExportDialogController,
+    available_bands_for,
     get_controller_source_state,
     get_source_items,
     get_target_items,
+    normalize_band_selection,
 )
-from .export_models import TABLE_FILE_FORMATS, validate_asset_id_under_root
+from .export_models import TABLE_FILE_FORMATS, ExportKind, validate_asset_id_under_root
 
 IMAGE_SCALE_PRESETS = [10, 15, 20, 30, 60, 100]
 
+# Field styling (bands / scale / destination) lives in the sibling CSS file so
+# it stays out of the component bodies; loaded once via ``solara.Style`` in
+# ``ExportDialog``.
+_EXPORT_DIALOG_CSS = Path(__file__).with_name("export_dialog.css").read_text(encoding="utf-8")
 
-def _hint_props(hint: str) -> dict[str, object]:
-    """Attach a real persistent hint only when the field needs one."""
-    return {
-        "hide_details": False,
-        "hint": hint,
-        "persistent_hint": True,
-    }
+
+def _validation_message(
+    *,
+    has_usable_sources: bool,
+    has_active_source: bool,
+    resolvable: bool,
+    gee_target: bool,
+    gee_asset_id: str,
+    asset_root_error: str | None,
+    gee_asset_conflict: bool,
+    export_name: str,
+    bands_empty: bool,
+    band_noun: str,
+) -> str:
+    """Return the single highest-priority blocking message, or ``""`` when valid.
+
+    One message at a time, in the order a user resolves them: pick a source,
+    then a valid destination target/id, then a non-empty band selection. The
+    dialog renders this once at the bottom and gates the Export button on it.
+    """
+    if not has_usable_sources:
+        return "No exportable layers available."
+    if not has_active_source:
+        # The Asset selector already makes this obvious — no message. The dialog
+        # still disables Export for this case via ``active_source is None``.
+        return ""
+    if not resolvable:
+        return "The selected layer cannot currently be exported."
+    if gee_target:
+        if not gee_asset_id.strip():
+            return "Asset ID is required."
+        if asset_root_error:
+            return asset_root_error
+        if gee_asset_conflict:
+            return "An asset with this id already exists. Edit the id or pick a different path."
+    elif not export_name.strip():
+        return "Name is required."
+    if bands_empty:
+        return f"Select at least one {band_noun}."
+    return ""
 
 
 @solara.component
@@ -44,14 +85,115 @@ def InlineExportFeedback(message: str, level: str) -> None:
         solara.Info(message)
 
 
+def _band_field_label(export_kind: ExportKind | None) -> str:
+    """User-facing field label. Images carry bands; tables carry properties."""
+    return "Properties" if export_kind == "table" else "Bands"
+
+
+def _toggle_button(label: str, *, selected: bool, disabled: bool = False):
+    """A styled toggle button shared by the band and scale pickers.
+
+    Selected buttons get a solid ``secondary`` fill with a white label so they
+    read on both light and dark themes; unselected inherit the neutral toggle
+    style. The enclosing ``v.BtnToggle`` should also carry ``color="secondary"``
+    so the selected accent (border/overlay) is secondary rather than the
+    default primary.
+    """
+    props: dict[str, object] = {
+        "children": [label],
+        "small": True,
+        "depressed": True,
+        "disabled": disabled,
+    }
+    if selected:
+        props["color"] = "secondary"
+        props["class_"] = "white--text"
+    return rv.Btn(**props)
+
+
+@solara.component
+def BandSelectorField(
+    available: tuple[str, ...],
+    selected: solara.Reactive[tuple[str, ...]],
+    dirty: solara.Reactive[bool],
+    export_kind: ExportKind | None,
+    disabled: bool = False,
+    loading: bool = False,
+) -> None:
+    """Multi-select toggle-button picker for the subset of bands/properties.
+
+    Renders one selectable button per band inside a ``v.BtnToggle``. Each
+    selected button gets a solid ``secondary`` fill with a white label (so it
+    reads on both light and dark themes); unselected buttons stay neutral.
+
+    While ``loading`` is set and no catalog is available yet, a spinner stands
+    in for the toggles — the window where image bands are auto-discovered from
+    the ee.Image. The empty-selection error is surfaced by the dialog's single
+    bottom validation message, not here. Returns ``None`` only when there is
+    nothing to show and nothing loading.
+    """
+    if not available and not loading:
+        return
+
+    label = _band_field_label(export_kind)
+    current = normalize_band_selection(available, selected.value)
+    show_loading = loading and not available
+    current_set = set(current)
+    # ``v.BtnToggle`` tracks selection by child index, so map bands <-> indices.
+    selected_indices = [index for index, band in enumerate(available) if band in current_set]
+    selected_index_set = set(selected_indices)
+
+    def _on_indices(new_indices) -> None:
+        picked = tuple(
+            available[index] for index in (new_indices or []) if 0 <= index < len(available)
+        )
+        new_selection = normalize_band_selection(available, picked)
+        if new_selection != selected.value:
+            selected.set(new_selection)
+        if not dirty.value:
+            dirty.set(True)
+
+    # Title on top, picker below — consistent with the Scale and Destination
+    # fields. Styling is in export_dialog.css.
+    with rv.Html(tag="div", class_="sepal-export-field"):
+        solara.Text(label, classes=["sepal-export-field-title"])
+
+        # Frameless but fixed-min-height slot: the spinner and the toggles occupy
+        # the same space, so switching layers never resizes the field while the
+        # catalog loads.
+        with rv.Html(tag="div", class_="sepal-band-slot"):
+            if show_loading:
+                rv.ProgressCircular(indeterminate=True, size=20, width=2, color="secondary")
+            else:
+                rv.BtnToggle(
+                    v_model=selected_indices,
+                    on_v_model=_on_indices,
+                    multiple=True,
+                    mandatory=False,
+                    dense=True,
+                    color="secondary",
+                    class_="sepal-band-toggle",
+                    children=[
+                        _toggle_button(
+                            band,
+                            selected=index in selected_index_set,
+                            disabled=disabled,
+                        )
+                        for index, band in enumerate(available)
+                    ],
+                )
+
+
 @solara.component
 def ImageScaleField(scale: solara.Reactive[int]) -> None:
     """Render SEPAL-style scale presets plus a custom numeric field."""
-    preset_value = scale.value if scale.value in IMAGE_SCALE_PRESETS else None
+    selected_preset_index = (
+        IMAGE_SCALE_PRESETS.index(scale.value) if scale.value in IMAGE_SCALE_PRESETS else None
+    )
 
-    def _handle_preset_scale(value: int | None) -> None:
-        if value is not None:
-            scale.set(int(value))
+    def _handle_preset_index(index: int | None) -> None:
+        if index is not None and 0 <= index < len(IMAGE_SCALE_PRESETS):
+            scale.set(int(IMAGE_SCALE_PRESETS[index]))
 
     def _handle_custom_scale(value: str) -> None:
         try:
@@ -62,39 +204,36 @@ def ImageScaleField(scale: solara.Reactive[int]) -> None:
         if numeric_value > 0:
             scale.set(numeric_value)
 
-    with rv.Html(
-        tag="div",
-        style_=(
-            "display: flex; align-items: center; gap: 12px;" " flex-wrap: nowrap; width: 100%;"
-        ),
-    ):
-        solara.Text("Scale")
-        with solara.ToggleButtonsSingle(
-            value=preset_value,
-            on_value=_handle_preset_scale,
-            mandatory=False,
-            dense=True,
-            style={"width": "fit-content"},
-        ):
-            for preset in IMAGE_SCALE_PRESETS:
-                solara.Button(
-                    label=str(preset),
-                    value=preset,
-                    small=True,
-                    text=True,
-                )
+    with rv.Html(tag="div", class_="sepal-export-field"):
+        solara.Text("Scale", classes=["sepal-export-field-title"])
+        with rv.Html(tag="div", class_="sepal-scale-row"):
+            # Same styling as the band picker: solid secondary fill on the
+            # selected preset, secondary accent (no default primary/blue).
+            rv.BtnToggle(
+                v_model=selected_preset_index,
+                on_v_model=_handle_preset_index,
+                multiple=False,
+                mandatory=False,
+                dense=True,
+                color="secondary",
+                class_="sepal-scale-toggle",
+                children=[
+                    _toggle_button(str(preset), selected=index == selected_preset_index)
+                    for index, preset in enumerate(IMAGE_SCALE_PRESETS)
+                ],
+            )
 
-        with rv.TextField(
-            v_model=str(scale.value),
-            on_v_model=_handle_custom_scale,
-            type="number",
-            suffix="m",
-            dense=True,
-            hide_details=True,
-            placeholder="Custom",
-            style_="max-width: 128px;",
-        ):
-            pass
+            with rv.TextField(
+                v_model=str(scale.value),
+                on_v_model=_handle_custom_scale,
+                type="number",
+                suffix="m",
+                dense=True,
+                hide_details=True,
+                placeholder="Custom",
+                class_="sepal-scale-custom",
+            ):
+                pass
 
 
 @solara.component
@@ -112,32 +251,53 @@ def ExportDialog(
     fields_disabled = active_source is None
     gee_target_selected = controller.selected_target.value == "gee"
     gee_asset_conflict = gee_target_selected and state.gee_asset_conflict.value
-
-    if gee_target_selected:
-        identifier_error = (
-            "" if fields_disabled or state.gee_asset_id.value.strip() else "Asset ID required"
-        )
-        asset_root_error = (
-            validate_asset_id_under_root(state.gee_asset_id.value, state.asset_root.value)
-            if not fields_disabled
-            else None
-        )
-    else:
-        identifier_error = (
-            "" if fields_disabled or controller.export_name.value.strip() else "Name required"
-        )
-        asset_root_error = None
-
-    submit_disabled = (
-        not has_usable_sources
-        or active_source is None
-        or resolved_export is None
-        or export_kind is None
-        or bool(resolve_error)
-        or bool(identifier_error)
-        or bool(asset_root_error)
-        or gee_asset_conflict
+    # Effective catalog = declared bands, else the bands auto-discovered from
+    # the ee.Image (image sources without a declared catalog). Discovered bands
+    # are gated by source id so a stale catalog from a previously selected
+    # source is never shown.
+    active_source_id = active_source.id if active_source is not None else ""
+    declared_bands = available_bands_for(resolved_export)
+    discovery_ran = bool(active_source_id) and state.discovered_source_id.value == active_source_id
+    discovered_bands = state.discovered_bands.value if discovery_ran else ()
+    available_bands = declared_bands or discovered_bands
+    # Every image gets a band picker; while its catalog is still being discovered
+    # (the task has not recorded a result for this source yet) show a same-height
+    # spinner. Computing this synchronously — rather than waiting for the async
+    # ``bands_loading`` flag — keeps the slot mounted the instant you switch
+    # layers, so it never unmounts-and-remounts.
+    bands_pending = (
+        active_source is not None
+        and export_kind == "image"
+        and not declared_bands
+        and not discovery_ran
     )
+    bands_loading = state.bands_loading.value or bands_pending
+    bands_required = bool(available_bands)
+    bands_empty = bands_required and not normalize_band_selection(
+        available_bands, state.selected_bands.value
+    )
+
+    asset_root_error = (
+        validate_asset_id_under_root(state.gee_asset_id.value, state.asset_root.value)
+        if gee_target_selected and not fields_disabled
+        else None
+    )
+    # Single source of truth for validation: one prioritized message, rendered
+    # once at the bottom, and the Export button is gated on it (plus the
+    # transient band-discovery window).
+    validation_message = _validation_message(
+        has_usable_sources=has_usable_sources,
+        has_active_source=active_source is not None,
+        resolvable=(resolved_export is not None and export_kind is not None and not resolve_error),
+        gee_target=gee_target_selected,
+        gee_asset_id=state.gee_asset_id.value,
+        asset_root_error=asset_root_error,
+        gee_asset_conflict=gee_asset_conflict,
+        export_name=controller.export_name.value,
+        bands_empty=bands_empty,
+        band_noun="property" if export_kind == "table" else "band",
+    )
+    submit_disabled = active_source is None or bool(validation_message) or bands_loading
 
     target_items = get_target_items(state.sepal_client)
     source_items = get_source_items(controller.sources)
@@ -164,15 +324,11 @@ def ExportDialog(
         scrollable=True,
     ):
         with solara.v.Card():
+            solara.Style(_EXPORT_DIALOG_CSS)
             solara.v.CardTitle(children=[title])
 
             with solara.v.CardText():
-                with solara.Column(style="gap: 22px; padding-top: 8px;"):
-                    if not has_usable_sources:
-                        solara.Warning("No exportable layers available.")
-                    elif resolve_error and state.notifications_enabled:
-                        solara.Warning("The selected layer cannot currently be exported.")
-
+                with solara.Column(gap="16px", classes=["sepal-export-body"]):
                     if source_items:
                         with rv.Select(
                             label="Asset",
@@ -185,55 +341,42 @@ def ExportDialog(
                         ):
                             pass
 
-                    with rv.RadioGroup(
-                        label="Destination",
-                        v_model=controller.selected_target.value,
-                        on_v_model=controller.selected_target.set,
-                        dense=True,
-                        mandatory=True,
-                        row=True,
-                        hide_details=True,
-                        disabled=fields_disabled,
-                    ):
-                        for item in target_items:
-                            rv.Radio(
-                                label=item["text"],
-                                value=item["value"],
-                                disabled=bool(item.get("disabled", False)) or fields_disabled,
-                            )
+                    if available_bands or bands_loading:
+                        BandSelectorField(
+                            available=available_bands,
+                            selected=state.selected_bands,
+                            dirty=state.bands_dirty,
+                            export_kind=export_kind,
+                            disabled=fields_disabled,
+                            loading=bands_loading,
+                        )
+
+                    with rv.Html(tag="div", class_="sepal-export-field"):
+                        solara.Text("Destination", classes=["sepal-export-field-title"])
+                        with rv.RadioGroup(
+                            v_model=controller.selected_target.value,
+                            on_v_model=controller.selected_target.set,
+                            dense=True,
+                            mandatory=True,
+                            row=True,
+                            hide_details=True,
+                            disabled=fields_disabled,
+                        ):
+                            for item in target_items:
+                                rv.Radio(
+                                    label=item["text"],
+                                    value=item["value"],
+                                    disabled=bool(item.get("disabled", False)) or fields_disabled,
+                                )
 
                     if gee_target_selected:
-                        if identifier_error:
-                            asset_id_kwargs: dict[str, object] = {
-                                "error": True,
-                                "error_messages": identifier_error,
-                                "hide_details": "auto",
-                            }
-                        elif asset_root_error:
-                            asset_id_kwargs = {
-                                "error": True,
-                                "error_messages": asset_root_error,
-                                "hide_details": False,
-                            }
-                        elif gee_asset_conflict:
-                            asset_id_kwargs = {
-                                "error": True,
-                                "error_messages": (
-                                    "An asset with this id already exists. "
-                                    "Edit the id or pick a different path."
-                                ),
-                                "hide_details": False,
-                            }
-                        else:
-                            asset_id_kwargs = {"hide_details": True}
-
                         with rv.TextField(
                             label="Asset ID",
                             v_model=state.gee_asset_id.value,
                             on_v_model=_handle_asset_id_change,
                             dense=True,
+                            hide_details=True,
                             disabled=fields_disabled,
-                            **asset_id_kwargs,
                         ):
                             pass
                     else:
@@ -242,9 +385,7 @@ def ExportDialog(
                             v_model=controller.export_name.value,
                             on_v_model=_handle_name_change,
                             dense=True,
-                            error=bool(identifier_error),
-                            error_messages=identifier_error or None,
-                            hide_details="auto",
+                            hide_details=True,
                             disabled=fields_disabled,
                         ):
                             pass
@@ -259,9 +400,6 @@ def ExportDialog(
                             disabled=fields_disabled,
                         ):
                             pass
-
-                    if export_kind == "image":
-                        ImageScaleField(scale=state.scale)
 
                     if export_kind == "table" and controller.selected_target.value in {
                         "drive",
@@ -284,13 +422,20 @@ def ExportDialog(
                             v_model=state.sepal_folder.value,
                             on_v_model=state.sepal_folder.set,
                             dense=True,
+                            placeholder="Relative to the module results directory",
+                            hide_details=True,
                             disabled=fields_disabled,
-                            **_hint_props("Relative to the module results directory."),
                         ):
                             pass
-                        solara.Info(
-                            "SEPAL exports are staged through Google Drive " "before being copied."
-                        )
+
+                    if export_kind == "image":
+                        ImageScaleField(scale=state.scale)
+
+                    # Always render the row (fixed height) so showing/clearing
+                    # the message never resizes the modal.
+                    with rv.Html(tag="div", class_="sepal-export-message"):
+                        if validation_message:
+                            solara.Text(validation_message, classes=["sepal-export-error"])
 
                     if not state.notifications_enabled and state.inline_message.value:
                         InlineExportFeedback(
@@ -317,4 +462,4 @@ def ExportDialog(
                 )
 
 
-__all__ = ["ExportDialog", "InlineExportFeedback"]
+__all__ = ["BandSelectorField", "ExportDialog", "InlineExportFeedback"]

--- a/pysepal/solara/components/export_engine.py
+++ b/pysepal/solara/components/export_engine.py
@@ -231,6 +231,20 @@ def _apply_viz_to_image(request: ExportRequest) -> object:
     return set_viz_params(request.ee_object, **request.vis_params)
 
 
+def _apply_band_selection(ee_object: object, request: ExportRequest) -> object:
+    """Subset an image to the user-picked bands before export.
+
+    Tables thread ``selectors`` directly through to the EE export call (where
+    Earth Engine interprets them as feature property names). Images need an
+    explicit ``image.select(...)`` because the image-export endpoints do not
+    accept a selectors parameter — the band subset has to be baked into the
+    image itself.
+    """
+    if request.export_kind != "image" or not request.selectors:
+        return ee_object
+    return ee_object.select(list(request.selectors))
+
+
 async def _submit_export(
     gee_interface: GEEInterface,
     request: ExportRequest,
@@ -240,6 +254,7 @@ async def _submit_export(
     """Dispatch the export submission through ``GEEInterface``."""
     if request.export_kind == "image":
         image_to_export = _apply_viz_to_image(request)
+        image_to_export = _apply_band_selection(image_to_export, request)
         if request.target == "gee":
             return await gee_interface.export_image_to_asset_async(
                 image=image_to_export,

--- a/pysepal/solara/components/export_hook.py
+++ b/pysepal/solara/components/export_hook.py
@@ -36,14 +36,11 @@ from .export_models import (
     validate_asset_id_under_root,
 )
 
-# Success toast carries an asset path / task id the user often wants to copy,
-# so add a few extra seconds beyond the 3s type default — not so long that it
-# lingers annoyingly.
+# Longer than the 3s toast default so the asset path / task id stays copyable.
 EXPORT_SUCCESS_TOAST_TIMEOUT = 8.0
 
-# Debounce window for the live GEE asset-existence check. The Solara hook
-# cancels the previous task invocation when dependencies change, so as long
-# as the user keeps typing the sleep never completes and no API call fires.
+# Debounce for the live GEE asset-existence check; task cancellation on new
+# input means no API call fires while the user is still typing.
 GEE_ASSET_CONFLICT_CHECK_DELAY = 0.35
 
 
@@ -62,6 +59,12 @@ class _ExportDialogState:
     last_default_name: solara.Reactive[str]
     gee_asset_conflict: solara.Reactive[bool]
     gee_asset_conflict_path: solara.Reactive[str]
+    selected_bands: solara.Reactive[tuple[str, ...]]
+    bands_dirty: solara.Reactive[bool]
+    last_default_bands: solara.Reactive[tuple[str, ...]]
+    discovered_bands: solara.Reactive[tuple[str, ...]]
+    discovered_source_id: solara.Reactive[str]
+    bands_loading: solara.Reactive[bool]
     gee_interface: GEEInterface
     drive_interface: GDriveInterface
     sepal_client: SepalClient | None
@@ -185,11 +188,9 @@ def get_target_items(sepal_client: SepalClient | None) -> list[dict[str, object]
 def resolve_source_state(
     source: ExportSource | None,
 ) -> tuple[ResolvedExport | None, ExportKind | None, str | None]:
-    """Resolve a source safely and verify its declared vs actual kind match.
+    """Resolve a source and verify its declared kind matches the real ee object.
 
-    Returns ``(resolved, kind, error)``: the resolved payload and kind when
-    everything is consistent, or ``(None, None, error_message)`` if the source
-    failed to resolve or its kind declaration did not match the real ee object.
+    Returns ``(resolved, kind, None)`` on success, else ``(None, None, error)``.
     """
     if source is None:
         return None, None, None
@@ -250,13 +251,8 @@ async def _resolve_gee_asset_conflict(
 ) -> tuple[bool, str]:
     """Probe Earth Engine for a name collision against the resolved asset id.
 
-    Returns ``(conflict, candidate_path)``. ``conflict`` is ``True`` only when
-    Earth Engine confirms an asset already lives at ``asset_id``. The probe
-    runs for the auto-filled default as well as user edits — many SEPAL apps
-    reuse the same module folder + name across sessions, so the default itself
-    is the most common collision. Lookup failures (permissions, network, the
-    known eeclient cross-loop httpx race) are treated as ``(False, "")`` — the
-    engine-side guard remains the authoritative check at submit time.
+    Returns ``(conflict, candidate_path)``; lookup failures count as no conflict,
+    since the engine-side guard is authoritative at submit time.
     """
     candidate = (asset_id or "").strip()
     if target != "gee" or not has_active_source or not candidate:
@@ -280,13 +276,10 @@ def _build_default_gee_asset_id(
     resolved_export: ResolvedExport,
     sepal_client: SepalClient | None,
 ) -> str:
-    """Pre-fill a sensible GEE asset path from the user's asset root + source.
+    """Pre-fill a GEE asset path as ``{asset_root}/{gee_folder or module}/{name}``.
 
-    Composes ``{asset_root}/{resolved.gee_folder or module}/{sanitized_name}``.
-    When ``resolved.gee_folder`` is an absolute path (starts with ``projects/``)
-    the asset root is ignored. Returns ``""`` when the asset root has not
-    finished loading yet (still contains the ``{project}`` placeholder), so
-    callers can wait before overwriting user input.
+    Ignores the asset root when ``gee_folder`` is absolute (``projects/…``);
+    returns ``""`` while the asset root is still loading.
     """
     if not asset_root or "{project}" in asset_root:
         return ""
@@ -319,6 +312,72 @@ def _source_defaults_signature(
         resolved_export.sepal_folder or "",
         resolved_export.table_file_format or DEFAULT_TABLE_FILE_FORMAT,
     )
+
+
+def available_bands_for(resolved_export: ResolvedExport | None) -> tuple[str, ...]:
+    """Return the *declared* ``ResolvedExport.bands`` catalog, or ``()``.
+
+    Image sources that omit it get bands auto-discovered instead
+    (see :func:`discover_image_bands`).
+    """
+    if resolved_export is None or not resolved_export.bands:
+        return ()
+    return tuple(resolved_export.bands)
+
+
+def default_bands_for(
+    resolved_export: ResolvedExport | None,
+    available: tuple[str, ...],
+) -> tuple[str, ...]:
+    """Return the initial selection for ``available``, in catalog order.
+
+    Whole catalog by default, narrowed to ``ResolvedExport.default_bands`` when
+    declared; an empty overlap falls back to the full catalog.
+    """
+    if not available:
+        return ()
+    requested = resolved_export.default_bands if resolved_export is not None else None
+    if not requested:
+        return available
+    requested_set = set(requested)
+    return tuple(band for band in available if band in requested_set) or available
+
+
+def resolved_default_bands(resolved_export: ResolvedExport | None) -> tuple[str, ...]:
+    """Return the initial selection for a source's *declared* catalog."""
+    return default_bands_for(resolved_export, available_bands_for(resolved_export))
+
+
+async def discover_image_bands(
+    gee_interface: GEEInterface,
+    ee_object: object,
+) -> tuple[str, ...]:
+    """Fetch an image's band names via GEE, returning ``()`` on any failure.
+
+    Auto-populates the picker for image sources without a declared ``bands``
+    catalog; failures just leave the picker hidden and export the full image.
+    """
+    band_names_fn = getattr(ee_object, "bandNames", None)
+    if band_names_fn is None:
+        return ()
+    try:
+        names = await gee_interface.get_info_async(band_names_fn())
+    except Exception:
+        return ()
+    if not names:
+        return ()
+    return tuple(str(name) for name in names)
+
+
+def normalize_band_selection(
+    available: tuple[str, ...],
+    selected: tuple[str, ...],
+) -> tuple[str, ...]:
+    """Filter ``selected`` against ``available`` and preserve catalog order."""
+    if not available:
+        return ()
+    selected_set = set(selected)
+    return tuple(band for band in available if band in selected_set)
 
 
 def use_export_dialog(
@@ -366,6 +425,12 @@ def use_export_dialog(
         last_default_name=solara.use_reactive(""),
         gee_asset_conflict=solara.use_reactive(False),
         gee_asset_conflict_path=solara.use_reactive(""),
+        selected_bands=solara.use_reactive(()),
+        bands_dirty=solara.use_reactive(False),
+        last_default_bands=solara.use_reactive(()),
+        discovered_bands=solara.use_reactive(()),
+        discovered_source_id=solara.use_reactive(""),
+        bands_loading=solara.use_reactive(False),
         gee_interface=gee_interface,
         drive_interface=drive_interface,
         sepal_client=sepal_client,
@@ -388,6 +453,16 @@ def use_export_dialog(
         export_kind,
         state.sepal_client,
     )
+    # Effective catalog: declared bands, else bands auto-discovered from the
+    # image. The source-id gate drops a stale catalog from a prior selection.
+    declared_bands = available_bands_for(resolved_export)
+    discovered_bands = (
+        state.discovered_bands.value
+        if active_source_id and state.discovered_source_id.value == active_source_id
+        else ()
+    )
+    available_bands = declared_bands or discovered_bands
+    default_bands = default_bands_for(resolved_export, available_bands)
     last_resolve_error_ref = solara.use_ref(None)
 
     def _push_inline(level: str, message: str) -> None:
@@ -446,9 +521,8 @@ def use_export_dialog(
     )
 
     async def _check_gee_asset_conflict() -> None:
-        # Skip the probe for structurally invalid paths — the visible "must
-        # live under <root>/" error is the gate. Probing a path the user
-        # cannot write to would just produce a 404 or permission error.
+        # Structurally invalid paths are gated by the visible "must live under
+        # <root>/" error; no point probing a path the user can't write to.
         if validate_asset_id_under_root(state.gee_asset_id.value, state.asset_root.value):
             state.gee_asset_conflict.set(False)
             state.gee_asset_conflict_path.set("")
@@ -524,6 +598,64 @@ def use_export_dialog(
         ],
     )
 
+    async def _sync_discovered_bands() -> None:
+        # Auto-discover bands only for image sources without a declared catalog.
+        if export_kind != "image" or declared_bands or resolved_export is None:
+            if state.bands_loading.value:
+                state.bands_loading.set(False)
+            return
+
+        state.bands_loading.set(True)
+        try:
+            names = await discover_image_bands(state.gee_interface, resolved_export.ee_object)
+        finally:
+            state.bands_loading.set(False)
+        # Tag with the source id so it applies only to the source it was fetched for.
+        state.discovered_source_id.set(active_source_id)
+        state.discovered_bands.set(names)
+
+    solara.lab.use_task(
+        _sync_discovered_bands,
+        # Keyed on source id, not the ee.Image identity (resolve() returns a
+        # fresh object each render, which would refetch every time). See the guide.
+        dependencies=[active_source_id, export_kind, declared_bands],
+        raise_error=False,
+        prefer_threaded=False,
+    )
+
+    def _reset_bands_dirty_on_source_change() -> None:
+        # A freshly selected source starts clean, so its defaults re-apply.
+        if state.bands_dirty.value:
+            state.bands_dirty.set(False)
+
+    solara.use_effect(_reset_bands_dirty_on_source_change, [active_source_id])
+
+    def _sync_default_bands() -> None:
+        # No catalog: clear stale picker state so a prior subset doesn't leak.
+        if not available_bands:
+            if state.last_default_bands.value:
+                state.last_default_bands.set(())
+            if state.selected_bands.value:
+                state.selected_bands.set(())
+            return
+
+        if state.bands_dirty.value:
+            return
+
+        if default_bands != state.last_default_bands.value:
+            state.last_default_bands.set(default_bands)
+            state.selected_bands.set(default_bands)
+
+    solara.use_effect(
+        _sync_default_bands,
+        [
+            active_source_id,
+            state.bands_dirty.value,
+            available_bands,
+            default_bands,
+        ],
+    )
+
     def _handle_resolve_error() -> None:
         if not resolve_error:
             last_resolve_error_ref.current = None
@@ -563,7 +695,14 @@ def use_export_dialog(
             export_name.set(description)
             asset_id = None
 
-        selectors = resolved_export.selectors
+        if available_bands:
+            picked = normalize_band_selection(available_bands, state.selected_bands.value)
+            if not picked:
+                raise ValueError("Select at least one band.")
+            selectors = picked
+        else:
+            selectors = tuple(resolved_export.selectors) if resolved_export.selectors else None
+
         return ExportRequest(
             ee_object=resolved_export.ee_object,
             export_kind=export_kind,
@@ -576,7 +715,7 @@ def use_export_dialog(
             sepal_folder=state.sepal_folder.value.strip() or None,
             table_file_format=state.table_file_format.value,
             image_file_format=resolved_export.image_file_format or DEFAULT_IMAGE_FILE_FORMAT,
-            selectors=tuple(selectors) if selectors else None,
+            selectors=selectors,
             max_pixels=resolved_export.max_pixels,
             max_vertices=resolved_export.max_vertices,
             priority=resolved_export.priority,
@@ -670,12 +809,20 @@ def use_export_dialog(
         state.gee_asset_id.set("")
         state.gee_asset_id_dirty.set(False)
         state.last_default_gee_asset_id.set("")
+        state.selected_bands.set(())
+        state.bands_dirty.set(False)
+        state.last_default_bands.set(())
+        state.discovered_bands.set(())
+        state.discovered_source_id.set("")
+        state.bands_loading.set(False)
         open_state.set(True)
 
     def close_dialog() -> None:
         _clear_inline()
         name_dirty.set(False)
         state.gee_asset_id_dirty.set(False)
+        state.bands_dirty.set(False)
+        state.bands_loading.set(False)
         open_state.set(False)
 
     def submit_export() -> None:
@@ -718,10 +865,15 @@ def use_export_dialog(
 
 __all__ = [
     "ExportDialogController",
+    "available_bands_for",
+    "default_bands_for",
+    "discover_image_bands",
     "get_active_source",
     "get_controller_source_state",
     "get_source_items",
     "get_target_items",
+    "normalize_band_selection",
     "resolve_source_state",
+    "resolved_default_bands",
     "use_export_dialog",
 ]

--- a/pysepal/solara/components/export_models.py
+++ b/pysepal/solara/components/export_models.py
@@ -60,6 +60,10 @@ class ResolvedExport:
     region: object = None
     default_scale: int | None = None
     selectors: tuple[str, ...] | None = None
+    bands: tuple[str, ...] | None = None
+    """Bands (images) / properties (tables) offered in the picker; ``None`` hides it."""
+    default_bands: tuple[str, ...] | None = None
+    """Initial picker selection; defaults to all ``bands``."""
     gee_folder: str = ""
     drive_folder: str = ""
     sepal_folder: str = ""

--- a/pysepal/templates/solara/solara_map_app/aoi_all_methods_mapapp.py
+++ b/pysepal/templates/solara/solara_map_app/aoi_all_methods_mapapp.py
@@ -61,6 +61,8 @@ class DemoExportDataset:
     default_name: str
     region: object = None
     default_scale: int | None = None
+    bands: tuple[str, ...] | None = None
+    default_bands: tuple[str, ...] | None = None
 
 
 def _get_aoi_key(aoi_value) -> str:
@@ -76,11 +78,26 @@ def _build_demo_datasets(aoi_value) -> tuple[DemoExportDataset, ...]:
     if aoi_value is None or aoi_value.feature_collection is None:
         return ()
 
-    region = aoi_value.feature_collection.geometry()
+    fc = aoi_value.feature_collection
     name_prefix = aoi_value.name.replace(" ", "_")
 
-    constant_image = ee.Image.constant(10).rename("constant_10").clip(region)
-    pixel_area_image = ee.Image.pixelArea().rename("pixel_area_m2").clip(region)
+    # clipToCollection masks to the collection's features, so a dense AOI never
+    # dissolves into one 2M-edge geometry the way clip(fc.geometry()) would
+    # (issue #996). ee.Image.clip only accepts a Geometry/Feature, so a
+    # FeatureCollection must go through clipToCollection.
+    constant_image = ee.Image.constant(10).rename("constant_10").clipToCollection(fc)
+    pixel_area_image = ee.Image.pixelArea().rename("pixel_area_m2").clipToCollection(fc)
+    multiband_image = (
+        ee.Image.constant(10)
+        .rename("constant_10")
+        .addBands(ee.Image.pixelArea().rename("pixel_area_m2"))
+        .addBands(ee.Image.constant(1).rename("flag"))
+        .clipToCollection(fc)
+    )
+
+    # Export region as the union of per-feature bounding boxes — same trick as
+    # clip, so exporting a dense AOI doesn't dissolve its geometry (issue #996).
+    region = fc.map(lambda f: ee.Feature(f.geometry().bounds())).geometry().bounds()
 
     return (
         DemoExportDataset(
@@ -108,6 +125,23 @@ def _build_demo_datasets(aoi_value) -> tuple[DemoExportDataset, ...]:
             default_name=f"{name_prefix}_pixel_area",
             region=region,
             default_scale=30,
+        ),
+        DemoExportDataset(
+            id="demo_multi_band",
+            label="Multi-band demo (3 bands)",
+            kind="image",
+            ee_object=multiband_image,
+            description=(
+                "Three-band demo image. Shows off the ExportLauncher band picker: "
+                "leave all bands selected to export everything, or narrow to a subset."
+            ),
+            default_name=f"{name_prefix}_multi_band",
+            region=region,
+            default_scale=30,
+            bands=("constant_10", "pixel_area_m2", "flag"),
+            # Pre-select the two bands that are most useful by default; the user
+            # can deselect or re-add `flag` from the dialog.
+            default_bands=("constant_10", "pixel_area_m2"),
         ),
     )
 
@@ -147,6 +181,8 @@ def _build_export_sources(
                     default_name=dataset.default_name,
                     region=dataset.region,
                     default_scale=dataset.default_scale,
+                    bands=dataset.bands,
+                    default_bands=dataset.default_bands,
                     drive_folder="pysepal_exports",
                     sepal_folder="exports",
                 ),

--- a/pysepal/templates/solara/solara_map_app/ui.ipynb
+++ b/pysepal/templates/solara/solara_map_app/ui.ipynb
@@ -61,7 +61,7 @@
     "    \"\"\"\n",
     "    setup_theme_colors()\n",
     "\n",
-    "    gee_session = EESession()\n",
+    "    gee_session = EESession.from_default()\n",
     "    gee_interface = GEEInterface(session=gee_session)\n",
     "    sepal_client = None\n",
     "    theme_state = get_current_theme_state()\n",

--- a/tests/test_solara/test_export_component.py
+++ b/tests/test_solara/test_export_component.py
@@ -27,13 +27,33 @@ from pysepal.solara.components.export import (
     submit_export_request,
     validate_asset_id_under_root,
 )
-from pysepal.solara.components.export_dialog import ExportDialog
-from pysepal.solara.components.export_hook import get_active_source, use_export_dialog
+from pysepal.solara.components.export_dialog import (
+    BandSelectorField,
+    ExportDialog,
+    ImageScaleField,
+    _validation_message,
+)
+from pysepal.solara.components.export_engine import _apply_band_selection
+from pysepal.solara.components.export_hook import (
+    available_bands_for,
+    default_bands_for,
+    discover_image_bands,
+    get_active_source,
+    normalize_band_selection,
+    resolved_default_bands,
+    use_export_dialog,
+)
 
 
 class _FakeImage:
+    def __init__(self, selected_bands: tuple[str, ...] | None = None):
+        self.selected_bands = tuple(selected_bands) if selected_bands else ()
+
     def bandNames(self):
-        return []
+        return list(self.selected_bands)
+
+    def select(self, bands):
+        return _FakeImage(selected_bands=tuple(bands))
 
 
 class _FakeTable:
@@ -65,6 +85,7 @@ def _render_preselected_dialog(
     force_conflict_path=None,
     force_asset_root=None,
     force_asset_id=None,
+    gee_interface=None,
 ):
     """Render ``ExportDialog`` with a source preselected and the dialog open.
 
@@ -79,13 +100,17 @@ def _render_preselected_dialog(
     Pass ``force_asset_root`` / ``force_asset_id`` to drive root + asset-id
     state directly — useful for asserting the root-validation UI without
     waiting on ``_load_asset_root`` (which fails silently against MagicMock).
+
+    Pass ``gee_interface`` to override the default ``MagicMock`` — a fake with
+    an ``async get_info_async`` lets the band auto-discovery task run to
+    completion so tests can assert the picker renders from discovered bands.
     """
 
     @solara.component
     def _Harness():
         controller = use_export_dialog(
             sources=[source],
-            gee_interface=MagicMock(),
+            gee_interface=gee_interface or MagicMock(),
             drive_interface=MagicMock(),
         )
 
@@ -1020,7 +1045,62 @@ def test_export_dialog_renders_single_asset_id_field_for_gee_target():
     assert "Export name" not in labels
 
 
-def test_export_dialog_marks_asset_id_field_with_error_on_conflict():
+def _msg(**overrides) -> str:
+    base = dict(
+        has_usable_sources=True,
+        has_active_source=True,
+        resolvable=True,
+        gee_target=True,
+        gee_asset_id="projects/demo/assets/x",
+        asset_root_error=None,
+        gee_asset_conflict=False,
+        export_name="demo",
+        bands_empty=False,
+        band_noun="band",
+    )
+    base.update(overrides)
+    return _validation_message(**base)
+
+
+def test_validation_message_priority_order():
+    assert _msg(has_usable_sources=False) == "No exportable layers available."
+    # No message when nothing is picked yet — the Asset selector guides that.
+    assert _msg(has_active_source=False) == ""
+    assert _msg(resolvable=False) == "The selected layer cannot currently be exported."
+    assert _msg(gee_asset_id="   ") == "Asset ID is required."
+    assert _msg(asset_root_error="Asset id must live under `X`.") == "Asset id must live under `X`."
+    assert _msg(gee_asset_conflict=True).startswith("An asset with this id already exists")
+    assert _msg(gee_target=False, export_name="   ") == "Name is required."
+    assert _msg(bands_empty=True) == "Select at least one band."
+    assert _msg(bands_empty=True, band_noun="property") == "Select at least one property."
+    assert _msg() == ""
+
+
+def test_validation_message_asset_id_blocks_before_bands():
+    # A missing asset id must win over an empty band selection (earlier step).
+    assert _msg(gee_asset_id="", bands_empty=True) == "Asset ID is required."
+
+
+def _bottom_validation_text(element) -> str:
+    """Join the text of the dialog's single bottom validation message."""
+
+    def _walk(widget):
+        yield widget
+        for child in getattr(widget, "children", ()) or ():
+            yield from _walk(child)
+
+    chunks = [
+        str(child)
+        for widget in _walk(element)
+        if widget.__class__.__name__ == "Html"
+        and "sepal-export-error" in str(getattr(widget, "class_", ""))
+        for child in getattr(widget, "children", ()) or ()
+    ]
+    return " ".join(chunks)
+
+
+def test_export_dialog_shows_bottom_validation_for_conflict():
+    """The asset-id conflict surfaces in the single bottom message, not the field."""
     source = ExportSource(
         id="demo",
         label="Demo layer",
@@ -1041,23 +1121,19 @@ def test_export_dialog_marks_asset_id_field_with_error_on_conflict():
         for child in getattr(widget, "children", ()) or ():
             yield from _walk(child)
 
+    assert "already exists" in _bottom_validation_text(element).lower()
+    # The Asset ID field itself no longer carries per-field error styling.
     asset_id_fields = [
         widget
         for widget in _walk(element)
         if widget.__class__.__name__ == "TextField" and getattr(widget, "label", None) == "Asset ID"
     ]
-
     assert asset_id_fields, "Asset ID field must be rendered"
-    field = asset_id_fields[0]
-    assert getattr(field, "error", False) is True
-    error_messages = str(getattr(field, "error_messages", ""))
-    assert "already exists" in error_messages.lower()
-    # Path should NOT be repeated in the message — the field already shows it.
-    assert "projects/demo/assets/reports/demo_export" not in error_messages
+    assert getattr(asset_id_fields[0], "error", False) in (False, None)
 
 
-def test_export_dialog_marks_asset_id_field_with_error_when_outside_root():
-    """User-edited asset_id outside the user's GEE asset root surfaces inline."""
+def test_export_dialog_shows_bottom_validation_when_asset_id_outside_root():
+    """An asset_id outside the user's GEE root surfaces in the bottom message."""
     source = ExportSource(
         id="demo",
         label="Demo layer",
@@ -1074,23 +1150,9 @@ def test_export_dialog_marks_asset_id_field_with_error_when_outside_root():
         force_asset_id="projects/someone-else/assets/exports/my_data",
     )
 
-    def _walk(widget):
-        yield widget
-        for child in getattr(widget, "children", ()) or ():
-            yield from _walk(child)
-
-    asset_id_fields = [
-        widget
-        for widget in _walk(element)
-        if widget.__class__.__name__ == "TextField" and getattr(widget, "label", None) == "Asset ID"
-    ]
-
-    assert asset_id_fields, "Asset ID field must be rendered"
-    field = asset_id_fields[0]
-    assert getattr(field, "error", False) is True
-    error_messages = str(getattr(field, "error_messages", ""))
-    assert "projects/my-project/assets/" in error_messages
-    assert "must live under" in error_messages.lower()
+    message = _bottom_validation_text(element)
+    assert "projects/my-project/assets/" in message
+    assert "must live under" in message.lower()
 
 
 def test_export_dialog_renders_export_name_and_drive_folder_for_drive_target():
@@ -1184,3 +1246,642 @@ def test_default_gee_folder_prefers_module_name():
 
     assert export_hook_module._default_gee_folder(sepal_client) == "aoi_all_methods"
     assert export_hook_module._default_gee_folder(None) == "pysepal_exports"
+
+
+# ---------------------------------------------------------------------------
+# Band picker: catalog helpers, engine application, dialog rendering
+# ---------------------------------------------------------------------------
+
+
+def test_available_bands_for_returns_empty_without_catalog():
+    resolved = ResolvedExport(ee_object=_FakeImage(), default_name="demo")
+    assert available_bands_for(resolved) == ()
+    assert available_bands_for(None) == ()
+
+
+def test_available_bands_for_returns_catalog_when_declared():
+    resolved = ResolvedExport(
+        ee_object=_FakeImage(),
+        default_name="demo",
+        bands=("B4", "B3", "B2"),
+    )
+    assert available_bands_for(resolved) == ("B4", "B3", "B2")
+
+
+def test_resolved_default_bands_defaults_to_full_catalog():
+    resolved = ResolvedExport(
+        ee_object=_FakeImage(),
+        default_name="demo",
+        bands=("B4", "B3", "B2"),
+    )
+    assert resolved_default_bands(resolved) == ("B4", "B3", "B2")
+
+
+def test_resolved_default_bands_filters_default_against_catalog():
+    resolved = ResolvedExport(
+        ee_object=_FakeImage(),
+        default_name="demo",
+        bands=("B4", "B3", "B2", "B1"),
+        default_bands=("B4", "B2", "MISSING"),
+    )
+    # Preserves catalog order; drops MISSING silently.
+    assert resolved_default_bands(resolved) == ("B4", "B2")
+
+
+def test_resolved_default_bands_falls_back_to_catalog_when_default_outside_catalog():
+    """If default_bands has no overlap with bands, fall back to all bands."""
+    resolved = ResolvedExport(
+        ee_object=_FakeImage(),
+        default_name="demo",
+        bands=("B4", "B3"),
+        default_bands=("nope",),
+    )
+    assert resolved_default_bands(resolved) == ("B4", "B3")
+
+
+def test_normalize_band_selection_preserves_catalog_order():
+    available = ("B4", "B3", "B2", "B1")
+    # User picked out of order — the catalog order should win.
+    assert normalize_band_selection(available, ("B2", "B4")) == ("B4", "B2")
+
+
+def test_normalize_band_selection_drops_unknown_picks():
+    assert normalize_band_selection(("B4", "B3"), ("B4", "ghost")) == ("B4",)
+
+
+def test_default_bands_for_defaults_to_full_available():
+    resolved = ResolvedExport(ee_object=_FakeImage(), default_name="demo")
+    assert default_bands_for(resolved, ("nir", "red")) == ("nir", "red")
+
+
+def test_default_bands_for_honors_declared_default_bands():
+    resolved = ResolvedExport(
+        ee_object=_FakeImage(),
+        default_name="demo",
+        default_bands=("red",),
+    )
+    # Order comes from the available catalog, not from default_bands.
+    assert default_bands_for(resolved, ("nir", "red", "green")) == ("red",)
+
+
+def test_default_bands_for_empty_available_returns_empty():
+    resolved = ResolvedExport(ee_object=_FakeImage(), default_name="demo")
+    assert default_bands_for(resolved, ()) == ()
+
+
+class _BandDiscoveryGeeInterface:
+    """Fake interface whose ``get_info_async`` returns preconfigured band names."""
+
+    def __init__(self, band_names=None, raises: Exception | None = None):
+        self.band_names = list(band_names) if band_names is not None else []
+        self.raises = raises
+        self.calls: list[object] = []
+
+    async def get_info_async(self, ee_object=None, tag=None, serialized_object=None):
+        self.calls.append(ee_object)
+        if self.raises is not None:
+            raise self.raises
+        return self.band_names
+
+
+def test_discover_image_bands_returns_band_names():
+    gee = _BandDiscoveryGeeInterface(band_names=["B4", "B3", "B2"])
+    image = _FakeImage(selected_bands=("B4", "B3", "B2"))
+
+    result = asyncio.run(discover_image_bands(gee, image))
+
+    assert result == ("B4", "B3", "B2")
+    assert gee.calls, "Discovery must call get_info_async on the image's bandNames()"
+
+
+def test_discover_image_bands_returns_empty_when_no_bands():
+    gee = _BandDiscoveryGeeInterface(band_names=[])
+    assert asyncio.run(discover_image_bands(gee, _FakeImage())) == ()
+
+
+def test_discover_image_bands_swallows_lookup_errors():
+    gee = _BandDiscoveryGeeInterface(raises=RuntimeError("transient network blip"))
+    # A failed discovery must degrade to no picker, never propagate.
+    assert asyncio.run(discover_image_bands(gee, _FakeImage())) == ()
+
+
+def test_discover_image_bands_handles_objects_without_bandnames():
+    gee = _BandDiscoveryGeeInterface(band_names=["ignored"])
+    assert asyncio.run(discover_image_bands(gee, object())) == ()
+
+
+def test_switching_source_does_not_leak_band_selection():
+    """Editing source A's bands then switching to B resets to B's own defaults."""
+    source_a = ExportSource(
+        id="a",
+        label="A",
+        kind="image",
+        resolve=lambda: ResolvedExport(
+            ee_object=_FakeImage(), default_name="a", bands=("b1", "b2", "b3")
+        ),
+    )
+    source_b = ExportSource(
+        id="b",
+        label="B",
+        kind="image",
+        resolve=lambda: ResolvedExport(
+            ee_object=_FakeImage(), default_name="b", bands=("x1", "x2")
+        ),
+    )
+    captured = {}
+
+    @solara.component
+    def _Harness():
+        controller = use_export_dialog(
+            sources=[source_a, source_b],
+            gee_interface=MagicMock(),
+            drive_interface=MagicMock(),
+        )
+        captured["controller"] = controller
+
+        def _drive():
+            controller.selected_source_id.set("a")
+            # User hand-edits A down to a subset and marks it dirty…
+            controller._state.selected_bands.set(("b1",))
+            controller._state.bands_dirty.set(True)
+            # …then switches to B, whose catalog is disjoint from A's.
+            controller.selected_source_id.set("b")
+
+        solara.use_effect(_drive, [])
+        return solara.Text("driven")
+
+    _render(_Harness.widget)
+
+    state = captured["controller"]._state
+    # B must show its own defaults, not A's leaked ("b1",) subset, and be clean.
+    assert state.selected_bands.value == ("x1", "x2")
+    assert state.bands_dirty.value is False
+
+
+def test_apply_band_selection_subsets_image_when_selectors_set():
+    original = _FakeImage()
+    request = ExportRequest(
+        ee_object=original,
+        export_kind="image",
+        target="gee",
+        name="demo",
+        selectors=("B4", "B3"),
+    )
+    result = _apply_band_selection(original, request)
+    assert isinstance(result, _FakeImage)
+    assert result.selected_bands == ("B4", "B3")
+    assert result is not original
+
+
+def test_apply_band_selection_passthrough_for_tables():
+    """Tables thread selectors directly to the EE export call — no image.select()."""
+    table = _FakeTable()
+    request = ExportRequest(
+        ee_object=table,
+        export_kind="table",
+        target="gee",
+        name="demo",
+        selectors=("ADM0_NAME",),
+    )
+    assert _apply_band_selection(table, request) is table
+
+
+def test_apply_band_selection_passthrough_when_no_selectors():
+    image = _FakeImage()
+    request = ExportRequest(
+        ee_object=image,
+        export_kind="image",
+        target="gee",
+        name="demo",
+        selectors=None,
+    )
+    assert _apply_band_selection(image, request) is image
+
+
+def test_submit_export_request_applies_band_selection_to_image_for_gee_asset():
+    """End-to-end: ExportRequest.selectors bakes into image.select() before submit."""
+    gee_interface = _FakeGeeInterfaceImageExports()
+    original_image = _FakeImage()
+
+    request = ExportRequest(
+        ee_object=original_image,
+        export_kind="image",
+        target="gee",
+        name="band_subset_export",
+        gee_asset_id="projects/demo/assets/demo/band_subset_export",
+        selectors=("B4", "B3", "B2"),
+    )
+
+    asyncio.run(
+        submit_export_request(
+            request,
+            gee_interface=gee_interface,
+            drive_interface=MagicMock(),
+            sepal_client=None,
+        )
+    )
+
+    submitted = gee_interface.exports[0]
+    submitted_image = submitted["image"]
+    assert isinstance(submitted_image, _FakeImage)
+    assert submitted_image.selected_bands == ("B4", "B3", "B2")
+
+
+def test_submit_export_request_applies_band_selection_after_viz_embed(monkeypatch):
+    """Vis embedding runs first, then band selection — both must end up applied."""
+    gee_interface = _FakeGeeInterfaceImageExports()
+    original_image = _FakeImage()
+    styled_image = _FakeImage()
+
+    def fake_set_viz_params(image, **_kwargs):
+        assert image is original_image
+        return styled_image
+
+    monkeypatch.setattr(
+        "pysepal.solara.components.export_engine.set_viz_params",
+        fake_set_viz_params,
+    )
+
+    request = ExportRequest(
+        ee_object=original_image,
+        export_kind="image",
+        target="gee",
+        name="styled_subset",
+        gee_asset_id="projects/demo/assets/demo/styled_subset",
+        vis_params={"bands": ["B4"], "palette": ["#000"]},
+        selectors=("B4",),
+    )
+
+    asyncio.run(
+        submit_export_request(
+            request,
+            gee_interface=gee_interface,
+            drive_interface=MagicMock(),
+            sepal_client=None,
+        )
+    )
+
+    submitted_image = gee_interface.exports[0]["image"]
+    # Result must be the styled image's .select() output, not the styled
+    # image directly — i.e. band selection happened after viz embedding.
+    assert isinstance(submitted_image, _FakeImage)
+    assert submitted_image.selected_bands == ("B4",)
+
+
+def test_export_dialog_renders_band_picker_for_image_source_with_bands():
+    source = ExportSource(
+        id="image-bands",
+        label="Image with bands",
+        kind="image",
+        resolve=lambda: ResolvedExport(
+            ee_object=_FakeImage(),
+            default_name="demo_image",
+            bands=("B4", "B3", "B2"),
+        ),
+    )
+    element = _render_preselected_dialog(source=source)
+
+    def _walk(widget):
+        yield widget
+        for child in getattr(widget, "children", ()) or ():
+            yield from _walk(child)
+
+    multi_toggles = [
+        widget
+        for widget in _walk(element)
+        if widget.__class__.__name__ == "BtnToggle" and getattr(widget, "multiple", False)
+    ]
+
+    assert multi_toggles, "Band picker (multi-toggle) must render when bands are declared"
+    # One button per band sits inside the multi-toggle group.
+    toggle_button_labels = []
+    for toggle in multi_toggles:
+        for child in toggle.children or ():
+            if child.__class__.__name__ == "Btn":
+                for grandchild in child.children or ():
+                    toggle_button_labels.append(str(grandchild))
+    assert "B4" in toggle_button_labels
+    assert "B3" in toggle_button_labels
+    assert "B2" in toggle_button_labels
+
+    # Label-bearing Text widget should say "Bands" for image kind.
+    label_texts = [
+        getattr(widget, "children", [])
+        for widget in _walk(element)
+        if widget.__class__.__name__ == "Html"
+    ]
+    flattened = [str(c) for group in label_texts for c in (group or [])]
+    assert any("Bands" in chunk for chunk in flattened)
+
+
+def test_band_selector_field_fills_selected_buttons_with_secondary():
+    """Selected bands get a solid secondary colour; unselected stay neutral."""
+    element = _render(
+        BandSelectorField.widget,
+        available=("B4", "B3", "B2"),
+        selected=solara.reactive(("B4", "B2")),
+        dirty=solara.reactive(False),
+        export_kind="image",
+        loading=False,
+    )
+
+    def _walk(widget):
+        yield widget
+        for child in getattr(widget, "children", ()) or ():
+            yield from _walk(child)
+
+    color_by_label = {}
+    class_by_label = {}
+    for widget in _walk(element):
+        if widget.__class__.__name__ == "Btn":
+            children = getattr(widget, "children", ()) or ()
+            if children:
+                label = str(children[0])
+                color_by_label[label] = getattr(widget, "color", "")
+                class_by_label[label] = getattr(widget, "class_", "") or ""
+
+    # B4 and B2 are selected → filled secondary; B3 is not → neutral (no colour).
+    assert color_by_label.get("B4") == "secondary"
+    assert color_by_label.get("B2") == "secondary"
+    assert color_by_label.get("B3") in ("", None)
+    # Selected labels are forced white so they read on the secondary fill;
+    # unselected inherit the theme text colour.
+    assert "white--text" in class_by_label.get("B4", "")
+    assert "white--text" in class_by_label.get("B2", "")
+    assert "white--text" not in class_by_label.get("B3", "")
+
+
+def test_image_scale_field_styles_selected_preset_like_bands():
+    """The scale presets reuse the band styling: selected = secondary + white."""
+    element = _render(ImageScaleField.widget, scale=solara.reactive(30))
+
+    def _walk(widget):
+        yield widget
+        for child in getattr(widget, "children", ()) or ():
+            yield from _walk(child)
+
+    toggles = [w for w in _walk(element) if w.__class__.__name__ == "BtnToggle"]
+    assert toggles, "Scale presets render inside a BtnToggle"
+    # Group carries secondary so the selected accent is not the default blue.
+    assert all(getattr(toggle, "color", None) == "secondary" for toggle in toggles)
+
+    color_by_label = {}
+    class_by_label = {}
+    for widget in _walk(element):
+        if widget.__class__.__name__ == "Btn":
+            children = getattr(widget, "children", ()) or ()
+            if children:
+                label = str(children[0])
+                color_by_label[label] = getattr(widget, "color", "")
+                class_by_label[label] = getattr(widget, "class_", "") or ""
+
+    # Scale defaults to 30 → that preset is filled secondary with a white label.
+    assert color_by_label.get("30") == "secondary"
+    assert "white--text" in class_by_label.get("30", "")
+    # A non-selected preset stays neutral.
+    assert color_by_label.get("10") in ("", None)
+
+
+def test_export_dialog_destination_uses_standalone_title():
+    """Destination drops the built-in radio label for a shared styled title."""
+    source = ExportSource(
+        id="demo",
+        label="Demo layer",
+        kind="table",
+        resolve=lambda: ResolvedExport(ee_object=_FakeTable(), default_name="demo_export"),
+    )
+    element = _render_preselected_dialog(source=source)
+
+    def _walk(widget):
+        yield widget
+        for child in getattr(widget, "children", ()) or ():
+            yield from _walk(child)
+
+    radio_groups = [w for w in _walk(element) if w.__class__.__name__ == "RadioGroup"]
+    assert radio_groups
+    # The built-in radio-group label is gone in favour of a standalone title.
+    assert not any(getattr(rg, "label", None) for rg in radio_groups)
+
+    html_chunks = [
+        str(child)
+        for widget in _walk(element)
+        if widget.__class__.__name__ == "Html"
+        for child in getattr(widget, "children", ()) or ()
+    ]
+    assert any("Destination" in chunk for chunk in html_chunks)
+
+
+def test_export_dialog_body_uses_single_rhythm_container():
+    """All fields sit in one sepal-export-body container (single-gap layout)."""
+    source = ExportSource(
+        id="demo",
+        label="Demo layer",
+        kind="table",
+        resolve=lambda: ResolvedExport(ee_object=_FakeTable(), default_name="demo_export"),
+    )
+    element = _render_preselected_dialog(source=source)
+
+    def _walk(widget):
+        yield widget
+        for child in getattr(widget, "children", ()) or ():
+            yield from _walk(child)
+
+    assert any(
+        "sepal-export-body" in str(getattr(w, "class_", "")) for w in _walk(element)
+    ), "The form body carries the single-rhythm sepal-export-body class"
+
+
+def test_export_dialog_band_picker_has_no_select_all_or_clear():
+    source = ExportSource(
+        id="image-bands",
+        label="Image with bands",
+        kind="image",
+        resolve=lambda: ResolvedExport(
+            ee_object=_FakeImage(),
+            default_name="demo_image",
+            bands=("B4", "B3", "B2"),
+        ),
+    )
+    element = _render_preselected_dialog(source=source)
+
+    def _walk(widget):
+        yield widget
+        for child in getattr(widget, "children", ()) or ():
+            yield from _walk(child)
+
+    button_labels = [
+        str(child)
+        for widget in _walk(element)
+        if widget.__class__.__name__ == "Btn"
+        for child in getattr(widget, "children", ()) or ()
+    ]
+
+    assert "Select all" not in button_labels
+    assert "Clear" not in button_labels
+
+
+class _ImageBandsDialogGee(_FakeGeeInterface):
+    """Fake whose ``get_info_async`` returns a fixed band-name list for discovery."""
+
+    def __init__(self, band_names):
+        super().__init__()
+        self._band_names = list(band_names)
+
+    async def get_info_async(self, ee_object=None, tag=None, serialized_object=None):
+        return self._band_names
+
+
+def test_export_dialog_renders_band_picker_from_discovered_bands():
+    """Image without a declared catalog shows the picker from auto-discovered bands."""
+    source = ExportSource(
+        id="image-no-bands",
+        label="Image without bands",
+        kind="image",
+        resolve=lambda: ResolvedExport(
+            ee_object=_FakeImage(),
+            default_name="demo_image",
+        ),
+    )
+    element = _render_preselected_dialog(
+        source=source,
+        gee_interface=_ImageBandsDialogGee(["nir", "red", "green"]),
+    )
+
+    def _walk(widget):
+        yield widget
+        for child in getattr(widget, "children", ()) or ():
+            yield from _walk(child)
+
+    multi_toggles = [
+        widget
+        for widget in _walk(element)
+        if widget.__class__.__name__ == "BtnToggle" and getattr(widget, "multiple", False)
+    ]
+    assert multi_toggles, "Picker must render for images from auto-discovered bands"
+
+    toggle_button_labels = []
+    for toggle in multi_toggles:
+        for child in toggle.children or ():
+            if child.__class__.__name__ == "Btn":
+                for grandchild in child.children or ():
+                    toggle_button_labels.append(str(grandchild))
+    assert "nir" in toggle_button_labels
+    assert "red" in toggle_button_labels
+    assert "green" in toggle_button_labels
+
+
+def test_band_selector_field_shows_spinner_while_loading():
+    """While discovery is in flight (loading, no catalog yet) a spinner stands in.
+
+    Asserted at the component level: the dialog-level ``bands_loading`` flag is
+    owned by the async discovery task, whose ``finally`` resets it before this
+    harness can capture it, so forcing it through the controller does not stick.
+    """
+    element = _render(
+        BandSelectorField.widget,
+        available=(),
+        selected=solara.reactive(()),
+        dirty=solara.reactive(False),
+        export_kind="image",
+        loading=True,
+    )
+
+    def _walk(widget):
+        yield widget
+        for child in getattr(widget, "children", ()) or ():
+            yield from _walk(child)
+
+    spinners = [
+        widget for widget in _walk(element) if widget.__class__.__name__ == "ProgressCircular"
+    ]
+    multi_toggles = [
+        widget
+        for widget in _walk(element)
+        if widget.__class__.__name__ == "BtnToggle" and getattr(widget, "multiple", False)
+    ]
+
+    assert spinners, "A spinner must stand in for the toggles while bands load"
+    assert not multi_toggles, "Toggles must not render until discovery completes"
+
+
+def test_band_selector_field_returns_nothing_without_catalog_or_loading():
+    """No catalog and not loading → the field renders nothing (opt-out path)."""
+    element = _render(
+        BandSelectorField.widget,
+        available=(),
+        selected=solara.reactive(()),
+        dirty=solara.reactive(False),
+        export_kind="image",
+        loading=False,
+    )
+
+    def _walk(widget):
+        yield widget
+        for child in getattr(widget, "children", ()) or ():
+            yield from _walk(child)
+
+    spinners = [
+        widget for widget in _walk(element) if widget.__class__.__name__ == "ProgressCircular"
+    ]
+    multi_toggles = [
+        widget
+        for widget in _walk(element)
+        if widget.__class__.__name__ == "BtnToggle" and getattr(widget, "multiple", False)
+    ]
+    assert not spinners
+    assert not multi_toggles
+
+
+def test_export_dialog_hides_band_picker_for_table_without_catalog():
+    """Tables never auto-discover — without a declared catalog the picker stays hidden."""
+    source = ExportSource(
+        id="table-no-catalog",
+        label="Table without properties",
+        kind="table",
+        resolve=lambda: ResolvedExport(
+            ee_object=_FakeTable(),
+            default_name="demo_table",
+        ),
+    )
+    element = _render_preselected_dialog(source=source)
+
+    def _walk(widget):
+        yield widget
+        for child in getattr(widget, "children", ()) or ():
+            yield from _walk(child)
+
+    multi_toggles = [
+        widget
+        for widget in _walk(element)
+        if widget.__class__.__name__ == "BtnToggle" and getattr(widget, "multiple", False)
+    ]
+
+    assert not multi_toggles, "Tables without a declared catalog show no picker"
+
+
+def test_export_dialog_labels_band_picker_as_properties_for_tables():
+    source = ExportSource(
+        id="table-props",
+        label="Table with properties",
+        kind="table",
+        resolve=lambda: ResolvedExport(
+            ee_object=_FakeTable(),
+            default_name="demo_table",
+            bands=("ADM0_NAME", "ADM1_NAME"),
+        ),
+    )
+    element = _render_preselected_dialog(source=source)
+
+    def _walk(widget):
+        yield widget
+        for child in getattr(widget, "children", ()) or ():
+            yield from _walk(child)
+
+    label_texts = [
+        getattr(widget, "children", [])
+        for widget in _walk(element)
+        if widget.__class__.__name__ == "Html"
+    ]
+    flattened = [str(c) for group in label_texts for c in (group or [])]
+    assert any("Properties" in chunk for chunk in flattened)
+    assert not any("Bands" == chunk for chunk in flattened)


### PR DESCRIPTION
## Summary

- Adds **band selection** to the Solara export dialog so users can pick which bands are written to the export, instead of always exporting all bands.
- Wires the selection through the export pipeline: dialog → hook → engine → models.
- Refactors the map **Legend** collapse control to a single persistent toggle bar (stable bottom-center click target) instead of a separate collapsed pill + corner chevron.
- Updates the export guide docs and the AOI mapapp example, and extends the export component tests to cover band selection.

## Test plan

- `nox -s test -- tests/test_solara/test_export_component.py`