### PR TITLE
fix(AssetSelect): guard None from get_assets_async

### DIFF
--- a/pysepal/sepalwidgets/inputs.py
+++ b/pysepal/sepalwidgets/inputs.py
@@ -925,7 +925,8 @@ class AssetSelect(v.Combobox, SepalWidget):
         )
 
         # get the list of user asset
-        raw_assets = gee_assets or await self.gee_interface.get_assets_async(self.folder)
+        # get_assets_async can return None for an empty/inaccessible folder; keep it iterable
+        raw_assets = gee_assets or await self.gee_interface.get_assets_async(self.folder) or []
 
         log.debug(
             f"[{id(self)}] {text} || [[[{id(self)} ]]]Already awaited for get_assets_async, current v_model is {self.v_model}"


### PR DESCRIPTION
`AssetSelect._get_items_async` crashed with `'NoneType' object is not iterable` when `get_assets_async` returned `None` (empty or inaccessible asset folder), since the result is iterated directly to build the dropdown. Guard it with `or []`.

The selected default asset was never affected — only the user-asset listing failed, so the widget's value stayed correct while the task errored in the log.
