### PR TITLE
fix: keep scratch files off NFS on SEPAL

### DIFF
--- a/pysepal/scripts/scratch.py
+++ b/pysepal/scripts/scratch.py
@@ -1,0 +1,37 @@
+"""Temporary directories that land on local disk.
+
+On a SEPAL sandbox ``$TMPDIR`` is unset and ``/tmp`` is nfs4 under the user's home
+export, so ``tempfile.mkdtemp()`` writes to a network filesystem and against the
+storage quota. ``/var/tmp`` is container-local and wiped with the session.
+"""
+
+import os
+import tempfile
+from pathlib import Path
+
+SEPAL_SCRATCH_DIR = Path("/var/tmp")
+
+
+def on_sepal() -> bool:
+    """Whether this process runs inside a SEPAL sandbox, which exports ``SEPAL=true``."""
+    return os.environ.get("SEPAL", "").strip().lower() == "true"
+
+
+def scratch_root() -> Path:
+    """Local disk on SEPAL, the stdlib temp dir anywhere else.
+
+    Falls back to the stdlib default when the SEPAL path is unusable, so a slow
+    write never becomes a failed one.
+    """
+    if on_sepal() and os.access(SEPAL_SCRATCH_DIR, os.W_OK):
+        return SEPAL_SCRATCH_DIR
+
+    return Path(tempfile.gettempdir())
+
+
+def scratch_dir(prefix: str = "sepal_ui_") -> Path:
+    """Create a new temporary directory under :func:`scratch_root`; the caller owns cleanup."""
+    root = scratch_root()
+    root.mkdir(parents=True, exist_ok=True)
+
+    return Path(tempfile.mkdtemp(prefix=prefix, dir=root))

--- a/pysepal/solara/asset_merger.py
+++ b/pysepal/solara/asset_merger.py
@@ -6,9 +6,10 @@ to work around Solara's limitation of serving assets from a single location.
 
 import logging
 import shutil
-import tempfile
 from pathlib import Path
 from typing import List, Sequence
+
+from pysepal.scripts.scratch import scratch_dir
 
 logger = logging.getLogger("sepalui.solara.asset_merger")
 
@@ -122,7 +123,7 @@ def create_merged_assets_directory(
         Path to the directory containing the merged assets (ready for Solara)
     """
     # Create temporary directory for merged assets
-    temp_dir = Path(tempfile.mkdtemp(prefix="sepal_ui_assets_"))
+    temp_dir = scratch_dir(prefix="sepal_ui_assets_")
     logger.debug(f"Created temporary assets directory: {temp_dir}")
 
     # Merge all assets

--- a/tests/test_scratch.py
+++ b/tests/test_scratch.py
@@ -1,0 +1,73 @@
+"""Scratch directories must land on local disk on SEPAL, where /tmp is NFS."""
+
+import tempfile
+from pathlib import Path
+
+from pysepal.scripts import scratch
+
+
+class TestOnSepal:
+    def test_true_only_for_the_platform_value(self, monkeypatch):
+        monkeypatch.setenv("SEPAL", "true")
+        assert scratch.on_sepal() is True
+
+    def test_tolerates_case_and_whitespace(self, monkeypatch):
+        monkeypatch.setenv("SEPAL", " True\n")
+        assert scratch.on_sepal() is True
+
+    def test_false_when_unset(self, monkeypatch):
+        monkeypatch.delenv("SEPAL", raising=False)
+        assert scratch.on_sepal() is False
+
+    def test_false_for_other_values(self, monkeypatch):
+        monkeypatch.setenv("SEPAL", "false")
+        assert scratch.on_sepal() is False
+
+
+class TestScratchRoot:
+    def test_stdlib_default_off_sepal(self, monkeypatch):
+        monkeypatch.delenv("SEPAL", raising=False)
+
+        assert scratch.scratch_root() == Path(tempfile.gettempdir())
+
+    def test_local_disk_on_sepal(self, monkeypatch):
+        monkeypatch.setenv("SEPAL", "true")
+        monkeypatch.setattr(scratch.os, "access", lambda *_: True)
+
+        assert scratch.scratch_root() == scratch.SEPAL_SCRATCH_DIR
+
+    def test_falls_back_when_the_sepal_path_is_not_writable(self, monkeypatch):
+        monkeypatch.setenv("SEPAL", "true")
+        monkeypatch.setattr(scratch.os, "access", lambda *_: False)
+
+        assert scratch.scratch_root() == Path(tempfile.gettempdir())
+
+    def test_tmpdir_does_not_override_the_local_disk(self, monkeypatch, tmp_path):
+        """TMPDIR says where to put temp files, not that the location is fast."""
+        monkeypatch.setenv("SEPAL", "true")
+        monkeypatch.setenv("TMPDIR", str(tmp_path))
+        monkeypatch.setattr(scratch.os, "access", lambda *_: True)
+
+        assert scratch.scratch_root() == scratch.SEPAL_SCRATCH_DIR
+
+
+class TestScratchDir:
+    def test_creates_a_new_directory_under_the_root(self, monkeypatch, tmp_path):
+        monkeypatch.setattr(scratch, "scratch_root", lambda: tmp_path)
+
+        created = scratch.scratch_dir(prefix="probe_")
+
+        assert created.is_dir()
+        assert created.parent == tmp_path
+        assert created.name.startswith("probe_")
+
+    def test_each_call_is_a_distinct_directory(self, monkeypatch, tmp_path):
+        monkeypatch.setattr(scratch, "scratch_root", lambda: tmp_path)
+
+        assert scratch.scratch_dir() != scratch.scratch_dir()
+
+    def test_creates_a_missing_root(self, monkeypatch, tmp_path):
+        root = tmp_path / "not" / "there" / "yet"
+        monkeypatch.setattr(scratch, "scratch_root", lambda: root)
+
+        assert scratch.scratch_dir().parent == root


### PR DESCRIPTION
On a SEPAL sandbox `$TMPDIR` is unset and `/tmp` is an nfs4 mount of the user's home export, so `tempfile.mkdtemp()` puts temporary data on a network filesystem — slow for many small writes, and counted against the storage quota. `/var/tmp` is container-local and wiped with the session, which is the lifetime temporary data wants anyway.

Adds `pysepal/scripts/scratch.py` (`on_sepal`, `scratch_root`, `scratch_dir`) and uses it in `asset_merger`, the only bare `mkdtemp` in the package. Nothing changes off SEPAL: `on_sepal()` is false, so it returns the standard temp directory as before. If `/var/tmp` is ever not writable it falls back to the standard directory rather than raising — a slow write beats a failed one.

One deliberate choice worth a look: `$TMPDIR` does **not** override the local disk on SEPAL. Setting `TMPDIR` says where you want temporary files, not that the location is fast, so honouring it would quietly put us back on NFS for anyone with `TMPDIR=$HOME/tmp` in their shell profile. There is a test pinning that behaviour so it does not get "fixed" later.

This came out of profiling PMTiles generation on a sandbox, where temporary files on NFS dominated runtime; the tiling-side half is a separate fix in vectortileserver. 190 tests pass, 10 new.