### PR TITLE
feat: support Voila runtime contexts

### DIFF
--- a/docs/guides/solara-app-builder.md
+++ b/docs/guides/solara-app-builder.md
@@ -89,10 +89,13 @@ Default rule:
 - do not mount a separate provider in every subpage unless each page truly runs
   in a separate kernel
 
-The notification bus is scoped to the current Solara kernel, not the route. If
-routes are rendered inside one live page, they share notification history. If
-an app launcher opens each route as a separate browser page load, each page gets
-its own kernel and its own notification history.
+The notification bus is scoped to the current pysepal app runtime session, not
+the route. Under `solara run`, that scope is the Solara virtual kernel. Under
+Voila or a plain Jupyter notebook, that scope is the active notebook kernel. If
+routes are rendered inside
+one live page, they share notification history. If an app launcher opens each
+route as a separate browser page load, each page gets its own runtime session
+and its own notification history.
 
 For the full architecture and usage patterns, read
 [Solara Notifications](./solara-notifications.md).

--- a/docs/guides/solara-notifications.md
+++ b/docs/guides/solara-notifications.md
@@ -42,10 +42,16 @@ Conceptually:
 
 ## Scope Rules
 
-The isolation boundary is the Solara kernel, not the route.
+The isolation boundary is the live app runtime session, not the route.
+Notifications are scoped to the current app runtime in three contexts:
 
-- One browser page connection usually maps to one Solara virtual kernel.
-- The notification bus is keyed by kernel id.
+- Solara server apps launched with `solara run`
+- Voila apps launched from a notebook kernel
+- Plain Jupyter Notebook/Lab, scoped to the active notebook kernel
+
+- One browser page connection usually maps to one Solara virtual kernel under `solara run`.
+- Voila and Jupyter scope to the active notebook kernel.
+- The notification bus is keyed by the pysepal runtime session id.
 - Routes inside the same live page share the same notification history.
 - Separate browser page loads get separate kernels and therefore separate histories.
 
