### PR TITLE
feat(mapping): PMTiles layers in LayersControl, and fix modal layering + the GEE event loop

### DIFF
--- a/docs/guides/solara-gee-patterns.md
+++ b/docs/guides/solara-gee-patterns.md
@@ -48,21 +48,31 @@ Use `use_thread` only for genuinely synchronous local work.
 
 ## Event Loop Rule for GEE
 
-The important event-loop detail is not `GEEInterface`'s private loop. In the
-session-backed path, `gee_interface.get_info_async(...)` delegates directly to
-`ee-client` awaitables.
+The rule is one event loop per app. `EESession` owns asyncio coordination
+primitives such as locks and semaphores, and `ee-client` caches a single
+`httpx.AsyncClient(http2=True)` per session. All of them bind lazily to the
+first event loop that needs them, so a second loop breaks them under
+contention.
 
-The real Solara risk is `use_task(prefer_threaded=True)`. Solara can run a
-coroutine task in a separate thread with its own event loop. At the same time,
-`EESession` owns asyncio coordination primitives such as locks and semaphores.
-Those primitives bind lazily to the first event loop that needs them.
+There are two ways to end up with a second loop:
+
+- `use_task(prefer_threaded=True)`. Solara runs the coroutine in a separate
+  thread with its own event loop.
+- `gee_interface.create_task(...)`. It hands the coroutine to `GEEInterface`'s
+  private loop, running in its own thread. Because `get_info_async` delegates
+  directly to `ee-client`, it runs on _whichever loop called it_ — so this is a
+  second loop even when every `use_task` in the app sets
+  `prefer_threaded=False`. Mixing the two scheduling styles in one app is what
+  breaks, which is why the legacy `sw.TaskButton` must not be combined with
+  `use_task` components.
 
 Two consequences follow:
 
 - Light testing can look fine. If a lock or semaphore is never contended, the
   code may appear to work across loops.
-- Under contention, or once waiters are created, asyncio can raise
-  `RuntimeError: ... is bound to a different event loop`.
+- Under contention, or once waiters are created, asyncio raises either
+  `RuntimeError: ... is bound to a different event loop` or
+  `RuntimeError: Non-thread-safe operation invoked on an event loop other than the current one` — which primitive loses the race varies between runs.
 
 **The rule for new Solara GEE apps:**
 

--- a/pysepal/frontend/css/base.css
+++ b/pysepal/frontend/css/base.css
@@ -23,9 +23,35 @@
   background-color: transparent;
 }
 
-/* set the bar on top of the map (800) when set to fullscreen */
+/*  ---------------------------------------------------------------------------
+ *  LAYERING CONTRACT
+ *
+ *  Everything pysepal floats over the page lives BELOW vuetify's modal
+ *  baseline (~200). That is deliberate: vuetify computes a dialog's z-index at
+ *  runtime (the `stackable` mixin reads computed z-indexes off the DOM), so any
+ *  app layer that outranks it has to be beaten with `!important` -- which
+ *  desynchronises that bookkeeping and silently breaks click-outside-to-close.
+ *  Keeping our layers underneath means vuetify's scrim covers the map on its
+ *  own, dialogs stack natively, and the scrim dims the legend and logger for
+ *  free.
+ *
+ *      100  fullscreen map
+ *      110  app bar
+ *      150  map legend
+ *      160  MapApp side panels
+ *      170  task pill / logger
+ *      ~201 vuetify scrim          <-- do not pin these two from CSS
+ *      ~202 vuetify dialog
+ *      9999 toast stack            <-- intentionally above modals
+ *
+ *  Add new floating chrome below 200. If something must sit above a modal,
+ *  say why, as the toast stack does. Enforced by
+ *  tests/test_frontend/test_layering_contract.py.
+ *  ------------------------------------------------------------------------ */
+
+/* set the bar on top of the map when set to fullscreen */
 header.v-app-bar {
-  z-index: 800 !important;
+  z-index: 110 !important;
 }
 
 /* set the menu_content on top of the map when it's set to fullscreen.
@@ -119,7 +145,7 @@ header.v-app-bar {
   position: fixed !important;
   width: 100vw;
   height: calc(100vh - 48px);
-  z-index: 800;
+  z-index: 100;
   bottom: 0;
   left: 0;
 }

--- a/pysepal/frontend/css/base.css
+++ b/pysepal/frontend/css/base.css
@@ -326,3 +326,12 @@ header.theme--light.v-app-bar.v-toolbar.v-sheet {
 .right-panel .drawer-top .v-sheet {
   background-color: transparent !important;
 }
+
+/* The legend and the open logger both float over the bottom of the map and
+ * would overlap, so an open legend collapses to its bar while the logger is up.
+ * Only `__body` is dropped -- `__bar` stays, so the legend keeps its icon and
+ * the user can still reach it. `.pill-log` is `v-if`-ed out of the DOM while
+ * the logger is closed, which makes its presence the signal. */
+body:has(.pill-log) .sepal-legend__body {
+  display: none;
+}

--- a/pysepal/mapping/layers_control.py
+++ b/pysepal/mapping/layers_control.py
@@ -3,7 +3,7 @@
 from types import SimpleNamespace
 from typing import Optional
 
-from ipyleaflet import GeoJSON, Map, TileLayer
+from ipyleaflet import GeoJSON, Layer, Map, TileLayer
 from ipywidgets import link
 
 from pysepal import sepalwidgets as sw
@@ -145,10 +145,74 @@ class VectorRow(sw.Html):
         link((layer, "visible"), (self.w_checkbox, "v_model"))
 
 
