### PR TITLE
fix(mapping): only prune foreign GDAL_DATA/PROJ_LIB, keep own-prefix paths

### DIFF
--- a/pysepal/mapping/gdal_env.py
+++ b/pysepal/mapping/gdal_env.py
@@ -1,20 +1,47 @@
-"""Sanitize GDAL/PROJ data environment variables."""
+"""Sanitize GDAL/PROJ data environment variables.
+
+SEPAL's system GDAL exports GDAL_DATA, PROJ_LIB and PROJ_DATA into every module
+venv, pointing at data files for a different GDAL build than the venv's wheels.
+That breaks raster reads, so drop them before anything imports rasterio.
+
+Paths inside the interpreter's own prefix are kept: they are this environment's
+own GDAL stack, and pyogrio and osgeo break without them. This cannot fix a mixed
+conda/wheel install, where a wheel's own libgdal lives in that prefix too.
+"""
 
 import os
 import sys
+from pathlib import Path
+
+GDAL_ENV_VARS = ("GDAL_DATA", "PROJ_LIB", "PROJ_DATA")
+"""Data-directory variables to sanitize.
+
+``PROJ_LIB`` is PROJ's pre-9.1 name for ``PROJ_DATA``; both are still exported in
+the wild, so a foreign PROJ install can arrive through either one.
+"""
+
+
+def _is_own_path(path: str) -> bool:
+    """Whether ``path`` resolves under one of this interpreter's own prefixes.
+
+    ``sys.base_prefix`` differs from ``sys.prefix`` inside a venv, and a venv
+    layered on a conda env inherits that env's GDAL stack, so both count as ours.
+    """
+    if not path:
+        return False
+
+    try:
+        resolved = Path(path).resolve()
+        prefixes = [Path(prefix).resolve() for prefix in (sys.prefix, sys.base_prefix)]
+    except OSError:
+        return False
+
+    return any(resolved.is_relative_to(prefix) for prefix in prefixes)
 
 
 def prune_foreign_gdal_env() -> None:
-    """Remove GDAL/PROJ data paths that belong to a foreign GDAL install.
-
-    On SEPAL the system GDAL exports ``GDAL_DATA``/``PROJ_LIB`` pointing at
-    data files for a different GDAL version than the one bundled with the
-    rasterio wheel, which breaks raster reads. Paths inside ``sys.prefix``
-    belong to this environment's own GDAL stack (e.g. conda) and are kept:
-    removing them breaks GDAL data discovery for the environment's own
-    GDAL-based libraries (pyogrio, osgeo).
-    """
-    for var in ("GDAL_DATA", "PROJ_LIB"):
+    """Delete the GDAL/PROJ data variables that point outside this environment."""
+    for var in GDAL_ENV_VARS:
         path = os.environ.get(var)
-        if path is not None and not path.startswith(sys.prefix):
+        if path is not None and not _is_own_path(path):
             del os.environ[var]

--- a/pysepal/mapping/gdal_env.py
+++ b/pysepal/mapping/gdal_env.py
@@ -1,0 +1,20 @@
+"""Sanitize GDAL/PROJ data environment variables."""
+
+import os
+import sys
+
+
+def prune_foreign_gdal_env() -> None:
+    """Remove GDAL/PROJ data paths that belong to a foreign GDAL install.
+
+    On SEPAL the system GDAL exports ``GDAL_DATA``/``PROJ_LIB`` pointing at
+    data files for a different GDAL version than the one bundled with the
+    rasterio wheel, which breaks raster reads. Paths inside ``sys.prefix``
+    belong to this environment's own GDAL stack (e.g. conda) and are kept:
+    removing them breaks GDAL data discovery for the environment's own
+    GDAL-based libraries (pyogrio, osgeo).
+    """
+    for var in ("GDAL_DATA", "PROJ_LIB"):
+        path = os.environ.get(var)
+        if path is not None and not path.startswith(sys.prefix):
+            del os.environ[var]

--- a/pysepal/mapping/sepal_map.py
+++ b/pysepal/mapping/sepal_map.py
@@ -9,7 +9,7 @@ from pysepal.mapping.bounds import (
     viewport_pixels_from_map,
 )
 from pysepal.mapping.fullscreen_control import FullScreenControl
