### PR TITLE
fix(gee): init_ee no-ops when credentials are unavailable

### DIFF
--- a/pysepal/scripts/gee.py
+++ b/pysepal/scripts/gee.py
@@ -370,12 +370,15 @@ def init_ee() -> None:
         credential_folder_path = Path.home() / ".config" / "earthengine"
         credential_file_path = credential_folder_path / "credentials"
 
-        if "EARTHENGINE_TOKEN" in os.environ and not credential_file_path.exists():
+        ee_token = os.environ.get("EARTHENGINE_TOKEN")
+        if ee_token and not credential_file_path.exists():
 
             # write the token to the appropriate folder
-            ee_token = os.environ["EARTHENGINE_TOKEN"]
             credential_folder_path.mkdir(parents=True, exist_ok=True)
             credential_file_path.write_text(ee_token)
+
+        if not credential_file_path.exists():
+            return
 
         # Extract the project name from credentials
         _credentials = json.loads(credential_file_path.read_text())

--- a/pysepal/scripts/gee.py
+++ b/pysepal/scripts/gee.py
@@ -45,10 +45,14 @@ def need_ee(func: Callable) -> Any:
 
     @wraps(func)
     def wrapper_ee(*args, **kwargs):
-        # try to connect to ee
+        # init_ee() is best-effort and no-ops without credentials, so require an
+        # initialized session here rather than trusting the call to have raised
         try:
             init_ee()
         except Exception:
+            pass
+
+        if not ee.data.is_initialized():
             raise Exception("This function needs an Earth Engine authentication")
 
         return func(*args, **kwargs)

--- a/tests/test_scripts/test_decorator.py
+++ b/tests/test_scripts/test_decorator.py
@@ -14,6 +14,8 @@ from pysepal.scripts import decorator as sd
 from pysepal.scripts.warning import SepalWarning
 
 
+@pytest.mark.gee
+@pytest.mark.skipif(not ee.data.is_initialized(), reason="GEE is not set")
 def test_init_ee() -> None:
     """Test the init_ee_from_token function."""
     credentials_filepath = Path(ee.oauth.get_credentials_path())

--- a/tests/test_scripts/test_decorator.py
+++ b/tests/test_scripts/test_decorator.py
@@ -70,6 +70,23 @@ def test_init_ee() -> None:
     return
 
 
+def test_need_ee_raises_when_not_initialized(monkeypatch) -> None:
+    """@need_ee must fail loudly when EE is not initialized.
+
+    init_ee() is best-effort (no-ops without credentials), so need_ee enforces the
+    requirement: the wrapped function must not run against an uninitialized session.
+    """
+    monkeypatch.setattr("pysepal.scripts.gee.init_ee", lambda: None)
+    monkeypatch.setattr(ee.data, "is_initialized", lambda: False)
+
+    @sd.need_ee
+    def use_ee() -> str:
+        return "ran"
+
+    with pytest.raises(Exception, match="needs an Earth Engine authentication"):
+        use_ee()
+
+
 def test_catch_errors() -> None:
     """Check the catch error decorator."""
     # create an external alert to test the wiring

--- a/tests/test_scripts/test_utils.py
+++ b/tests/test_scripts/test_utils.py
@@ -108,6 +108,8 @@ def test_get_file_size() -> None:
     return
 
 
+@pytest.mark.gee
+@pytest.mark.skipif(not ee.data.is_initialized(), reason="GEE is not set")
 def test_init_ee() -> None:
     """Test the init_ee_from_token function."""
     credentials_filepath = Path(ee.oauth.get_credentials_path())
@@ -160,6 +162,23 @@ def test_init_ee() -> None:
         su.init_ee()
 
     return
+
+
+def test_init_ee_without_credentials_is_noop(monkeypatch, tmp_path) -> None:
+    """init_ee() must not crash when no usable credentials are available.
+
+    Reproduces the fork-PR CI failure: EARTHENGINE_TOKEN is defined but empty and
+    no credential file exists. The bootstrap must leave Earth Engine uninitialized
+    (so the non-GEE suite still collects and GEE tests skip) instead of writing an
+    empty credentials file and dying in ``json.loads("")``.
+    """
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    monkeypatch.setattr(ee.data, "is_initialized", lambda: False)
+    monkeypatch.setenv("EARTHENGINE_TOKEN", "")
+
+    su.init_ee()  # must not raise
+
+    assert not (tmp_path / ".config" / "earthengine" / "credentials").exists()
 
 
 def test_to_colors() -> None:


### PR DESCRIPTION
The secret-gating added in #988 sets `EARTHENGINE_TOKEN` to an empty string on fork PRs. `init_ee()` treated the present-but-empty variable as a real token, wrote an empty credentials file, and then crashed in `json.loads("")`. Because `conftest.py` calls `init_ee()` at import time, this failed collection of the **entire** non-GEE suite — our first external PR (#1011) hit exactly this.

`init_ee()` now treats an empty/absent token as "no credentials" and returns early, leaving Earth Engine uninitialized so the non-GEE suite still runs and GEE tests skip via the existing `skipif(not ee.data.is_initialized())`. The two credential-dependent `init_ee` tests move behind `@pytest.mark.gee` — they were convention violations that the collection crash had been masking.

Tested with a new credential-free regression test that reproduces the exact CI failure and then passes; the full default lane is green locally, and the pre-existing `test_conf` flake / Planet-API errors reproduce on `main` too.