+class ToggleRow(sw.Html):
+
+    w_checkbox: Optional[sw.SimpleCheckbox] = None
+    "the checkbox to hide/show the layer"
+
+    def __init__(self, layer: Layer, control: "LayersControl", index: int) -> None:
+        """Html row element to describe a layer exposing no visibility trait.
+
+        Layers such as the ipyleaflet ``PMTilesLayer`` inherit from ``Layer`` rather
+        than ``RasterLayer``, so they have neither ``visible`` nor ``opacity`` to link
+        a widget to. They are hidden by removing them from the map instead, which means
+        the control has to remember them, and where they sat, to keep the row in place.
+
+        Showing a layer again appends it to the map, so it lands on top of anything
+        added while it was hidden. That cannot be undone from python: ipywidgets reuses
+        the views of the models already present, so reordering ``m.layers`` never
+        replays leaflet's ``addLayer`` and the stack stays as it is.
+
+        Args:
+            layer: the layer associated to the row
+            control: the layer control owning the registry of hidden layers
+            index: the position of the row, restored as is when the layer is hidden
+        """
+        self.layer = layer
+        self.control = control
+        self.index = index
+
+        # create the checkbox, by default layer are visible
+        self.w_checkbox = sw.SimpleCheckbox(
+            v_model=layer not in control.hidden, small=True, label=layer.name, color="primary"
+        )
+        kwargs = {"style": "width: 10%;", "tag": "td"}
+        checkbox_cell = sw.Html(children=[self.w_checkbox], **kwargs)
+
+        # create the label
+        kwargs = {"style_": "width: 40%;", "tag": "td"}
+        label_cell = sw.Html(children=[layer.name], **kwargs)
+
+        # create an empty row to align on
+        kwargs = {"style_": "width: 50%;", "tag": "td"}
+        empty_cell = sw.Html(children=[""], **kwargs)
+
+        # build a html tr from it
+        super().__init__(tag="tr", children=[label_cell, empty_cell, checkbox_cell])
+
+        # add js behavior
+        self.w_checkbox.observe(self._toggle_layer, "v_model")
+
+    def _toggle_layer(self, *args) -> None:
+        """Add or remove the layer from the map."""
+        # the registry drives the rebuild triggered by the map, so update it first
+        if self.w_checkbox.v_model:
+            self.control.hidden.pop(self.layer, None)
+            self.control.m.add(self.layer)
+        else:
+            self.control.hidden[self.layer] = self.index
+            self.control.m.remove(self.layer)
+
+        return
+
+
 class LayersControl(MenuControl):
 
     m: Optional[Map] = None
     "the map controlled by the layercontrol"
+
+    hidden: Optional[dict] = None
+    "the layers this control removed from the map to hide them, and their row position"
 
     group: Optional[sw.RadioGroup] = None
     "As radio button cannot behave individually we add an extra GroupRadio to wrap the table"
