### PR TITLE
test(mapping): gee-mark credential-dependent control tests

### DIFF
--- a/tests/test_mapping/test_AoiControl.py
+++ b/tests/test_mapping/test_AoiControl.py
@@ -40,6 +40,8 @@ def test_add_aoi_ee(ee_points: Tuple[ee.Geometry.Point], aoi_control: sm.AoiCont
     return
 
 
+@pytest.mark.gee
+@pytest.mark.skipif(not ee.data.is_initialized(), reason="GEE is not set")
 def test_add_aoi(points: Tuple[sg.Point], aoi_control: sm.AoiControl) -> None:
     """Add an aoi to the control.
 
@@ -59,6 +61,8 @@ def test_add_aoi(points: Tuple[sg.Point], aoi_control: sm.AoiControl) -> None:
     return
 
 
+@pytest.mark.gee
+@pytest.mark.skipif(not ee.data.is_initialized(), reason="GEE is not set")
 def test_remove_aoi(points: Tuple[sg.Point], aoi_control: sm.AoiControl) -> None:
     """Remove an aoi from the control.
 
@@ -81,6 +85,8 @@ def test_remove_aoi(points: Tuple[sg.Point], aoi_control: sm.AoiControl) -> None
     return
 
 
+@pytest.mark.gee
+@pytest.mark.skipif(not ee.data.is_initialized(), reason="GEE is not set")
 def test_click_btn(points: Tuple[sg.Point], aoi_control: sm.AoiControl) -> None:
     """Click on the btn to change the zoom.
 
@@ -111,6 +117,8 @@ def test_click_btn(points: Tuple[sg.Point], aoi_control: sm.AoiControl) -> None:
     return
 
 
+@pytest.mark.gee
+@pytest.mark.skipif(not ee.data.is_initialized(), reason="GEE is not set")
 def test_zoom(points: Tuple[sg.Point], aoi_control: sm.AoiControl) -> None:
     """Check the map is zoomed.
 

--- a/tests/test_mapping/test_LayersControl.py
+++ b/tests/test_mapping/test_LayersControl.py
@@ -177,6 +177,8 @@ def test_ungrouped() -> None:
     return
 
 
+@pytest.mark.gee
+@pytest.mark.skipif(not ee.data.is_initialized(), reason="GEE is not set")
 def test_vectors() -> None:
     """Check that vectors are grouped together and they can be controlled."""
     m = sm.SepalMap()


### PR DESCRIPTION
Follow-up to #1012. With the `conftest` collection crash fixed, fork PR CI (#1011) now runs the suite — which surfaced 5 pre-existing `test_mapping` tests that reach live Earth Engine (4 `AoiControl` tests via a `@need_ee` method, `LayersControl::test_vectors` via `AoiModel(admin=...)`) but weren't `@pytest.mark.gee`. They ran in the default lane and failed on a credential-less fork.

Marking them (same convention as the rest of the file) makes them skip on forks and run in `test_gee` on push. Verified locally: the 5 are deselected in the default lane and pass in the gee lane.
