### PR TITLE
fix(templates): schedule the map_app layer button on solara's loop

### DIFF
--- a/pysepal/templates/solara/solara_map_app/app.py
+++ b/pysepal/templates/solara/solara_map_app/app.py
@@ -50,6 +50,7 @@ from pysepal.solara.components.legend import (
     LegendComponent,
     LegendData,
 )
+from pysepal.solara.components.task_button import TaskButtonComponent, use_task_button
 from pysepal.solara.notifications import NotificationProvider, use_notifications
 
 logger = logging.getLogger("SEPALUI.map_app")
@@ -457,29 +458,37 @@ def MapAppDemo():
     sepal_map = solara.use_memo(build_map, [id(gee_interface)])
     app_model = solara.use_memo(AppModel, [])
 
+    async def add_ndvi_layer():
+        """Add the demo layer.
+
+        Scheduled through ``use_task`` rather than ``gee_interface.create_task``: the
+        latter runs on GEEInterface's own event loop, and two loops sharing the
+        eeclient http/2 client crash it mid-request.
+        """
+        await sepal_map.add_ee_layer_async(
+            _ndvi_composite(),
+            vis_params=NDVI_VIS,
+            name="Sentinel-2 NDVI",
+            key=NDVI_LAYER_ID,
+        )
+        sepal_map.center = DEMO_CENTER
+        sepal_map.zoom = 12
+        layer_legends.set(
+            _upsert_legends(
+                layer_legends.value,
+                LayerLegend(NDVI_LAYER_ID, "Sentinel-2 NDVI", _gradient_legend("NDVI", NDVI_VIS)),
+            )
+        )
+
+    ndvi_task = solara.lab.use_task(
+        add_ndvi_layer, dependencies=None, raise_error=False, prefer_threaded=False
+    )
+    ndvi_btn_props = use_task_button(ndvi_task, on_start=ndvi_task)
+
     def build_layer_buttons():
-        """Build the ipyvuetify buttons once; they close over stable reactives."""
-        btn_add = sw.TaskButton("add layer", small=True, block=True)
+        """Build the sync ipyvuetify buttons once; they close over stable reactives."""
         btn_pmtiles = sw.Btn("add pmtiles layer", small=True, block=True)
         btn_remove = sw.Btn("remove all layers", small=True, block=True)
-
-        async def add_ndvi_layer():
-            await sepal_map.add_ee_layer_async(
-                _ndvi_composite(),
-                vis_params=NDVI_VIS,
-                name="Sentinel-2 NDVI",
-                key=NDVI_LAYER_ID,
-            )
-            sepal_map.center = DEMO_CENTER
-            sepal_map.zoom = 12
-            layer_legends.set(
-                _upsert_legends(
-                    layer_legends.value,
-                    LayerLegend(
-                        NDVI_LAYER_ID, "Sentinel-2 NDVI", _gradient_legend("NDVI", NDVI_VIS)
-                    ),
-                )
-            )
 
         def add_pmtiles_layer():
             """Add vector tiles, which the layer control drives without Earth Engine."""
@@ -499,12 +508,9 @@ def MapAppDemo():
 
         btn_pmtiles.on_event("click", lambda *args: add_pmtiles_layer())
         btn_remove.on_event("click", lambda *args: remove_all_layers())
-        btn_add.configure(
-            task_factory=lambda: gee_interface.create_task(func=add_ndvi_layer, key=NDVI_LAYER_ID)
-        )
-        return btn_add, btn_pmtiles, btn_remove
+        return btn_pmtiles, btn_remove
 
-    btn_add, btn_pmtiles, btn_remove = solara.use_memo(build_layer_buttons, [id(gee_interface)])
+    btn_pmtiles, btn_remove = solara.use_memo(build_layer_buttons, [id(gee_interface)])
 
     aoi_key = _aoi_key(aoi_data.value)
     previous_aoi_key = solara.use_ref(aoi_key)
@@ -574,7 +580,7 @@ def MapAppDemo():
             "title": "Layers",
             "icon": "mdi-layers",
             "content": [
-                btn_add,
+                TaskButtonComponent(label="add layer", **ndvi_btn_props, small=True, block=True),
                 btn_pmtiles,
                 btn_remove,
                 AdminButton(app_model, logger_instance=logger),

--- a/tests/test_solara/test_voila_template_entrypoint.py
+++ b/tests/test_solara/test_voila_template_entrypoint.py
@@ -49,6 +49,28 @@ def test_app_exposes_shared_component_and_authenticated_page_wrapper():
     )
 
 
+def test_app_never_schedules_gee_work_on_a_second_event_loop():
+    """Every async button must go through solara's loop, not GEEInterface's own.
+
+    ``GEEInterface.create_task`` hands the coroutine to a private event loop running
+    in its own thread, while ``solara.lab.use_task`` runs it on solara's. Mixing both
+    in one app makes two loops share the single ``httpx.AsyncClient(http2=True)``
+    cached on the eeclient session, and its asyncio primitives bind to whichever loop
+    touched them first -- so a concurrent call from the other one dies mid-request.
+    """
+    module = ast.parse(APP_PATH.read_text())
+
+    create_task_calls = [
+        node
+        for node in ast.walk(module)
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Attribute)
+        and node.func.attr == "create_task"
+    ]
+
+    assert create_task_calls == []
+
+
 def test_voila_notebook_only_imports_and_displays_shared_component():
     """The notebook remains a thin runtime entrypoint with no duplicated UI."""
     notebook = json.loads(NOTEBOOK_PATH.read_text())


### PR DESCRIPTION
Clicking "add layer" and "Run Processing" close together in `solara_map_app` crashes with `RuntimeError: Non-thread-safe operation invoked on an event loop other than the current one`, thrown from inside httpcore's HTTP/2 read lock.

Two event loops were sharing one HTTP client:

| | scheduler | loop |
|---|---|---|
| `btn_add` | `sw.TaskButton.configure(task_factory=…)` → `GEETask` → `run_coroutine_threadsafe` | **GEEInterface's private loop**, in its own thread |
| process panel | `solara.lab.use_task(…, prefer_threaded=False)` | **solara's loop** |

Both reach `gee_interface.get_info_async`, which awaits directly and so runs on whichever loop called it. `eeclient` caches a single `httpx.AsyncClient(http2=True)` per session, and its asyncio primitives bind to the loop that first touches them — a concurrent call from the other loop then dies. Reproduced standalone: one such client driven from two loops raises a loop-binding `RuntimeError` within a handful of requests.

`prefer_threaded=False` was already set and is correct; it isn't sufficient, because the second loop here is `GEEInterface`'s deliberate one rather than a throwaway per-task loop.

The fix is what pysepal already prescribes — `TaskButtonComponent` + `use_task`, so every async path stays on solara's loop. `GEETask`'s `key` is only a log label (`self.key = key or function.__name__`), so nothing is lost by dropping it.

Regression covered by an AST check in the existing template test: no `create_task` call may appear in the template.

Not a new bug — `create_task` has been in the template since March, and `use_task` arrived alongside it in #1015 yesterday, which is what made the two loops live at once.

Worth noting separately: `GEEInterface` exposing two entry points that land on different loops while sharing a non-thread-safe client is a trap for any downstream app. Filing that on its own.

Stacked on #1018 (both touch `build_layer_buttons`); base retargets to `main` once that merges.