-from pysepal.mapping.gdal_env import prune_foreign_gdal_env
+from pysepal.mapping.gdal_env import GDAL_ENV_VARS, prune_foreign_gdal_env
 from pysepal.mapping.visualization import (
     get_viz_params,
     get_viz_params_async,
@@ -19,7 +19,7 @@ from pysepal.scripts.gee_interface import GEEInterface
 from pysepal.sepalwidgets.vue_app import ThemeToggle
 from pysepal.solara.theme import ThemeState
 
-if "GDAL_DATA" in os.environ or "PROJ_LIB" in os.environ:
+if any(var in os.environ for var in GDAL_ENV_VARS):
     prune_foreign_gdal_env()
 
 import json

--- a/pysepal/mapping/sepal_map.py
+++ b/pysepal/mapping/sepal_map.py
@@ -9,6 +9,7 @@ from pysepal.mapping.bounds import (
     viewport_pixels_from_map,
 )
 from pysepal.mapping.fullscreen_control import FullScreenControl
+from pysepal.mapping.gdal_env import prune_foreign_gdal_env
 from pysepal.mapping.visualization import (
     get_viz_params,
     get_viz_params_async,
@@ -18,10 +19,8 @@ from pysepal.scripts.gee_interface import GEEInterface
 from pysepal.sepalwidgets.vue_app import ThemeToggle
 from pysepal.solara.theme import ThemeState
 
-if "GDAL_DATA" in list(os.environ.keys()):
-    del os.environ["GDAL_DATA"]
-if "PROJ_LIB" in list(os.environ.keys()):
-    del os.environ["PROJ_LIB"]
+if "GDAL_DATA" in os.environ or "PROJ_LIB" in os.environ:
+    prune_foreign_gdal_env()
 
 import json
 import math

--- a/tests/test_mapping/test_gdal_env.py
+++ b/tests/test_mapping/test_gdal_env.py
@@ -1,0 +1,32 @@
+"""Test the GDAL/PROJ data environment sanitizer."""
+
+import os
+import sys
+
+from pysepal.mapping.gdal_env import prune_foreign_gdal_env
+
+
+def test_prune_foreign_gdal_env(monkeypatch) -> None:
+    """Foreign GDAL/PROJ data paths are pruned, own-prefix paths are kept."""
+    # foreign paths (e.g. the SEPAL system GDAL) are removed
+    monkeypatch.setenv("GDAL_DATA", "/nonexistent-foreign/share/gdal")
+    monkeypatch.setenv("PROJ_LIB", "/nonexistent-foreign/share/proj")
+    prune_foreign_gdal_env()
+    assert "GDAL_DATA" not in os.environ
+    assert "PROJ_LIB" not in os.environ
+
+    # paths inside sys.prefix (the environment's own GDAL stack) are kept
+    own_gdal = os.path.join(sys.prefix, "share", "gdal")
+    own_proj = os.path.join(sys.prefix, "share", "proj")
+    monkeypatch.setenv("GDAL_DATA", own_gdal)
+    monkeypatch.setenv("PROJ_LIB", own_proj)
+    prune_foreign_gdal_env()
+    assert os.environ["GDAL_DATA"] == own_gdal
+    assert os.environ["PROJ_LIB"] == own_proj
+
+    # unset variables are left untouched
+    monkeypatch.delenv("GDAL_DATA", raising=False)
+    monkeypatch.delenv("PROJ_LIB", raising=False)
+    prune_foreign_gdal_env()
+    assert "GDAL_DATA" not in os.environ
+    assert "PROJ_LIB" not in os.environ

--- a/tests/test_mapping/test_gdal_env.py
+++ b/tests/test_mapping/test_gdal_env.py
@@ -2,31 +2,89 @@
 
 import os
 import sys
+from pathlib import Path
 
-from pysepal.mapping.gdal_env import prune_foreign_gdal_env
+import pytest
+
+from pysepal.mapping.gdal_env import GDAL_ENV_VARS, prune_foreign_gdal_env
 
 
-def test_prune_foreign_gdal_env(monkeypatch) -> None:
-    """Foreign GDAL/PROJ data paths are pruned, own-prefix paths are kept."""
-    # foreign paths (e.g. the SEPAL system GDAL) are removed
-    monkeypatch.setenv("GDAL_DATA", "/nonexistent-foreign/share/gdal")
-    monkeypatch.setenv("PROJ_LIB", "/nonexistent-foreign/share/proj")
+@pytest.fixture(autouse=True)
+def _clean_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Start every case from an environment with no data variables set."""
+    for var in GDAL_ENV_VARS:
+        monkeypatch.delenv(var, raising=False)
+
+    return
+
+
+def test_every_data_var_is_covered() -> None:
+    """The cases below parametrize over the constant, so pin what it must hold."""
+    assert set(GDAL_ENV_VARS) == {"GDAL_DATA", "PROJ_LIB", "PROJ_DATA"}
+
+    return
+
+
+@pytest.mark.parametrize("var", GDAL_ENV_VARS)
+def test_foreign_path_is_pruned(monkeypatch: pytest.MonkeyPatch, var: str) -> None:
+    """A path outside every own prefix belongs to the SEPAL system GDAL."""
+    monkeypatch.setenv(var, "/usr/share/gdal")
     prune_foreign_gdal_env()
+
+    assert var not in os.environ
+
+    return
+
+
+@pytest.mark.parametrize("var", GDAL_ENV_VARS)
+def test_own_prefix_path_is_kept(monkeypatch: pytest.MonkeyPatch, var: str) -> None:
+    """A path under sys.prefix belongs to this environment's own GDAL stack."""
+    own = str(Path(sys.prefix) / "share" / "gdal")
+    monkeypatch.setenv(var, own)
+    prune_foreign_gdal_env()
+
+    assert os.environ[var] == own
+
+    return
+
+
+@pytest.mark.parametrize("var", GDAL_ENV_VARS)
+def test_base_prefix_path_is_kept(monkeypatch: pytest.MonkeyPatch, var: str) -> None:
+    """A venv layered on conda reaches its GDAL stack through sys.base_prefix."""
+    own = str(Path(sys.base_prefix) / "share" / "gdal")
+    monkeypatch.setattr(sys, "prefix", "/nonexistent/venv")
+    monkeypatch.setenv(var, own)
+    prune_foreign_gdal_env()
+
+    assert os.environ[var] == own
+
+    return
+
+
+def test_sibling_prefix_is_pruned(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A sibling env sharing a name prefix is foreign, so string matching won't do."""
+    monkeypatch.setenv("GDAL_DATA", f"{sys.prefix}-other/share/gdal")
+    prune_foreign_gdal_env()
+
     assert "GDAL_DATA" not in os.environ
-    assert "PROJ_LIB" not in os.environ
 
-    # paths inside sys.prefix (the environment's own GDAL stack) are kept
-    own_gdal = os.path.join(sys.prefix, "share", "gdal")
-    own_proj = os.path.join(sys.prefix, "share", "proj")
-    monkeypatch.setenv("GDAL_DATA", own_gdal)
-    monkeypatch.setenv("PROJ_LIB", own_proj)
-    prune_foreign_gdal_env()
-    assert os.environ["GDAL_DATA"] == own_gdal
-    assert os.environ["PROJ_LIB"] == own_proj
+    return
 
-    # unset variables are left untouched
-    monkeypatch.delenv("GDAL_DATA", raising=False)
-    monkeypatch.delenv("PROJ_LIB", raising=False)
+
+def test_empty_value_is_pruned(monkeypatch: pytest.MonkeyPatch) -> None:
+    """An empty value sends GDAL looking in an empty directory."""
+    monkeypatch.setenv("GDAL_DATA", "")
     prune_foreign_gdal_env()
+
     assert "GDAL_DATA" not in os.environ
-    assert "PROJ_LIB" not in os.environ
+
+    return
+
+
+def test_unset_vars_are_left_alone() -> None:
+    """The sanitizer is a no-op when the environment exports nothing."""
+    prune_foreign_gdal_env()
+
+    assert not any(var in os.environ for var in GDAL_ENV_VARS)
+
+    return


### PR DESCRIPTION
## Problem

`pysepal/mapping/sepal_map.py` unconditionally deletes `GDAL_DATA` and `PROJ_LIB` from `os.environ` at import time (an old workaround for the SEPAL system GDAL breaking the wheel-bundled rasterio).

In conda environments those variables point at the environment's **own** GDAL data directory, and deleting them poisons GDAL data discovery for the environment's own GDAL stack. The full failure chain, observed in a conda-based app (spatial_risk):

1. `import pysepal.mapping.sepal_map` deletes `GDAL_DATA` (set by conda activation to `$CONDA_PREFIX/share/gdal`).
2. The pip rasterio wheel, imported afterwards, registers its bundled `rasterio/gdal_data` path in its internal GDAL config (correct only for its private libgdal).
3. When a raster layer is displayed, localtileserver's `TileClient` forwards rasterio's env options **process-wide** into `os.environ` for its background tile-server thread — so `GDAL_DATA` now points at `site-packages/rasterio/gdal_data`, which contains no `header.dxf`.
4. A later lazy `import pyogrio` (e.g. `GeoDataFrame.to_file`) runs its `header.dxf` sanity check against the poisoned `GDAL_DATA` and raises:

   ```
   ValueError: Found GDAL data directory at .../envs/<env>/share/gdal but it
   does not appear to correctly contain GDAL data files
   ```

## Fix

Replace the unconditional deletion with `_prune_foreign_gdal_env()`: delete `GDAL_DATA`/`PROJ_LIB` only when they point **outside** `sys.prefix`.

- SEPAL case unchanged: a system GDAL exporting `/usr/share/gdal` into a venv is still pruned.
- Conda/venv case fixed: paths inside the interpreter's own prefix belong to the environment's own GDAL stack and are kept.

## Testing

- New unit test `test_prune_foreign_gdal_env` covering foreign-path pruning, own-prefix preservation, and unset variables.
- Manually verified in the affected conda env: `GDAL_DATA` survives the sepal_map import, `import pyogrio` succeeds, and `GDAL_DATA=/usr/share/gdal` is still removed.