### PR TITLE
fix(FileInput): select_file must store string paths, not PosixPath

### DIFF
--- a/pysepal/sepalwidgets/file_input.py
+++ b/pysepal/sepalwidgets/file_input.py
@@ -204,15 +204,15 @@ class FileInput(v.VuetifyTemplate, SepalWidget):
         if self.client:
             raise NotImplementedError("Selecting files is not supported for remote files (yet)")
 
-        file_path = path  # path should be deprecated
-        path = Path(file_path)
+        path = Path(path)
 
         # test file existence
         if not path.is_file():
             raise Exception(f"{path} is not a file")
 
-        self.current_folder = file_path.parent
-        self.value = str(file_path)
+        # current_folder is a Unicode trait, so store the parent as a string
+        self.current_folder = str(path.parent)
+        self.value = str(path)
 
 
 def __getattr__(name: str):

--- a/tests/test_sepalwidgets/test_file_input.py
+++ b/tests/test_sepalwidgets/test_file_input.py
@@ -1,0 +1,32 @@
+"""Test the FileInput widget in pysepal.sepalwidgets.file_input."""
+
+from pathlib import Path
+
+from pysepal.sepalwidgets.file_input import FileInput
+
+
+def test_select_file_accepts_path(tmp_path: Path) -> None:
+    """select_file must accept a Path and store string traits.
+
+    current_folder is a Unicode trait, so assigning a Path raised a TraitError.
+    """
+    csv = tmp_path / "classes.csv"
+    csv.write_text("lc_class,desc,color\n1,a,#000000\n")
+
+    file_input = FileInput(initial_folder=str(tmp_path), root=str(tmp_path))
+    file_input.select_file(csv)
+
+    assert file_input.value == str(csv)
+    assert file_input.current_folder == str(tmp_path)
+
+
+def test_select_file_accepts_str(tmp_path: Path) -> None:
+    """select_file must also accept a plain string path (str has no .parent)."""
+    csv = tmp_path / "classes.csv"
+    csv.write_text("lc_class,desc,color\n1,a,#000000\n")
+
+    file_input = FileInput(initial_folder=str(tmp_path), root=str(tmp_path))
+    file_input.select_file(str(csv))
+
+    assert file_input.value == str(csv)
+    assert file_input.current_folder == str(tmp_path)


### PR DESCRIPTION
`FileInput.select_file` (in `pysepal/sepalwidgets/file_input.py`) is broken for both input types:

```python
file_path = path            # caller may pass str or Path
path = Path(file_path)
...
self.current_folder = file_path.parent   # PosixPath -> Unicode trait => TraitError
self.value = str(file_path)              # (and a str arg has no .parent => AttributeError)
```

`current_folder` is a `Unicode` trait, so assigning `path.parent` (a `PosixPath`) raises `TraitError`; passing a plain `str` raises `AttributeError` on the same line. Either way the method is unusable, which is why call sites that select a file programmatically have had to work around it by setting `.value` directly.

### Fix

Normalize the argument to a `Path` and store `str()` values:

```python
path = Path(path)
...
self.current_folder = str(path.parent)
self.value = str(path)
```

Adds `tests/test_sepalwidgets/test_file_input.py` covering `select_file` with both a `Path` and a `str` (this class had no test file). Both fail on `main` (`TraitError`) and pass with the fix.

Found while working on a SEPAL module that drives this dialog's file selection.