@@ -164,6 +228,7 @@ class LayersControl(MenuControl):
         """
         # save the map
         self.m = m
+        self.hidden = {}
 
         # create a loading to place it on top of the card. It will always be visible
         # even when the card is scrolled
@@ -196,10 +261,25 @@ class LayersControl(MenuControl):
         """Update the table content."""
         # create the vector line
         vectors = [lyr for lyr in reversed(self.m.layers) if isinstance(lyr, GeoJSON)]
+
+        # overlays owning no visible trait (PMTiles, ...) cannot be linked to a
+        # checkbox, they are displayed alongside the vectors and toggled by hand
+        others = [
+            lyr
+            for lyr in reversed(self.m.layers)
+            if lyr.base is False and not lyr.has_trait("visible")
+        ]
+
+        # splice the hidden ones back where they sat, else a row would jump away
+        # from the cursor that just unchecked it
+        for layer, index in sorted(self.hidden.items(), key=lambda item: item[1]):
+            others.insert(min(index, len(others)), layer)
+
         vector_rows = []
-        if len(vectors) > 0:
+        if len(vectors) > 0 or len(others) > 0:
             head = [HeaderRow(ms.layer_control.vector.header)]
             rows = [VectorRow(lyr) for lyr in vectors]
+            rows += [ToggleRow(lyr, self, i) for i, lyr in enumerate(others)]
             vector_rows = head + rows
 
         # create a table of layerLine

--- a/pysepal/sepalwidgets/vue/MapApp.vue
+++ b/pysepal/sepalwidgets/vue/MapApp.vue
@@ -1008,10 +1008,6 @@ export default {
   transform: translate(-50%, -50%);
 }
 
-.dialog-container {
-  z-index: 1010 !important;
-}
-
 .dialog-card {
   max-width: 100%;
   max-height: 90vh;
@@ -1051,30 +1047,24 @@ export default {
   position: fixed !important;
   width: 100vw !important;
   height: 100vh !important;
-  z-index: 800;
+  z-index: 100;
   bottom: 0;
   left: 0;
 }
 
-/* v-dialog overlay should be below our dialog but above other elements */
-.v-overlay__scrim {
-  z-index: 1005 !important;
-  position: fixed !important;
-  top: 0 !important;
-  left: 0 !important;
-  width: 100vw !important;
-  height: 100vh !important;
-}
-
-/* Ensure dialog overlay covers navigation drawer and right panel */
-.v-application .v-overlay--active .v-overlay__scrim {
-  z-index: 1005 !important;
-}
+/* The scrim is deliberately NOT overridden. It used to be forced to
+   `position: fixed` at `100vw/100vh` to cover a map that outranked it, but the
+   app's layers now sit below vuetify's baseline so the default
+   (`absolute`, inset 0 inside a fixed `.v-overlay`) already covers the
+   viewport. Pinning explicit viewport units also made resizing visibly lag:
+   vuetify declares `transition: .3s` with no property, i.e. `all`, so an
+   explicit width/height ANIMATES to its new size on every resize (measured at
+   ~296ms) while inset-based sizing settles in ~2ms. */
 
 /* Ensure right panel is below dialog overlay */
 .v-application .jupyter-widget {
   position: relative;
-  z-index: 1001 !important;
+  z-index: 160 !important;
 }
 
 #map-container .leaflet-left {

--- a/pysepal/solara/components/Legend.vue
+++ b/pysepal/solara/components/Legend.vue
@@ -222,7 +222,9 @@ module.exports = {
       ) / 2
   );
   transform: translateX(-50%);
-  z-index: 1000;
+  /* Below vuetify's modal baseline on purpose -- see the layering contract at
+     the top of frontend/css/base.css. The scrim then dims it during a modal. */
+  z-index: 150;
   pointer-events: auto;
   font-family: Roboto, sans-serif;
   /* Stack body over the toggle bar and keep everything centered. Because the
@@ -434,15 +436,5 @@ module.exports = {
 .sepal-legend__label {
   white-space: nowrap;
   font-size: 12px;
-}
-</style>
-
-<style>
-/* Non-scoped: `body` is outside this component's scope attribute, so the
-   selector must run as plain global CSS. Hides the legend while a step
-   dialog/modal is open — its stacking context sits above the modal scrim
-   due to the jupyter-widget z-index. */
-body.sepal-modal-open .sepal-legend {
-  display: none;
 }
 </style>

--- a/pysepal/solara/notifications/NotificationUI.vue
+++ b/pysepal/solara/notifications/NotificationUI.vue
@@ -452,9 +452,10 @@ export default {
   position: fixed;
   bottom: 8px;
   right: calc(var(--sepal-notification-right-offset, 0px) + 8px);
-  /* Match the toast stack so ongoing task progress stays visible over
-   * dialogs the user might open. */
-  z-index: 9999;
+  /* Below vuetify's modal baseline, unlike the toast stack: the scrim should
+   * dim the pill and the logger rather than let them float over a dialog.
+   * See the layering contract in frontend/css/base.css. */
+  z-index: 170;
   display: flex;
   flex-direction: column;
   align-items: flex-end;

--- a/pysepal/solara/session_manager.py
+++ b/pysepal/solara/session_manager.py
@@ -206,6 +206,17 @@ class SessionManager:
         return self._sessions.copy()
 
 
+def can_create_sessions() -> bool:
+    """Whether a SEPAL session can exist for the current runtime at all.
+
+    ``create_session`` needs solara's request headers. Voila, plain Jupyter and
+    plain scripts never have them, so a missing session there is expected rather
+    than a forgotten ``@with_sepal_sessions`` -- callers should degrade to their
+    headerless fallback instead of raising.
+    """
+    return headers.value is not None
+
+
 def setup_sessions() -> Callable:
     """Set up sessions management for Solara applications.
 

--- a/pysepal/solara/theme.py
+++ b/pysepal/solara/theme.py
@@ -64,13 +64,16 @@ def _get_fallback_theme_state() -> ThemeState:
 
 def get_current_theme_state() -> ThemeState:
     """Return the theme state for the current Solara kernel session."""
-    from .session_manager import SessionManager
+    from .session_manager import SessionManager, can_create_sessions
 
     if SessionManager.is_initialized():
         session_manager = SessionManager()
         theme_state = session_manager.get_session_component("theme_state")
         if theme_state is not None:
             return theme_state