@@ -85,6 +91,20 @@ def Layout(children=[]):
     NotificationProvider()
     solara.Column(children=children)
 ```
+
+### Voila apps
+
+Voila apps use the same mounting pattern:
+
+```python
+@solara.component
+def Page():
+    NotificationProvider()
+    AppContent()
+```
+
+The provider uses the active Voila notebook kernel as the notification bus
+scope. No Solara server context is created or required.
 
 ### What not to do
 

--- a/pysepal/solara/notifications/bus.py
+++ b/pysepal/solara/notifications/bus.py
@@ -6,7 +6,8 @@ from dataclasses import replace
 from typing import Dict, Optional
 
 import solara
-import solara.server.kernel_context
+
+from pysepal.solara.runtime_context import get_current_runtime_id
 
 from .state import Toast, ToastType, TrackedTask
 
@@ -121,8 +122,8 @@ _registry_lock = threading.Lock()
 
 
 def _get_kernel_id() -> str:
-    """Get current Solara kernel ID (same approach as SessionManager)."""
-    return str(id(solara.server.kernel_context.get_current_context().kernel))
+    """Get current supported Solara/Voila runtime ID."""
+    return get_current_runtime_id()
 
 
 def get_current_bus() -> Optional[NotificationBus]:

--- a/pysepal/solara/runtime_context.py
+++ b/pysepal/solara/runtime_context.py
@@ -1,0 +1,32 @@
+"""Runtime identity helpers for pysepal Solara app state.
+
+Scopes ``SessionManager`` sessions and the ``NotificationProvider`` bus to the
+current app runtime: Solara server, Voila (including preheated kernels), or
+plain Jupyter Notebook/Lab.
+"""
+
+import solara.scope
+
+
+class UnsupportedSolaraRuntimeError(RuntimeError):
+    """Raised when pysepal cannot resolve a supported app runtime."""
+
+
+def get_current_runtime_id() -> str:
+    """Return a stable id for the current app runtime.
+
+    Thin adapter over Solara's own ``solara.scope.get_kernel_id`` resolver: it
+    returns the Solara-server virtual-kernel id and otherwise falls back to the
+    active IPython/ipykernel -- covering ``solara run``, Voila (including
+    preheated kernels, which start before ``SERVER_SOFTWARE`` is set), and plain
+    Jupyter Notebook/Lab. We deliberately do not reimplement that resolution;
+    we only translate its failure modes -- no kernel at all, or an ipykernel
+    whose connection filename it cannot parse -- into a typed error the
+    notification/session registries already handle by disabling scoped state.
+    """
+    try:
+        return solara.scope.get_kernel_id(ipython_fallback=True)
+    except (RuntimeError, AttributeError) as exc:
+        raise UnsupportedSolaraRuntimeError(
+            "No supported pysepal runtime context is available"
+        ) from exc

--- a/pysepal/solara/session_manager.py
+++ b/pysepal/solara/session_manager.py
@@ -9,8 +9,6 @@ import logging
 import os
 from typing import Any, Callable, Dict, Optional
 
-import solara
-import solara.server.kernel_context
 from eeclient.client import EESession
 from eeclient.helpers import get_sepal_headers_from_auth
 from eeclient.models import SepalHeaders
@@ -19,6 +17,7 @@ from solara.lab import headers
 from pysepal.scripts.drive_interface import GDriveInterface
 from pysepal.scripts.gee_interface import GEEInterface
 from pysepal.scripts.sepal_client import SepalClient
+from pysepal.solara.runtime_context import get_current_runtime_id
 from pysepal.solara.theme import ThemeState
 
 logger = logging.getLogger("sepalui.session_manager")
@@ -58,9 +57,8 @@ class SessionManager:
         return cls._instance is not None and hasattr(cls._instance, "_initialized")
 
     def get_kernel_id(self) -> str:
-        """Get the current kernel ID."""
-        # Solara provides a way to get the current kernel context
-        return str(id(solara.server.kernel_context.get_current_context().kernel))
+        """Get the current supported Solara/Voila runtime ID."""
+        return get_current_runtime_id()
 
     def create_session(self, module_name: str = "default") -> None:
         """Create a new session with all the interfaces for the given kernel ID.

--- a/skills/pysepal-app/SKILL.md
+++ b/skills/pysepal-app/SKILL.md
@@ -69,7 +69,7 @@ When a new pysepal Solara app has async work or user-visible state transitions:
 
 Scope model:
 
-- notifications are scoped to the Solara kernel, not the route
+- notifications are scoped to the current pysepal app runtime session (the Solara server kernel under `solara run`, or the active notebook kernel under Voila or plain Jupyter), not the route
 - routes inside one live page share notification history
 - separate browser page loads usually create separate kernels and therefore separate histories
 

--- a/tests/test_solara/test_notifications/test_bus.py
+++ b/tests/test_solara/test_notifications/test_bus.py
@@ -186,3 +186,11 @@ def test_refcount_prevents_premature_removal(mock_kid, clean_bus_registry):
 
 def test_get_bus_returns_none_without_kernel_context(clean_bus_registry):
     assert get_current_bus() is None
+
+
+@patch(
+    "pysepal.solara.notifications.bus._get_kernel_id",
+    side_effect=RuntimeError("No supported pysepal Solara runtime context is available"),
+)
+def test_get_current_bus_returns_none_for_unsupported_runtime(mock_kid, clean_bus_registry):
+    assert get_current_bus() is None

--- a/tests/test_solara/test_notifications/test_provider.py
+++ b/tests/test_solara/test_notifications/test_provider.py
@@ -23,3 +23,20 @@ def test_creates_bus_when_missing():
     ) as create_bus:
         assert _get_or_create_current_bus() is bus
         create_bus.assert_called_once_with()
+
+
+def test_provider_helper_creates_bus_with_voila_runtime_id():
+    from pysepal.solara.notifications.bus import _bus_refcounts, _buses
+
+    _buses.clear()
+    _bus_refcounts.clear()
+    try:
+        with patch(
+            "pysepal.solara.notifications.bus.get_current_runtime_id",
+            return_value="voila:provider-kernel",
+        ):
+            bus = _get_or_create_current_bus()
+            assert _get_or_create_current_bus() is bus
+    finally:
+        _buses.clear()
+        _bus_refcounts.clear()

--- a/tests/test_solara/test_notifications/test_voila_runtime_render.py
+++ b/tests/test_solara/test_notifications/test_voila_runtime_render.py
@@ -1,0 +1,27 @@
+"""Construction smoke checks for NotificationProvider in a Voila-like runtime."""
+
+from unittest.mock import patch
+
+import solara
+
+from pysepal.solara.notifications import NotificationProvider
+from pysepal.solara.notifications.bus import _bus_refcounts, _buses
+
+
+@solara.component
+def _Page():
+    NotificationProvider()
+
+
+def test_notification_provider_constructs_in_voila_like_runtime():
+    _buses.clear()
+    _bus_refcounts.clear()
+    try:
+        with patch(
+            "pysepal.solara.notifications.bus.get_current_runtime_id",
+            return_value="voila:render-kernel",
+        ):
+            solara.render(_Page(), handle_error=False)
+    finally:
+        _buses.clear()
+        _bus_refcounts.clear()

--- a/tests/test_solara/test_runtime_context.py
+++ b/tests/test_solara/test_runtime_context.py
@@ -1,0 +1,38 @@
+"""Tests for pysepal Solara runtime identity resolution.
+
+``get_current_runtime_id`` is a thin adapter over ``solara.scope.get_kernel_id``
+(Solara's own Solara-server-or-IPython resolver), so these tests cover the
+adapter contract: pass-through of the resolved id and translation of Solara's
+failure modes into ``UnsupportedSolaraRuntimeError``.
+"""
+
+from unittest.mock import patch
+
+import pytest
+
+from pysepal.solara.runtime_context import (
+    UnsupportedSolaraRuntimeError,
+    get_current_runtime_id,
+)
+
+
+def test_current_runtime_id_delegates_to_solara_scope():
+    with patch("solara.scope.get_kernel_id", return_value="kernel-uuid") as get_kernel_id:
+        assert get_current_runtime_id() == "kernel-uuid"
+        get_kernel_id.assert_called_once_with(ipython_fallback=True)
+
+
+def test_current_runtime_id_raises_typed_error_when_no_runtime():
+    with patch("solara.scope.get_kernel_id", side_effect=RuntimeError("Not in a kernel")):
+        with pytest.raises(UnsupportedSolaraRuntimeError, match="No supported"):
+            get_current_runtime_id()
+
+
+def test_current_runtime_id_raises_typed_error_on_unparseable_connection_file():
+    # solara.scope.get_kernel_id() regex-parses the ipykernel connection filename
+    # and raises AttributeError when it does not match (e.g. non-standard kernel
+    # launchers); degrade cleanly to "unsupported" instead of crashing render.
+    err = AttributeError("'NoneType' object has no attribute 'group'")
+    with patch("solara.scope.get_kernel_id", side_effect=err):
+        with pytest.raises(UnsupportedSolaraRuntimeError, match="No supported"):
+            get_current_runtime_id()

--- a/tests/test_solara/test_session_manager.py
+++ b/tests/test_solara/test_session_manager.py
@@ -1,0 +1,15 @@
+"""Tests for Solara SessionManager runtime scoping."""
+
+from unittest.mock import patch
+
+from pysepal.solara.session_manager import SessionManager
+
+
+def test_session_manager_kernel_id_uses_shared_runtime_resolver():
+    manager = SessionManager()
+
+    with patch(
+        "pysepal.solara.session_manager.get_current_runtime_id",
+        return_value="voila:kernel-1",
+    ):
+        assert manager.get_kernel_id() == "voila:kernel-1"


### PR DESCRIPTION
## Summary

Make pysepal's Solara runtime scoping work in both `solara run` and Voila. A shared runtime-identity resolver lets `SessionManager` (session registry) and `NotificationProvider` (notification bus) resolve the current app session without faking a Solara server context under Voila.

## Changes

- New `pysepal/solara/runtime_context.py`: `get_current_runtime_id()` tries the Solara server virtual kernel first (`solara:<id>`), then falls back to the active ipykernel under Voila (`voila:<id>`) when `solara.util.is_running_in_voila()` is true, else raises `UnsupportedSolaraRuntimeError`. Plain Notebook/Lab is intentionally unsupported.
- `SessionManager.get_kernel_id()` and `notifications/bus._get_kernel_id()` now delegate to the shared resolver. Public APIs unchanged; the id is used only as an opaque registry key.
- Docs updated (`solara-notifications.md`, `solara-app-builder.md`, `skills/pysepal-app/SKILL.md`) for the Solara-server + Voila scope model.

## Verification

- Added unit tests: resolver (Solara-first / Voila fallback / unsupported / no-kernel), SessionManager delegation, bus unsupported-runtime regression, provider Voila-scope, and a construction smoke test.
- `nox -s test`: full non-GEE suite green (370 passed, 1 skipped).
- Real ipykernel proof (`SERVER_SOFTWARE=voila`, no solara context): resolver + bus + session all resolve to a stable `voila:<id>`.
- Live Voila server serves the smoke notebook (HTTP 200, clean kernel start). The final in-browser visual click-through (toasts appearing) is a manual check still to be done.

## Note

Voila detection relies on `solara.util.is_running_in_voila()` (the `SERVER_SOFTWARE` env var), by design. `create_bus`/`create_session` don't catch `UnsupportedSolaraRuntimeError`, so a non-standard Voila deployment missing that env var would surface the error at render — strictly better than before (the old code always raised under Voila). Hardening that path is a possible follow-up.