+
+        if not can_create_sessions():
+            return _get_fallback_theme_state()
 
         raise RuntimeError(
             "Session manager is active but no theme state exists for the current kernel. "

--- a/pysepal/solara/utils.py
+++ b/pysepal/solara/utils.py
@@ -13,7 +13,7 @@ from pysepal_api import SepalClient
 from pysepal.scripts.drive_interface import GDriveInterface
 from pysepal.scripts.gee_interface import GEEInterface
 
-from .session_manager import SessionManager
+from .session_manager import SessionManager, can_create_sessions
 
 logger = logging.getLogger(__name__)
 
@@ -62,6 +62,10 @@ def get_current_gee_interface() -> GEEInterface:
         if interface is not None:
             return interface
 
+        if not can_create_sessions():
+            logger.debug("No SEPAL session is possible here; using the fallback")
+            return _get_fallback_gee_interface()
+
         raise RuntimeError(
             "Session manager is active but no session exists for the current kernel. "
             "Ensure your Page component is decorated with @with_sepal_sessions."
@@ -100,6 +104,10 @@ def get_current_drive_interface() -> GDriveInterface:
         interface = session_manager.get_session_component("drive_interface")
         if interface is not None:
             return interface
+
+        if not can_create_sessions():
+            logger.debug("No SEPAL session is possible here; using the fallback")
+            return _get_fallback_drive_interface()
 
         raise RuntimeError(
             "Session manager is active but no session exists for the current kernel. "

--- a/pysepal/templates/solara/solara_map_app/app.py
+++ b/pysepal/templates/solara/solara_map_app/app.py
@@ -50,6 +50,7 @@ from pysepal.solara.components.legend import (
     LegendComponent,
     LegendData,
 )
+from pysepal.solara.components.task_button import TaskButtonComponent, use_task_button
 from pysepal.solara.notifications import NotificationProvider, use_notifications
 
 logger = logging.getLogger("SEPALUI.map_app")
@@ -457,29 +458,37 @@ def MapAppDemo():
     sepal_map = solara.use_memo(build_map, [id(gee_interface)])
     app_model = solara.use_memo(AppModel, [])
 
+    async def add_ndvi_layer():
+        """Add the demo layer.
+
+        Scheduled through ``use_task`` rather than ``gee_interface.create_task``: the
+        latter runs on GEEInterface's own event loop, and two loops sharing the
+        eeclient http/2 client crash it mid-request.
+        """
+        await sepal_map.add_ee_layer_async(
+            _ndvi_composite(),
+            vis_params=NDVI_VIS,
+            name="Sentinel-2 NDVI",
+            key=NDVI_LAYER_ID,
+        )
+        sepal_map.center = DEMO_CENTER
+        sepal_map.zoom = 12
+        layer_legends.set(
+            _upsert_legends(
+                layer_legends.value,
+                LayerLegend(NDVI_LAYER_ID, "Sentinel-2 NDVI", _gradient_legend("NDVI", NDVI_VIS)),
+            )
+        )
+
+    ndvi_task = solara.lab.use_task(
+        add_ndvi_layer, dependencies=None, raise_error=False, prefer_threaded=False
+    )
+    ndvi_btn_props = use_task_button(ndvi_task, on_start=ndvi_task)
+
     def build_layer_buttons():
-        """Build the ipyvuetify buttons once; they close over stable reactives."""
-        btn_add = sw.TaskButton("add layer", small=True, block=True)
+        """Build the sync ipyvuetify buttons once; they close over stable reactives."""
         btn_pmtiles = sw.Btn("add pmtiles layer", small=True, block=True)
         btn_remove = sw.Btn("remove all layers", small=True, block=True)
-
-        async def add_ndvi_layer():
-            await sepal_map.add_ee_layer_async(
-                _ndvi_composite(),
-                vis_params=NDVI_VIS,
-                name="Sentinel-2 NDVI",
-                key=NDVI_LAYER_ID,
-            )
-            sepal_map.center = DEMO_CENTER
-            sepal_map.zoom = 12
-            layer_legends.set(
-                _upsert_legends(
-                    layer_legends.value,
-                    LayerLegend(
-                        NDVI_LAYER_ID, "Sentinel-2 NDVI", _gradient_legend("NDVI", NDVI_VIS)
-                    ),
-                )
-            )
 
         def add_pmtiles_layer():
             """Add vector tiles, which the layer control drives without Earth Engine."""
@@ -499,12 +508,9 @@ def MapAppDemo():
 
         btn_pmtiles.on_event("click", lambda *args: add_pmtiles_layer())
         btn_remove.on_event("click", lambda *args: remove_all_layers())
-        btn_add.configure(
-            task_factory=lambda: gee_interface.create_task(func=add_ndvi_layer, key=NDVI_LAYER_ID)
-        )
-        return btn_add, btn_pmtiles, btn_remove
+        return btn_pmtiles, btn_remove
 
-    btn_add, btn_pmtiles, btn_remove = solara.use_memo(build_layer_buttons, [id(gee_interface)])
+    btn_pmtiles, btn_remove = solara.use_memo(build_layer_buttons, [id(gee_interface)])
 
     aoi_key = _aoi_key(aoi_data.value)
     previous_aoi_key = solara.use_ref(aoi_key)
@@ -574,7 +580,7 @@ def MapAppDemo():
             "title": "Layers",
             "icon": "mdi-layers",
             "content": [
-                btn_add,
+                TaskButtonComponent(label="add layer", **ndvi_btn_props, small=True, block=True),
                 btn_pmtiles,
                 btn_remove,
                 AdminButton(app_model, logger_instance=logger),

--- a/pysepal/templates/solara/solara_map_app/app.py
+++ b/pysepal/templates/solara/solara_map_app/app.py
@@ -24,6 +24,7 @@ from pathlib import Path
 import ee
 import solara
 from component.model import AppModel
+from ipyleaflet import PMTilesLayer
 
 import pysepal.sepalwidgets as sw
 from pysepal import mapping as sm
@@ -58,6 +59,7 @@ DUMMY_DATA_DIR = Path(__file__).resolve().parents[4] / "tests" / "data" / "aoi_m
 NDVI_LAYER_ID = "demo_ndvi"
 PIXEL_AREA_LAYER_ID = "demo_pixel_area"
 ELEVATION_CLASS_LAYER_ID = "demo_elevation_class"
+PMTILES_LAYER_ID = "demo_pmtiles"
 AOI_LAYER_IDS = (PIXEL_AREA_LAYER_ID, ELEVATION_CLASS_LAYER_ID)
 
 DEMO_CENTER = [4.75, -74.12]
@@ -71,6 +73,32 @@ ELEVATION_CLASSES = (
     (2, "Upland (500-1500 m)", "#41b6c4"),
     (3, "Highland (>= 1500 m)", "#253494"),
 )
+
+# Vector tiles read straight from a public archive: the browser range-requests the
+# PMTiles itself, so nothing is proxied through the kernel. ``source-layer`` must
+# match a layer id inside the archive ("buildings" here) or nothing is painted.
+PMTILES_URL = "https://r2-public.protomaps.com/protomaps-sample-datasets/nz-buildings-v3.pmtiles"
+PMTILES_CENTER = [-43.5565, 172.6062]
+PMTILES_STYLE = {
+    "version": 8,
+    "sources": {"nz_buildings": {"type": "vector", "url": f"pmtiles://{PMTILES_URL}"}},
+    "layers": [
+        {
+            "id": "buildings-fill",
+            "type": "fill",
+            "source": "nz_buildings",
+            "source-layer": "buildings",
+            "paint": {"fill-color": "#41b6c4", "fill-opacity": 0.6},
+        },
+        {
+            "id": "buildings-outline",
+            "type": "line",
+            "source": "nz_buildings",
+            "source-layer": "buildings",
+            "paint": {"line-color": "#253494", "line-width": 0.5},
+        },
+    ],
+}
 
 setup_solara_server(extra_asset_locations=[])
 
@@ -432,6 +460,7 @@ def MapAppDemo():
     def build_layer_buttons():
         """Build the ipyvuetify buttons once; they close over stable reactives."""
         btn_add = sw.TaskButton("add layer", small=True, block=True)
+        btn_pmtiles = sw.Btn("add pmtiles layer", small=True, block=True)
         btn_remove = sw.Btn("remove all layers", small=True, block=True)
 
         async def add_ndvi_layer():
@@ -452,6 +481,15 @@ def MapAppDemo():
                 )
             )
 
+        def add_pmtiles_layer():
+            """Add vector tiles, which the layer control drives without Earth Engine."""
+            sepal_map.add_layer(
+                PMTilesLayer(name="NZ buildings", url=PMTILES_URL, style=PMTILES_STYLE),
+                key=PMTILES_LAYER_ID,
+            )
+            sepal_map.center = PMTILES_CENTER
+            sepal_map.zoom = 14
+
         def remove_all_layers():
             sepal_map.remove_all()
             sepal_map.center = DEMO_CENTER
@@ -459,13 +497,14 @@ def MapAppDemo():
             layer_legends.set(())
             outputs.set(None)
 
+        btn_pmtiles.on_event("click", lambda *args: add_pmtiles_layer())
         btn_remove.on_event("click", lambda *args: remove_all_layers())
         btn_add.configure(
             task_factory=lambda: gee_interface.create_task(func=add_ndvi_layer, key=NDVI_LAYER_ID)
         )
-        return btn_add, btn_remove
+        return btn_add, btn_pmtiles, btn_remove
 
-    btn_add, btn_remove = solara.use_memo(build_layer_buttons, [id(gee_interface)])
+    btn_add, btn_pmtiles, btn_remove = solara.use_memo(build_layer_buttons, [id(gee_interface)])
 
     aoi_key = _aoi_key(aoi_data.value)
     previous_aoi_key = solara.use_ref(aoi_key)
@@ -534,8 +573,16 @@ def MapAppDemo():
         {
             "title": "Layers",
             "icon": "mdi-layers",
-            "content": [btn_add, btn_remove, AdminButton(app_model, logger_instance=logger)],
-            "description": "Add a standalone demo layer, or clear the map and its legends.",
+            "content": [
+                btn_add,
+                btn_pmtiles,
+                btn_remove,
+                AdminButton(app_model, logger_instance=logger),
+            ],
+            "description": (
+                "Add a standalone demo layer or a PMTiles vector layer, or clear the map "
+                "and its legends. Both show up in the layer control, top right."
+            ),
             "divider": True,
         },
         {

--- a/pysepal/templates/solara/solara_map_app/app.py
+++ b/pysepal/templates/solara/solara_map_app/app.py
@@ -30,6 +30,7 @@ import pysepal.sepalwidgets as sw
 from pysepal import mapping as sm
 from pysepal.sepalwidgets.vue_app import MapApp
 from pysepal.solara import (
+    get_current_drive_interface,
     get_current_gee_interface,
     get_current_theme_state,
     setup_sessions,
@@ -420,14 +421,25 @@ def ProcessPanel(aoi_data, outputs, layer_legends, sepal_map, gee_interface):
 
 
 @solara.component
-def ExportPanel(aoi_data, outputs):
-    """Export the selected AOI and any processed outputs."""
+def ExportPanel(aoi_data, outputs, gee_interface, drive_interface):
+    """Export the selected AOI and any processed outputs.
+
+    The interfaces are threaded in rather than looked up here. Both
+    ``get_current_gee_interface`` and ``get_current_drive_interface`` raise once
+    the SessionManager is live but the current render has no session, and this
+    panel is rendered as a child of MapApp's right panel -- a separate render
+    root from the ``@with_sepal_sessions`` page that establishes the session.
+    Resolving them once at the top of :func:`MapAppDemo` keeps the lookup where
+    the session is known to exist.
+    """
     ExportLauncher(
         sources=_export_sources(aoi_data.value, outputs.value),
         dialog_title="Export datasets",
         default_target="gee",
         button_text=True,
         block=True,
+        gee_interface=gee_interface,
+        drive_interface=drive_interface,
     )
 
 
@@ -437,6 +449,7 @@ def MapAppDemo():
     setup_theme_colors()
 
     gee_interface = get_current_gee_interface()
+    drive_interface = get_current_drive_interface()
     theme_state = get_current_theme_state()
 
     aoi_data = solara.use_reactive(None)
@@ -594,7 +607,14 @@ def MapAppDemo():
         {
             "title": "Export",
             "icon": "mdi-export-variant",
-            "content": [ExportPanel(aoi_data=aoi_data, outputs=outputs)],
+            "content": [
+                ExportPanel(
+                    aoi_data=aoi_data,
+                    outputs=outputs,
+                    gee_interface=gee_interface,
+                    drive_interface=drive_interface,
+                )
+            ],
             "description": "Send the AOI or a processed output to Earth Engine, Drive or SEPAL.",
         },
     ]

--- a/tests/test_frontend/test_layering_contract.py
+++ b/tests/test_frontend/test_layering_contract.py
@@ -1,0 +1,95 @@
+"""Guards for the modal layering contract.
+
+pysepal's floating chrome (map, app bar, legend, task pill) must stay BELOW
+Vuetify's modal baseline. Vuetify derives a dialog's z-index at runtime -- the
+``stackable`` mixin reads computed z-indexes off the DOM -- so any app layer
+that outranks it has to be beaten with ``!important``, which desynchronises that
+bookkeeping and silently breaks click-outside-to-close.
+
+The historical failure mode: the fullscreen map sat at 800, above Vuetify's
+~201 scrim, so an outside click landed on the map and ``click:outside`` never
+fired. Every workaround that pinned ``.v-overlay`` or ``.v-dialog__content``
+from CSS traded that bug for a worse one (the dialog rendering behind its own
+scrim). The fix was to renumber the app's own layers underneath instead.
+"""
+
+import re
+from pathlib import Path
+
+import pysepal.frontend.styles as ss
+import pysepal.sepalwidgets as sw
+import pysepal.solara as solara_pkg
+
+BASE_CSS = ss.CSS_DIR / "base.css"
+MAP_APP_VUE = Path(sw.__file__).parent / "vue" / "MapApp.vue"
+LEGEND_VUE = Path(solara_pkg.__file__).parent / "components" / "Legend.vue"
+NOTIFICATION_VUE = Path(solara_pkg.__file__).parent / "notifications" / "NotificationUI.vue"
+
+VUETIFY_OVERLAY_Z_INDEX = 201
+
+# Selector -> the file whose rule sets its z-index. Each must stay under the
+# scrim so a modal covers it instead of it punching through.
+APP_LAYERS = {
+    ".full-screen-map > .leaflet-container": BASE_CSS,
+    "header.v-app-bar": BASE_CSS,
+    ".sepal-legend": LEGEND_VUE,
+    ".pill-wrapper": NOTIFICATION_VUE,
+}
+
+# Rules that pin Vuetify's own modal elements. `.v-overlay__scrim` is exempt:
+# it is a child of `.v-overlay`, which is its own stacking context, so a
+# z-index there cannot lift it out and is merely inert.
+FORBIDDEN_PINS = (".v-overlay", ".v-dialog__content", ".dialog-container")
+
+
+def _z_index_for(selector: str, path: Path) -> int:
+    """Return the z-index declared in the rule block for ``selector``.
+
+    Anchored to the start of a line so a `.vue` template's ``class="…"`` never
+    shadows the stylesheet rule of the same name.
+    """
+    text = path.read_text()
+    rule = re.search(
+        rf"^{re.escape(selector)}\s*\{{([^}}]*)\}}",
+        text,
+        re.MULTILINE,
+    )
+    assert rule, f"no CSS rule for {selector} in {path.name}"
+    match = re.search(r"z-index:\s*(\d+)", rule.group(1))
+    assert match, f"{selector} in {path.name} declares no z-index"
+    return int(match.group(1))
+
+
+def test_app_layers_stay_below_the_vuetify_modal_baseline():
+    """Floating chrome must sit under the scrim, so modals cover it natively."""
+    for selector, path in APP_LAYERS.items():
+        z = _z_index_for(selector, path)
+        assert z < VUETIFY_OVERLAY_Z_INDEX, (
+            f"{selector} ({path.name}) is at z-index {z}, above Vuetify's "
+            f"{VUETIFY_OVERLAY_Z_INDEX} scrim. Renumber it below instead of "
+            f"pinning Vuetify's layers -- see the contract in base.css."
+        )
+
+
+def _rules(text: str):
+    """Yield ``(selector, body)`` for each CSS rule, ignoring comments.
+
+    Comments are stripped first: a prose mention of ``.v-overlay`` would
+    otherwise be read as a selector and swallow the next rule's body.
+    """
+    text = re.sub(r"/\*.*?\*/", "", text, flags=re.DOTALL)
+    for match in re.finditer(r"([^{}]+)\{([^{}]*)\}", text):
+        yield match.group(1).strip(), match.group(2)
+
+
+def test_no_stylesheet_pins_the_vuetify_modal_z_index():
+    """Pinning the scrim or the dialog breaks click-outside-to-close."""
+    for path in (BASE_CSS, MAP_APP_VUE, LEGEND_VUE, NOTIFICATION_VUE):
+        for selector, body in _rules(path.read_text()):
+            if not any(pin in selector for pin in FORBIDDEN_PINS):
+                continue
+            assert "z-index" not in body, (
+                f"{path.name} pins a z-index on '{selector}'. Vuetify computes "
+                f"dialog stacking at runtime; overriding it desynchronises the "
+                f"stackable mixin and click-outside stops firing."
+            )

--- a/tests/test_mapping/test_LayersControl.py
+++ b/tests/test_mapping/test_LayersControl.py
@@ -2,6 +2,7 @@
 
 import ee
 import pytest
+from ipyleaflet import Map, Marker, PMTilesLayer
 
 from pysepal import aoi
 from pysepal import mapping as sm
@@ -197,5 +198,90 @@ def test_vectors() -> None:
     # set the visibility from the layer
     aoi_layer.visible = True
     assert vector_row.w_checkbox.v_model is True
+
+    return
+
+
+def _pmtiles(name: str) -> PMTilesLayer:
+    """Return a PMTiles layer, which owns no visible trait."""
+    return PMTilesLayer(name=name, url=f"https://example.com/{name}.pmtiles")
+
+
+def test_toggle_row_keeps_its_position() -> None:
+    """Check that hiding a layer does not move its row under the user's cursor."""
+    m = Map()
+    layer_control = sm.LayersControl(m)
+    m.add(_pmtiles("first"))
+    m.add(_pmtiles("second"))
+
+    def row_names() -> list:
+        return [r.layer.name for r in layer_control.tile.get_children(klass=sm.ToggleRow)]
+
+    def row(name: str):
+        return next(
+            r for r in layer_control.tile.get_children(klass=sm.ToggleRow) if r.layer.name == name
+        )
+
+    assert row_names() == ["second", "first"]
+
+    # hiding must leave the row exactly where it was
+    row("second").w_checkbox.v_model = False
+    assert row_names() == ["second", "first"]
+
+    # and a layer added meanwhile must not displace it either
+    m.add(_pmtiles("third"))
+    assert row_names() == ["second", "third", "first"]
+
+    row("second").w_checkbox.v_model = True
+    assert row_names() == ["second", "third", "first"]
+
+    return
+
+
+def test_toggle_row() -> None:
+    """Check that a layer exposing no visible trait still gets a row."""
+    m = Map()
+    layer_control = sm.LayersControl(m)
+    m.add(PMTilesLayer(name="pmtiles", url="https://example.com/tiles.pmtiles"))
+
+    rows = layer_control.tile.get_children(klass=sm.ToggleRow)
+
+    assert len(rows) == 1
+    assert rows[0].w_checkbox.v_model is True
+
+    return
+
+
+def test_toggle_row_skips_linkable_layers() -> None:
+    """Check that a layer owning a visible trait is left out of the toggle rows."""
+    m = Map()
+    layer_control = sm.LayersControl(m)
+
+    # a Marker is neither a GeoJSON nor a TileLayer but it can still be linked,
+    # and SepalMap ships one by default so it must not show up as a blank row
+    m.add(Marker(location=(0, 0)))
+
+    assert len(layer_control.tile.get_children(klass=sm.ToggleRow)) == 0
+
+    return
+
+
+def test_toggle_layer() -> None:
+    """Check that such a layer is hidden by removing it from the map."""
+    m = Map()
+    layer_control = sm.LayersControl(m)
+    layer = PMTilesLayer(name="pmtiles", url="https://example.com/tiles.pmtiles")
+    m.add(layer)
+
+    # hiding drops it from the map but the row must survive to switch it back on
+    layer_control.tile.get_children(klass=sm.ToggleRow)[0].w_checkbox.v_model = False
+    rows = layer_control.tile.get_children(klass=sm.ToggleRow)
+    assert layer not in m.layers
+    assert len(rows) == 1
+    assert rows[0].w_checkbox.v_model is False
+
+    rows[0].w_checkbox.v_model = True
+    assert layer in m.layers
+    assert len(layer_control.tile.get_children(klass=sm.ToggleRow)) == 1
 
     return

--- a/tests/test_solara/test_notifications/test_notification_ui_template.py
+++ b/tests/test_solara/test_notifications/test_notification_ui_template.py
@@ -30,19 +30,32 @@ def _numeric_property(rule_body: str, name: str) -> int:
 
 
 _DIALOG_Z_INDEX = 202  # Vuetify 2 v-dialog__content default
+_OVERLAY_Z_INDEX = 201  # Vuetify 2 v-overlay default
 
 
-def test_notification_layers_sit_above_dialogs():
-    """Keep pill and toast layers above Vuetify dialog/overlay defaults.
+def test_toasts_sit_above_dialogs():
+    """Keep the toast stack above Vuetify dialog/overlay defaults.
 
-    Notifications are often *about* the dialog (errors, progress) so they must
-    remain visible even when a modal is open — otherwise users miss critical
-    feedback and assume the app is unresponsive.
+    Toasts are often *about* the dialog (errors, progress) so they must remain
+    visible even when a modal is open — otherwise users miss critical feedback
+    and assume the app is unresponsive.
     """
     toast_z = _numeric_property(_rule_body(".toast-stack"), "z-index")
-    pill_z = _numeric_property(_rule_body(".pill-wrapper"), "z-index")
     assert toast_z > _DIALOG_Z_INDEX, f"toast z-index {toast_z} not above dialog"
-    assert pill_z > _DIALOG_Z_INDEX, f"pill z-index {pill_z} not above dialog"
+
+
+def test_pill_sits_below_the_modal_baseline():
+    """Keep the pill/logger under Vuetify's scrim, unlike the toast stack.
+
+    It used to share the toast tier, which floated the logger panel over open
+    modals. It now sits below the scrim so a modal dims it instead — and because
+    every app layer above Vuetify's baseline has to be pinned with `!important`,
+    which desynchronises the `stackable` mixin's runtime z-index bookkeeping and
+    breaks click-outside-to-close. See the layering contract in
+    ``pysepal/frontend/css/base.css``.
+    """
+    pill_z = _numeric_property(_rule_body(".pill-wrapper"), "z-index")
+    assert pill_z < _OVERLAY_Z_INDEX, f"pill z-index {pill_z} not below the scrim"
 
 
 def test_notification_pill_keeps_mapapp_right_offset_hook():

--- a/tests/test_solara/test_session_manager.py
+++ b/tests/test_solara/test_session_manager.py
@@ -13,3 +13,56 @@ def test_session_manager_kernel_id_uses_shared_runtime_resolver():
         return_value="voila:kernel-1",
     ):
         assert manager.get_kernel_id() == "voila:kernel-1"
+
+
+def test_getters_fall_back_when_no_session_can_exist():
+    """Voila and plain Jupyter have no SEPAL headers, so no session can exist.
+
+    ``setup_sessions`` initialises the SessionManager on every kernel start,
+    including under Voila, but ``create_session`` bails out when
+    ``headers.value`` is None. Treating "initialised but sessionless" as a
+    missing ``@with_sepal_sessions`` therefore broke every non-Solara runtime:
+    the headerless fallbacks were unreachable.
+    """
+    from pysepal.solara import theme, utils
+
+    # Two patch targets on purpose: utils binds the predicate at import time,
+    # while theme must import it lazily (session_manager imports ThemeState from
+    # theme, so a module-level import there would be circular).
+    with (
+        patch.object(SessionManager, "is_initialized", return_value=True),
+        patch.object(SessionManager, "get_session_component", return_value=None),
+        patch.object(utils, "can_create_sessions", return_value=False),
+        patch("pysepal.solara.session_manager.can_create_sessions", return_value=False),
+        patch.object(utils, "_get_fallback_gee_interface", return_value="fallback-gee"),
+        patch.object(utils, "_get_fallback_drive_interface", return_value="fallback-drive"),
+        patch.object(theme, "_get_fallback_theme_state", return_value="fallback-theme"),
+    ):
+        assert utils.get_current_gee_interface() == "fallback-gee"
+        assert utils.get_current_drive_interface() == "fallback-drive"
+        assert theme.get_current_theme_state() == "fallback-theme"
+
+
+def test_getters_still_raise_when_headers_exist_but_session_is_missing():
+    """With headers present we ARE in a solara request, so a missing session is a bug.
+
+    That is the case the error message is for -- a Page without
+    ``@with_sepal_sessions`` -- and it must keep raising.
+    """
+    import pytest
+
+    from pysepal.solara import theme, utils
+
+    with (
+        patch.object(SessionManager, "is_initialized", return_value=True),
+        patch.object(SessionManager, "get_session_component", return_value=None),
+        patch.object(utils, "can_create_sessions", return_value=True),
+        patch("pysepal.solara.session_manager.can_create_sessions", return_value=True),
+    ):
+        for getter in (
+            utils.get_current_gee_interface,
+            utils.get_current_drive_interface,
+            theme.get_current_theme_state,
+        ):
+            with pytest.raises(RuntimeError, match="Session manager is active"):
+                getter()

--- a/tests/test_solara/test_voila_template_entrypoint.py
+++ b/tests/test_solara/test_voila_template_entrypoint.py
@@ -49,6 +49,28 @@ def test_app_exposes_shared_component_and_authenticated_page_wrapper():
     )
 
 
+def test_app_never_schedules_gee_work_on_a_second_event_loop():
+    """Every async button must go through solara's loop, not GEEInterface's own.
+
+    ``GEEInterface.create_task`` hands the coroutine to a private event loop running
+    in its own thread, while ``solara.lab.use_task`` runs it on solara's. Mixing both
+    in one app makes two loops share the single ``httpx.AsyncClient(http2=True)``
+    cached on the eeclient session, and its asyncio primitives bind to whichever loop
+    touched them first -- so a concurrent call from the other one dies mid-request.
+    """
+    module = ast.parse(APP_PATH.read_text())
+
+    create_task_calls = [
+        node
+        for node in ast.walk(module)
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Attribute)
+        and node.func.attr == "create_task"
+    ]
+
+    assert create_task_calls == []
+
+
 def test_voila_notebook_only_imports_and_displays_shared_component():
     """The notebook remains a thin runtime entrypoint with no duplicated UI."""
     notebook = json.loads(NOTEBOOK_PATH.read_text())


### PR DESCRIPTION
Four things, one commit each. They arrived together because each surfaced the next.

**PMTiles in `LayersControl`.** `PMTilesLayer` extends `Layer`, not `RasterLayer`, so the `isinstance` checks dropped it entirely and it has no `visible` trait to link a checkbox to. Rows are now picked by capability instead, and layers without a `visible` trait toggle via map add/remove — with the hidden ones tracked so a row can't delete itself. No PMTiles import, so no ipyleaflet version floor.

**GEE event-loop crash in the map_app template.** `sw.TaskButton` scheduled onto `GEEInterface`'s private loop while the process panel used `use_task` on solara's — two loops sharing the one `httpx.AsyncClient(http2=True)` cached on the eeclient session. Migrated to `TaskButtonComponent`, which pysepal's docs already prescribed. `prefer_threaded=False` was already set and doesn't cover this case.

**Modal layering.** The fullscreen map sat at `z-index: 800`, above vuetify's `~201` scrim, so an outside click landed on the map and no dialog could be dismissed by clicking away. Pinning vuetify's own z-index to compensate is worse — the `stackable` mixin computes stacking at runtime, so an `!important` override desyncs it. Renumbered our layers underneath instead (map 100 → pill 170), so vuetify stacks natively and its scrim dims the legend and logger for free. Also drops MapApp's scrim size override, which made every resize animate (~296ms → ~2ms).

**Voila sessions.** Three getters read "SessionManager initialised but sessionless" as a missing `@with_sepal_sessions` and raised. Under Voila no session can ever exist, so their headerless fallbacks were unreachable and the template couldn't start. They now raise only when a session was genuinely possible.

**Note on the notification layer.** The Logger now sits behind modals, as intended. The task-progress pill is a `v-if`/`v-else` sibling inside the same fixed `.pill-wrapper`, so the two cannot be stacked separately and the pill goes behind too. An existing test asserted the opposite for both; it is now split — toasts still above dialogs, pill below.

**Tested:** 419 in the fast lane plus `test_gee`. The CSS is measured in a headless browser — stacking, click-to-dismiss and resize timing — rather than eyeballed. New guards cover the layering contract, PMTiles rows, and keeping `create_task` out of the template. The event-loop fix hasn't been re-clicked in a live app (needs a GEE session).
