### PR TITLE
Render categorical rasters via add_raster(class_colors=...)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ dependencies = [
     "jupyter-server-proxy", # required for localtileserver
     "planet>=2.0,<3.0",
     "pyarrow",
-    "localtileserver>=0.10.1", # first version with rio-tiler v7 support
+    "localtileserver>=1.0.0", # first version with the colormap registry add_raster needs
     "pygaul>=0.4.2", # GAUL 2024 with iso3_code and gaul0_code columns
     "pygadm>=0.5.0", # use the class implementation
     # miscellaneous

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ dependencies = [
     "colorama",
     "pipreqs",
     # read local data
+    "rasterio", # read raster metadata and prepare COGs for the tile server
     "rioxarray",
     "dask",  # used by rioxarray in the inspector
     "geopandas>=0.14.0",

--- a/pysepal/mapping/__init__.py
+++ b/pysepal/mapping/__init__.py
@@ -28,5 +28,6 @@ from .map_btn import *
 from .marker_cluster import *
 from .menu_control import *
 from .sepal_map import *
+from .tiling import *
 from .visualization import *
 from .zoom_control import *

--- a/pysepal/mapping/raster_style.py
+++ b/pysepal/mapping/raster_style.py
@@ -1,0 +1,163 @@
+"""Decide how a local raster is coloured when it is served as tiles.
+
+Two ways to paint a raster, both returning the keyword arguments that
+``localtileserver.get_leaflet_tile_layer`` expects, so
+:meth:`~pysepal.mapping.SepalMap.add_raster` can pick one and stay a single code
+path:
+
+- categorical, from an explicit ``{class code: '#rrggbb'}`` mapping
+- continuous, stretching a matplotlib colormap across the value range
+
+Everything here is internal to ``add_raster``.
+"""
+
+import logging
+from pathlib import Path
+from typing import Optional, Tuple
+
+__all__ = []
+
+log = logging.getLogger("sepalui.mapping.raster_style")
+
+# rio-tiler renders through a 256-entry lookup table, so a class code has to be a
+# byte to survive to the tile. Codes outside that range are renumbered instead.
+MAX_CLASS_CODE = 255
+
+
+def _hex_to_rgb(hex_color: str) -> Tuple[int, int, int]:
+    """Convert ``'#rgb'`` or ``'#rrggbb'`` to an ``(r, g, b)`` tuple."""
+    h = hex_color.lstrip("#")
+    if len(h) == 3:
+        h = "".join(c * 2 for c in h)
+    if len(h) != 6:
+        raise ValueError(f"{hex_color!r} is not a '#rgb' or '#rrggbb' color")
+    return tuple(int(h[i : i + 2], 16) for i in (0, 2, 4))  # type: ignore[return-value]
+
+
+def _build_class_colormap(class_colors: dict) -> dict:
+    """Build a discrete ``{pixel value: (r, g, b, a)}`` LUT for a categorical raster.
+
+    Only the declared classes are in the LUT, including code 0 -- an area
+    calculation treats it as a valid, sampleable class, so it has to be visible.
+    Anything absent renders transparent, which rio-tiler already does for an
+    unmatched value; padding the LUT out to 256 entries instead would push
+    rio-tiler onto its ``make_lut`` path, where a value above 255 wraps into a
+    real class and gets painted with that class's color.
+    """
+    return {int(code): (*_hex_to_rgb(color), 255) for code, color in class_colors.items()}
+
+
+def _needs_dense_codes(class_colors: dict) -> bool:
+    """Whether the class codes have to be renumbered before they can be served."""
+    codes = [int(code) for code in class_colors]
+    return any(code < 0 or code > MAX_CLASS_CODE for code in codes)
+
+
+def _densify_class_codes(image: Path, class_colors: dict, cache_dir: Path) -> Tuple[Path, dict]:
+    """Rewrite a raster as ``uint8`` with its class codes renumbered from 1.
+
+    A tile is colored through a 256-entry table, so a code outside ``0..255``
+    cannot reach the renderer as itself. Renumbering to a dense range is the only
+    way to draw such a class; 0 is reserved for the transparent background.
+
+    Args:
+        image: the source raster.
+        class_colors: the caller's ``{class code: '#rrggbb'}`` mapping.
+        cache_dir: where the renumbered copy is kept.
+
+    Returns:
+        the path to serve, and the ``class_colors`` restated in the new codes.
+    """
+    import numpy as np
+    import rasterio as rio
+
+    from pysepal.mapping.tiling import _hash_for_cache, _write_atomically
+
+    codes = sorted(int(code) for code in class_colors)
+    if len(codes) > MAX_CLASS_CODE:
+        raise ValueError(
+            f"{len(codes)} classes exceed the {MAX_CLASS_CODE} a tile palette can hold"
+        )
+
+    dense = {code: position + 1 for position, code in enumerate(codes)}
+    renumbered = {dense[code]: class_colors[code] for code in codes}
+    for color in renumbered.values():
+        _hex_to_rgb(color)  # fail before rewriting a raster for an unusable palette
+
+    dst = cache_dir / f"{image.name}.{_hash_for_cache(str(image))}.classes.tif"
+    if dst.exists():
+        return dst, renumbered
+
+    with rio.open(image) as ds:
+        profile = ds.profile | {
+            "driver": "GTiff",
+            "dtype": "uint8",
+            "count": 1,
+            "nodata": 0,
+            "tiled": True,
+            "blockxsize": 512,
+            "blockysize": 512,
+            "compress": "deflate",
+        }
+        with _write_atomically(dst) as tmp:
+            with rio.open(tmp, "w", **profile) as out:
+                for _, window in ds.block_windows(1):
+                    source = ds.read(1, window=window)
+                    target = np.zeros(source.shape, dtype="uint8")
+                    for code, position in dense.items():
+                        target[source == code] = position
+                    out.write(target, 1, window=window)
+
+    log.info("Renumbered %s to dense uint8 class codes so every class can be drawn.", image)
+    return dst, renumbered
+
+
+def _class_color_kwargs(class_colors: dict) -> Optional[dict]:
+    """Return the ``get_leaflet_tile_layer`` kwargs for a categorical raster.
+
+    The LUT is registered server-side rather than passed as a matplotlib
+    ``Colormap``: that is the only localtileserver route preserving per-class
+    alpha, since the Colormap path forces alpha to 1 and loses the transparent
+    background. Returns ``None`` when the registration helper is unavailable, so
+    the caller can fall back to a continuous colormap.
+
+    ``vmin``/``vmax`` pin the render range to the byte range the class codes
+    already live in. Without them localtileserver rescales any non-``uint8`` tile
+    onto 0-255 before the colormap runs, which turns class codes into ramp
+    positions and leaves the whole raster transparent; pinning both ends makes
+    that rescale an identity.
+    """
+    try:
+        from localtileserver.tiler.palettes import register_colormap
+    except ImportError:
+        return None
+
+    return {
+        "colormap": register_colormap(_build_class_colormap(class_colors)),
+        "vmin": 0,
+        "vmax": MAX_CLASS_CODE,
+    }
+
+
+def _continuous_color_kwargs(image: Path, bands, colormap) -> dict:
+    """Return the ``get_leaflet_tile_layer`` kwargs for a continuous raster.
+
+    A multi-band source without an explicit single band is rendered as an RGB
+    composite; anything else is one band with ``colormap`` across its range.
+
+    ``colormap`` goes straight through -- ``get_leaflet_tile_layer`` accepts a
+    name, a matplotlib ``Colormap`` or a list of colors, and only the arguments
+    it names (``indexes``, ``colormap``, ``vmin``, ``vmax``, ``nodata``,
+    ``stretch``, ``expression``) reach the tile URL. Everything else lands on the
+    widget as an unrecognised trait and is silently dropped, which is what the
+    large-image ``style`` dict used here until 3.9.0 did.
+    """
+    import rasterio as rio
+
+    with rio.open(image) as ds:
+        count = ds.count
+
+    if count > 1 and not isinstance(bands, int):
+        return {"indexes": list(bands) if bands else [3, 2, 1]}
+
+    return {"indexes": [bands if isinstance(bands, int) else 1], "colormap": colormap}

--- a/pysepal/mapping/raster_style.py
+++ b/pysepal/mapping/raster_style.py
@@ -15,6 +15,10 @@ import logging
 from pathlib import Path
 from typing import Optional, Tuple
 
+import numpy as np
+
+from pysepal.mapping.tiling import _hash_for_cache, _write_atomically
+
 __all__ = []
 
 log = logging.getLogger("sepalui.mapping.raster_style")
@@ -68,10 +72,9 @@ def _densify_class_codes(image: Path, class_colors: dict, cache_dir: Path) -> Tu
     Returns:
         the path to serve, and the ``class_colors`` restated in the new codes.
     """
-    import numpy as np
+    # rasterio stays lazy: importing it costs ~160ms and a GEE-only app that
+    # never touches a local raster should not pay that at import time
     import rasterio as rio
-
-    from pysepal.mapping.tiling import _hash_for_cache, _write_atomically
 
     codes = sorted(int(code) for code in class_colors)
     if len(codes) > MAX_CLASS_CODE:

--- a/pysepal/mapping/raster_style.py
+++ b/pysepal/mapping/raster_style.py
@@ -87,7 +87,11 @@ def _densify_class_codes(image: Path, class_colors: dict, cache_dir: Path) -> Tu
     for color in renumbered.values():
         _hex_to_rgb(color)  # fail before rewriting a raster for an unusable palette
 
-    dst = cache_dir / f"{image.name}.{_hash_for_cache(str(image))}.classes.tif"
+    # the renumbering depends on which classes were asked for, so the codes are
+    # part of the identity: mapping {300, 1024} and later just {1024} produce
+    # different pixels, and sharing one file would paint 300 as 1024
+    tag = _hash_for_cache(str(image), *(str(code) for code in codes))
+    dst = cache_dir / f"{image.name}.{tag}.classes.tif"
     if dst.exists():
         return dst, renumbered
 

--- a/pysepal/mapping/sepal_map.py
+++ b/pysepal/mapping/sepal_map.py
@@ -29,6 +29,7 @@ from pysepal.solara.theme import ThemeState
 if any(var in os.environ for var in GDAL_ENV_VARS):
     prune_foreign_gdal_env()
 
+import asyncio
 import json
 import math
 import random
@@ -413,6 +414,7 @@ class SepalMap(ipl.Map):
         vmax: Optional[float] = None,
         nodata: Optional[float] = None,
         optimize: bool = True,
+        warp_to_3857: bool = False,
     ) -> ipl.TileLayer:
         """Adds a local raster dataset to the map.
 
@@ -431,13 +433,19 @@ class SepalMap(ipl.Map):
             vmax: value mapped to the last color. See ``vmin``.
             nodata: value to render transparent. Defaults to the file's declared nodata, which some products tag incorrectly.
             optimize: prepare a tiled COG with overviews before serving. On by default because rio-tiler otherwise reads full-resolution pixels for every tile. Turn it off for a large raster you do not want copied into the tile cache, or one that already has ``.ovr`` sidecars.
+            warp_to_3857: reproject to Web Mercator while preparing, so tiles are cut in the CRS they are served in instead of being warped per request. Needs ``optimize=True``. Off by default because it doubles the preparation work for a raster that is already close to 3857.
 
         Returns:
             the local tile layer embedding the raster member (to be used with other tools of sepal-ui)
 
+        Note:
+            The first add of a large raster runs a GDAL pass over every pixel and
+            blocks until it finishes. In a Solara app use :meth:`add_raster_async`
+            instead, which does that part in a worker thread.
+
         .. versionadded:: 3.9.0
-            ``class_colors``, ``vmin``, ``vmax``, ``nodata`` and ``optimize``,
-            plus overview preparation by default.
+            ``class_colors``, ``vmin``, ``vmax``, ``nodata``, ``optimize`` and
+            ``warp_to_3857``, plus overview preparation by default.
 
         .. versionchanged:: 3.9.0
             ``colormap`` now reaches the tile server. It was previously packed into
@@ -445,9 +453,98 @@ class SepalMap(ipl.Map):
             reading in localtileserver 0.10.0, so rasters rendered with
             localtileserver's default coloring regardless of what was requested.
         """
-        from localtileserver import TileClient, get_leaflet_tile_layer
+        served, class_colors = self._prepare_raster(image, class_colors, optimize, warp_to_3857)
+        return self._attach_raster(
+            image,
+            served,
+            bands=bands,
+            layer_name=layer_name,
+            colormap=colormap,
+            opacity=opacity,
+            fit_bounds=fit_bounds,
+            key=key,
+            class_colors=class_colors,
+            vmin=vmin,
+            vmax=vmax,
+            nodata=nodata,
+        )
 
-        # force cast to Path and then start the client
+    async def add_raster_async(
+        self,
+        image: Union[str, Path],
+        bands: Optional[Union[list, int]] = None,
+        layer_name: str = "Layer_" + su.random_string(),
+        colormap: Union[str, "mpc.Colormap"] = "inferno",
+        opacity: float = 1.0,
+        fit_bounds: bool = True,
+        key: str = "",
+        class_colors: Optional[dict] = None,
+        vmin: Optional[float] = None,
+        vmax: Optional[float] = None,
+        nodata: Optional[float] = None,
+        optimize: bool = True,
+        warp_to_3857: bool = False,
+    ) -> ipl.TileLayer:
+        """Add a local raster without blocking the event loop.
+
+        Same arguments and return as :meth:`add_raster`. Preparing a raster for
+        tiling is a GDAL pass over every pixel, so on a large file the
+        synchronous call freezes the kernel for as long as that takes; here it
+        runs in a worker thread and only the layer attach stays on the loop.
+        Both are cheap once a raster has been prepared, since the result is
+        cached.
+
+        Args:
+            image: The image file path.
+            bands: The image bands to use. It can be either a number (e.g., 1) or a list (e.g., [3, 2, 1]). Defaults to None.
+            layer_name: The layer name to use for the raster. Defaults to None. If a layer is already using this name 3 random letter will be added
+            colormap: The name of the colormap to use for the raster, such as 'gray' and 'terrain'. More can be found at https://matplotlib.org/3.1.0/tutorials/colors/colormaps.html. Defaults to inferno.
+            opacity: the opacity of the layer, default 1.0.
+            fit_bounds: Whether or not we should fit the map to the image bounds. Default to True.
+            key: the unequivocal key of the layer. by default use a normalized str of the layer name
+            class_colors: mapping of class code to a hex color, for a categorical raster. See :meth:`add_raster`.
+            vmin: value mapped to the first color. See :meth:`add_raster`.
+            vmax: value mapped to the last color. See :meth:`add_raster`.
+            nodata: value to render transparent. See :meth:`add_raster`.
+            optimize: prepare a tiled COG with overviews before serving. See :meth:`add_raster`.
+            warp_to_3857: reproject to Web Mercator while preparing. See :meth:`add_raster`.
+
+        Returns:
+            the local tile layer embedding the raster member (to be used with other tools of sepal-ui)
+
+        .. versionadded:: 3.9.0
+        """
+        served, class_colors = await asyncio.to_thread(
+            self._prepare_raster, image, class_colors, optimize, warp_to_3857
+        )
+        return self._attach_raster(
+            image,
+            served,
+            bands=bands,
+            layer_name=layer_name,
+            colormap=colormap,
+            opacity=opacity,
+            fit_bounds=fit_bounds,
+            key=key,
+            class_colors=class_colors,
+            vmin=vmin,
+            vmax=vmax,
+            nodata=nodata,
+        )
+
+    def _prepare_raster(
+        self,
+        image: Union[str, Path],
+        class_colors: Optional[dict],
+        optimize: bool,
+        warp_to_3857: bool = False,
+    ) -> tuple:
+        """Produce the serve-ready raster path, doing all of the expensive work.
+
+        Touches only the filesystem, so it is safe to run off the UI thread --
+        which is what :meth:`add_raster_async` does. Returns the path to serve
+        and the ``class_colors`` restated in whatever codes that path uses.
+        """
         image = Path(image)
 
         if not image.is_file():
@@ -459,15 +556,49 @@ class SepalMap(ipl.Map):
             cache_dir.mkdir(parents=True, exist_ok=True)
             source, class_colors = _densify_class_codes(image, class_colors, cache_dir)
 
+        if warp_to_3857 and not optimize:
+            # reprojecting means writing a new raster, which is the very thing
+            # optimize=False asks us not to do
+            log.warning("warp_to_3857 needs optimize=True; %s is served in its own CRS.", image)
+
         # rio-tiler reads full-resolution pixels for every tile when the source
         # has no overviews, so serve a prepared COG. Fast no-op when the raster
         # is already tiled with overviews. class_colors settles the overview
         # resampling; without it fall back to the dtype guess.
         served = (
-            _optimize_for_tiles(source, categorical=True if class_colors else None)
+            _optimize_for_tiles(
+                source,
+                categorical=True if class_colors else None,
+                warp_to_3857=warp_to_3857,
+            )
             if optimize
             else str(source)
         )
+        return served, class_colors
+
+    def _attach_raster(
+        self,
+        image: Union[str, Path],
+        served: str,
+        bands: Optional[Union[list, int]] = None,
+        layer_name: str = "",
+        colormap: Union[str, "mpc.Colormap"] = "inferno",
+        opacity: float = 1.0,
+        fit_bounds: bool = True,
+        key: str = "",
+        class_colors: Optional[dict] = None,
+        vmin: Optional[float] = None,
+        vmax: Optional[float] = None,
+        nodata: Optional[float] = None,
+    ) -> ipl.TileLayer:
+        """Serve a prepared raster and put it on the map.
+
+        The half of ``add_raster`` that mutates the map, so it belongs on the
+        thread that owns the widgets.
+        """
+        from localtileserver import TileClient, get_leaflet_tile_layer
+
+        image = Path(image)
         client = TileClient(served)
 
         # check inputs

--- a/pysepal/mapping/sepal_map.py
+++ b/pysepal/mapping/sepal_map.py
@@ -10,6 +10,13 @@ from pysepal.mapping.bounds import (
 )
 from pysepal.mapping.fullscreen_control import FullScreenControl
 from pysepal.mapping.gdal_env import GDAL_ENV_VARS, prune_foreign_gdal_env
+from pysepal.mapping.raster_style import (
+    _class_color_kwargs,
+    _continuous_color_kwargs,
+    _densify_class_codes,
+    _needs_dense_codes,
+)
+from pysepal.mapping.tiling import _optimize_for_tiles, default_cache_dir
 from pysepal.mapping.visualization import (
     get_viz_params,
     get_viz_params_async,
@@ -27,7 +34,7 @@ import math
 import random
 import string
 from pathlib import Path
-from typing import TYPE_CHECKING, List, Optional, Sequence, Union, cast
+from typing import TYPE_CHECKING, List, Optional, Sequence, Union
 
 import ee
 import ipyleaflet as ipl
@@ -401,6 +408,11 @@ class SepalMap(ipl.Map):
         opacity: float = 1.0,
         fit_bounds: bool = True,
         key: str = "",
+        class_colors: Optional[dict] = None,
+        vmin: Optional[float] = None,
+        vmax: Optional[float] = None,
+        nodata: Optional[float] = None,
+        optimize: bool = True,
     ) -> ipl.TileLayer:
         """Adds a local raster dataset to the map.
 
@@ -414,14 +426,26 @@ class SepalMap(ipl.Map):
             opacity: the opacity of the layer, default 1.0.
             key: the unequivocal key of the layer. by default use a normalized str of the layer name
             fit_bounds: Whether or not we should fit the map to the image bounds. Default to True.
+            class_colors: mapping of class code to ``'#rgb'`` or ``'#rrggbb'``, for a categorical raster. When set, each class is drawn in its exact color and anything absent is transparent, instead of stretching ``colormap`` across the value range. Code 0 is colored like any other; codes outside ``0-255`` are served from a renumbered copy, since a tile palette only holds 256 entries. Up to 255 classes.
+            vmin: value mapped to the first color. Defaults to the file's own minimum, i.e. an auto-stretch. Pin both ends to reproduce a fixed palette (a QGIS ramp, a shared legend) rather than one that shifts per file. Ignored when ``class_colors`` is set.
+            vmax: value mapped to the last color. See ``vmin``.
+            nodata: value to render transparent. Defaults to the file's declared nodata, which some products tag incorrectly.
+            optimize: prepare a tiled COG with overviews before serving. On by default because rio-tiler otherwise reads full-resolution pixels for every tile. Turn it off for a large raster you do not want copied into the tile cache, or one that already has ``.ovr`` sidecars.
 
         Returns:
             the local tile layer embedding the raster member (to be used with other tools of sepal-ui)
+
+        .. versionadded:: 3.9.0
+            ``class_colors``, ``vmin``, ``vmax``, ``nodata`` and ``optimize``,
+            plus overview preparation by default.
+
+        .. versionchanged:: 3.9.0
+            ``colormap`` now reaches the tile server. It was previously packed into
+            a large-image ``style`` dict, which ``get_leaflet_tile_layer`` stopped
+            reading in localtileserver 0.10.0, so rasters rendered with
+            localtileserver's default coloring regardless of what was requested.
         """
-        import matplotlib.pyplot as plt
-        import rioxarray
         from localtileserver import TileClient, get_leaflet_tile_layer
-        from matplotlib import colors as mpc
 
         # force cast to Path and then start the client
         image = Path(image)
@@ -429,53 +453,51 @@ class SepalMap(ipl.Map):
         if not image.is_file():
             raise Exception(ms.mapping.no_image)
 
-        client = TileClient(image)
+        source = image
+        if class_colors and _needs_dense_codes(class_colors):
+            cache_dir = default_cache_dir()
+            cache_dir.mkdir(parents=True, exist_ok=True)
+            source, class_colors = _densify_class_codes(image, class_colors, cache_dir)
+
+        # rio-tiler reads full-resolution pixels for every tile when the source
+        # has no overviews, so serve a prepared COG. Fast no-op when the raster
+        # is already tiled with overviews. class_colors settles the overview
+        # resampling; without it fall back to the dtype guess.
+        served = (
+            _optimize_for_tiles(source, categorical=True if class_colors else None)
+            if optimize
+            else str(source)
+        )
+        client = TileClient(served)
 
         # check inputs
         if layer_name in [layer.name for layer in self.layers]:
             layer_name = layer_name + su.random_string()
 
-        # set the colors as independent colors
-        if isinstance(colormap, str):
-            cmap = plt.get_cmap(name=colormap)
-        color_list = [mpc.rgb2hex(cmap(i)) for i in range(cmap.N)]
-
-        da = rioxarray.open_rasterio(image, masked=True)
-        # print
-        print(da)
-        da = da.chunk({"x": 1000, "y": 1000})
-
-        multi_band = False
-        if len(da.band) > 1 and not isinstance(bands, int):
-            multi_band = True
-            bands = bands if bands else [3, 2, 1]
-        elif len(da.band) == 1:
-            bands = 1
-
-        if multi_band:
-            cast(list, bands)
-            style = {
-                "bands": [
-                    {"band": bands[0], "palette": "#f00"},
-                    {"band": bands[1], "palette": "#0f0"},
-                    {"band": bands[2], "palette": "#00f"},
-                ]
-            }
-        else:
-            style = {
-                "bands": [
-                    {"band": bands, "palette": color_list},
-                ]
-            }
+        color_kwargs = _class_color_kwargs(class_colors) if class_colors else None
+        if class_colors and color_kwargs is None:
+            log.warning(
+                "localtileserver register_colormap unavailable; %s falls back to "
+                "the continuous colormap and its classes may render dark.",
+                image,
+            )
+        if color_kwargs is None:
+            color_kwargs = _continuous_color_kwargs(image, bands, colormap)
+            color_kwargs |= {"vmin": vmin, "vmax": vmax}
+        elif vmin is not None or vmax is not None:
+            # the categorical path pins its own range; a caller's would rescale
+            # the class codes into ramp positions and blank the raster
+            log.warning("vmin/vmax are ignored when class_colors is set.")
 
         # create the layer
         layer = get_leaflet_tile_layer(
             client,
-            style=style,
             name=layer_name,
             opacity=opacity,
             max_zoom=20,
             max_native_zoom=20,
+            nodata=nodata,
+            **color_kwargs,
         )
         self.add_layer(layer, key=key)
 

--- a/pysepal/mapping/sepal_map.py
+++ b/pysepal/mapping/sepal_map.py
@@ -604,10 +604,14 @@ class SepalMap(ipl.Map):
         # add the da to the layer as an extra member for the v_inspector
         layer.raster = str(image)
 
-        # zoom on the layer if requested
+        # zoom on the layer if requested. Not client.default_zoom: that frames the
+        # raster in a single 256px tile, leaving it about an eighth of the
+        # viewport wide. zoom_bounds is what add_ee_layer autocenters with -- it
+        # sizes to the canvas, allows for whatever panels MapApp has laid over it,
+        # and stops at the tightest zoom that still shows the whole raster.
         if fit_bounds is True:
-            self.center = client.center()
-            self.zoom = client.default_zoom
+            (south, west), (north, east) = layer.bounds
+            self.zoom_bounds((west, south, east, north))
 
         return layer
 

--- a/pysepal/mapping/sepal_map.py
+++ b/pysepal/mapping/sepal_map.py
@@ -439,7 +439,7 @@ class SepalMap(ipl.Map):
             the local tile layer embedding the raster member (to be used with other tools of sepal-ui)
 
         Note:
-            The first add of a large raster runs a GDAL pass over every pixel and
+            The first add of a large raster rewrites every one of its pixels and
             blocks until it finishes. In a Solara app use :meth:`add_raster_async`
             instead, which does that part in a worker thread.
         """
@@ -477,30 +477,9 @@ class SepalMap(ipl.Map):
     ) -> ipl.TileLayer:
         """Add a local raster without blocking the event loop.
 
-        Same arguments and return as :meth:`add_raster`. Preparing a raster for
-        tiling is a GDAL pass over every pixel, so on a large file the
-        synchronous call freezes the kernel for as long as that takes; here it
-        runs in a worker thread and only the layer attach stays on the loop.
-        Both are cheap once a raster has been prepared, since the result is
-        cached.
-
-        Args:
-            image: The image file path.
-            bands: The image bands to use. It can be either a number (e.g., 1) or a list (e.g., [3, 2, 1]). Defaults to None.
-            layer_name: The layer name to use for the raster. Defaults to None. If a layer is already using this name 3 random letter will be added
-            colormap: The name of the colormap to use for the raster, such as 'gray' and 'terrain'. More can be found at https://matplotlib.org/3.1.0/tutorials/colors/colormaps.html. Defaults to inferno.
-            opacity: the opacity of the layer, default 1.0.
-            fit_bounds: Whether or not we should fit the map to the image bounds. Default to True.
-            key: the unequivocal key of the layer. by default use a normalized str of the layer name
-            class_colors: mapping of class code to a hex color, for a categorical raster. See :meth:`add_raster`.
-            vmin: value mapped to the first color. See :meth:`add_raster`.
-            vmax: value mapped to the last color. See :meth:`add_raster`.
-            nodata: value to render transparent. See :meth:`add_raster`.
-            optimize: prepare a tiled COG with overviews before serving. See :meth:`add_raster`.
-            warp_to_3857: reproject to Web Mercator while preparing. See :meth:`add_raster`.
-
-        Returns:
-            the local tile layer embedding the raster member (to be used with other tools of sepal-ui)
+        Same arguments and return as :meth:`add_raster`. Preparing a raster
+        rewrites every one of its pixels into a tiled COG; that runs in a worker
+        thread here, leaving only the layer attach on the loop.
         """
         served, class_colors = await asyncio.to_thread(
             self._prepare_raster, image, class_colors, optimize, warp_to_3857

--- a/pysepal/mapping/sepal_map.py
+++ b/pysepal/mapping/sepal_map.py
@@ -442,16 +442,6 @@ class SepalMap(ipl.Map):
             The first add of a large raster runs a GDAL pass over every pixel and
             blocks until it finishes. In a Solara app use :meth:`add_raster_async`
             instead, which does that part in a worker thread.
-
-        .. versionadded:: 3.9.0
-            ``class_colors``, ``vmin``, ``vmax``, ``nodata``, ``optimize`` and
-            ``warp_to_3857``, plus overview preparation by default.
-
-        .. versionchanged:: 3.9.0
-            ``colormap`` now reaches the tile server. It was previously packed into
-            a large-image ``style`` dict, which ``get_leaflet_tile_layer`` stopped
-            reading in localtileserver 0.10.0, so rasters rendered with
-            localtileserver's default coloring regardless of what was requested.
         """
         served, class_colors = self._prepare_raster(image, class_colors, optimize, warp_to_3857)
         return self._attach_raster(
@@ -511,8 +501,6 @@ class SepalMap(ipl.Map):
 
         Returns:
             the local tile layer embedding the raster member (to be used with other tools of sepal-ui)
-
-        .. versionadded:: 3.9.0
         """
         served, class_colors = await asyncio.to_thread(
             self._prepare_raster, image, class_colors, optimize, warp_to_3857

--- a/pysepal/mapping/sepal_map.py
+++ b/pysepal/mapping/sepal_map.py
@@ -531,11 +531,13 @@ class SepalMap(ipl.Map):
         # rio-tiler reads full-resolution pixels for every tile when the source
         # has no overviews, so serve a prepared COG. Fast no-op when the raster
         # is already tiled with overviews. class_colors settles the overview
-        # resampling; without it fall back to the dtype guess.
+        # resampling either way -- without it the raster is being drawn as a ramp,
+        # so averaged overviews are right even for the integer dtypes
+        # prepare_for_tiles would otherwise guess were classes (an int16 DEM).
         served = (
             _optimize_for_tiles(
                 source,
-                categorical=True if class_colors else None,
+                categorical=bool(class_colors),
                 warp_to_3857=warp_to_3857,
             )
             if optimize

--- a/pysepal/mapping/tiling.py
+++ b/pysepal/mapping/tiling.py
@@ -21,6 +21,7 @@ import hashlib
 import logging
 import os
 import pathlib
+import uuid
 from typing import Iterator, Optional, Union
 
 from pysepal.scripts.scratch import scratch_root
@@ -77,12 +78,24 @@ def _optimize_for_tiles(
         return str(image)
 
 
-def _hash_for_cache(path: str) -> str:
+def _hash_for_cache(path: str, *recipe: str) -> str:
+    """Identify a cache entry by its source *and* how it was prepared.
+
+    ``recipe`` carries everything that changes the output for the same input --
+    overview resampling, class renumbering -- so a second call asking for
+    different treatment does not get handed the first call's file.
+
+    ``st_mtime_ns`` rather than whole seconds: a rewrite that keeps the byte
+    count and lands inside the same second would otherwise look unchanged.
+    """
     st = os.stat(path)
     h = hashlib.sha1()
     h.update(path.encode())
     h.update(str(st.st_size).encode())
-    h.update(str(int(st.st_mtime)).encode())
+    h.update(str(st.st_mtime_ns).encode())
+    for item in recipe:
+        h.update(b"\x00")
+        h.update(item.encode())
     return h.hexdigest()[:16]
 
 
@@ -95,7 +108,10 @@ def _write_atomically(dst: Union[str, pathlib.Path]) -> Iterator[str]:
     corrupt source.
     """
     dst = pathlib.Path(dst)
-    tmp = dst.with_name(f"{dst.name}.{os.getpid()}.part")
+    # unique per writer, not just per process: add_raster_async hands preparation
+    # to a thread pool, so two concurrent adds share a pid and would otherwise
+    # write the same file -- one publishing it while the other is mid-write
+    tmp = dst.with_name(f"{dst.name}.{os.getpid()}.{uuid.uuid4().hex[:8]}.part")
     try:
         yield str(tmp)
         os.replace(tmp, dst)
@@ -246,13 +262,13 @@ def prepare_for_tiles(
 
     cache_dir = str(cache_dir or default_cache_dir())
     os.makedirs(cache_dir, exist_ok=True)
-    tag = _hash_for_cache(path)
+    tag = _hash_for_cache(path, resampling)
     out = os.path.join(
         cache_dir,
         f"{os.path.basename(path)}.{tag}" + (".3857.cog.tif" if warp_to_3857 else ".cog.tif"),
     )
-    # the tag covers the source's size and mtime, so an existing entry is this
-    # exact raster already prepared
+    # the tag covers the source and the resampling, so an existing entry is this
+    # exact raster already prepared the same way
     if os.path.exists(out) and not force:
         return {"path": out, "report": analyze_tif(out)}
 

--- a/pysepal/mapping/tiling.py
+++ b/pysepal/mapping/tiling.py
@@ -10,6 +10,10 @@ Everything runs through rasterio's own GDAL rather than the ``gdal_translate``
 / ``gdaladdo`` / ``gdalwarp`` binaries: those cannot be declared as a dependency
 -- they are not on PyPI -- so a ``pip install`` would silently fall back to
 serving unprepared, unprojected rasters.
+
+``rasterio`` is imported inside the functions that need it. ``pysepal.mapping``
+pulls this module in, and importing rasterio costs ~160ms, which an app that only
+draws Earth Engine layers should not pay to display a map.
 """
 
 import contextlib
@@ -33,11 +37,20 @@ BLOCK_SIZE = 512
 def default_cache_dir() -> pathlib.Path:
     """The directory prepared rasters are cached in.
 
+    Derived files, not user output, so they belong in a cache rather than next to
+    the source or under ``module_results``.
+
     Returns:
-        ``$PYSEPAL_TILE_CACHE`` when set, otherwise ``~/.cache/localtiles``.
+        ``$PYSEPAL_TILE_CACHE`` when set, otherwise ``localtiles`` inside
+        ``$XDG_CACHE_HOME`` (``~/.cache`` when that is unset).
     """
     override = os.environ.get(CACHE_DIR_ENV_VAR)
-    return pathlib.Path(override) if override else pathlib.Path.home() / ".cache" / "localtiles"
+    if override:
+        return pathlib.Path(override)
+
+    xdg = os.environ.get("XDG_CACHE_HOME")
+    root = pathlib.Path(xdg) if xdg else pathlib.Path.home() / ".cache"
+    return root / "localtiles"
 
 
 def _optimize_for_tiles(

--- a/pysepal/mapping/tiling.py
+++ b/pysepal/mapping/tiling.py
@@ -23,6 +23,8 @@ import os
 import pathlib
 from typing import Iterator, Optional, Union
 
+from pysepal.scripts.scratch import scratch_root
+
 __all__ = ["analyze_tif", "prepare_for_tiles"]
 
 log = logging.getLogger("sepalui.mapping.tiling")
@@ -37,20 +39,23 @@ BLOCK_SIZE = 512
 def default_cache_dir() -> pathlib.Path:
     """The directory prepared rasters are cached in.
 
-    Derived files, not user output, so they belong in a cache rather than next to
-    the source or under ``module_results``.
+    A prepared COG is a derived file, so it belongs on scratch rather than in the
+    user's home: on a SEPAL sandbox the home export is nfs4 and quota'd, which
+    would make every tile read cross the network and charge the user for the
+    copy. :func:`~pysepal.scripts.scratch.scratch_root` is container-local there.
+
+    A fixed name under that root rather than :func:`scratch_dir`, which mints a
+    unique directory per call and would defeat the caching entirely.
 
     Returns:
-        ``$PYSEPAL_TILE_CACHE`` when set, otherwise ``localtiles`` inside
-        ``$XDG_CACHE_HOME`` (``~/.cache`` when that is unset).
+        ``$PYSEPAL_TILE_CACHE`` when set, otherwise ``pysepal-tiles`` under the
+        scratch root.
     """
     override = os.environ.get(CACHE_DIR_ENV_VAR)
     if override:
         return pathlib.Path(override)
 
-    xdg = os.environ.get("XDG_CACHE_HOME")
-    root = pathlib.Path(xdg) if xdg else pathlib.Path.home() / ".cache"
-    return root / "localtiles"
+    return scratch_root() / "pysepal-tiles"
 
 
 def _optimize_for_tiles(

--- a/pysepal/mapping/tiling.py
+++ b/pysepal/mapping/tiling.py
@@ -1,0 +1,249 @@
+"""Prepare a raster for fast tile serving.
+
+``rio-tiler`` reads full-resolution pixels for every tile when the source has no
+overviews, so low zooms are slow and each tile logs a ``NoOverviewWarning``.
+:func:`prepare_for_tiles` returns a tiled COG with overviews, kept in a cache
+directory and reused on later calls, and is a fast no-op when the raster is
+already good enough.
+
+Everything runs through rasterio's own GDAL rather than the ``gdal_translate``
+/ ``gdaladdo`` / ``gdalwarp`` binaries: those cannot be declared as a dependency
+-- they are not on PyPI -- so a ``pip install`` would silently fall back to
+serving unprepared, unprojected rasters.
+"""
+
+import contextlib
+import hashlib
+import logging
+import os
+import pathlib
+from typing import Iterator, Optional, Union
+
+__all__ = ["analyze_tif", "prepare_for_tiles"]
+
+log = logging.getLogger("sepalui.mapping.tiling")
+
+#: Overrides where prepared rasters are cached, for a sandbox with a disk quota.
+CACHE_DIR_ENV_VAR = "PYSEPAL_TILE_CACHE"
+
+#: Edge of a tile block, and the size overviews are built down to.
+BLOCK_SIZE = 512
+
+
+def default_cache_dir() -> pathlib.Path:
+    """The directory prepared rasters are cached in.
+
+    Returns:
+        ``$PYSEPAL_TILE_CACHE`` when set, otherwise ``~/.cache/localtiles``.
+    """
+    override = os.environ.get(CACHE_DIR_ENV_VAR)
+    return pathlib.Path(override) if override else pathlib.Path.home() / ".cache" / "localtiles"
+
+
+def _optimize_for_tiles(
+    image: Union[str, pathlib.Path],
+    categorical: Optional[bool] = None,
+    warp_to_3857: bool = False,
+) -> str:
+    """Return a tiling-optimized (cached COG with overviews) path.
+
+    Best-effort wrapper around :func:`prepare_for_tiles`: on failure the raw
+    raster is served, which still tiles, just more slowly.
+    """
+    try:
+        return prepare_for_tiles(str(image), warp_to_3857=warp_to_3857, categorical=categorical)[
+            "path"
+        ]
+    except Exception as e:
+        log.warning("Tiling optimization failed for %s (%s); serving the raw raster.", image, e)
+        return str(image)
+
+
+def _hash_for_cache(path: str) -> str:
+    st = os.stat(path)
+    h = hashlib.sha1()
+    h.update(path.encode())
+    h.update(str(st.st_size).encode())
+    h.update(str(int(st.st_mtime)).encode())
+    return h.hexdigest()[:16]
+
+
+@contextlib.contextmanager
+def _write_atomically(dst: Union[str, pathlib.Path]) -> Iterator[str]:
+    """Yield a temporary path to write, moved onto ``dst`` only once it is whole.
+
+    Two kernels adding the same raster resolve to the same cache entry, and a
+    reader that opens a half-written GeoTIFF fails in ways that look like a
+    corrupt source.
+    """
+    dst = pathlib.Path(dst)
+    tmp = dst.with_name(f"{dst.name}.{os.getpid()}.part")
+    try:
+        yield str(tmp)
+        os.replace(tmp, dst)
+    finally:
+        with contextlib.suppress(OSError):
+            if tmp.exists():
+                tmp.unlink()
+
+
+def _guess_categorical(ds) -> bool:
+    """Guess whether a raster holds classes rather than a continuous measure.
+
+    Only consulted when the caller doesn't say: passing ``class_colors`` to
+    ``add_raster`` settles it, and this dtype test cannot tell a class map from
+    an integer DEM.
+    """
+    return ds.count == 1 and ds.dtypes[0].startswith(
+        ("int8", "uint8", "int16", "uint16", "int32", "uint32")
+    )
+
+
+def _has_overviews(ds) -> bool:
+    return any(ds.overviews(i + 1) for i in range(ds.count))
+
+
+def _is_tiled(ds) -> bool:
+    # block_shapes is None on some drivers; treat as not tiled
+    try:
+        bs = ds.block_shapes
+        return bool(bs) and all((b[0] > 1 and b[1] > 1) for b in bs)
+    except Exception:
+        return False
+
+
+def _needs_reproject(ds, target_epsg: Optional[int]) -> bool:
+    if not target_epsg or not ds.crs:
+        return False
+    try:
+        return ds.crs.to_epsg() != target_epsg
+    except Exception:
+        return True
+
+
+def _predictor_for(dtype: str) -> int:
+    """The DEFLATE predictor that matches the sample format.
+
+    2 is horizontal differencing, defined for integers only; floating point
+    needs 3, and using 2 there either errors or compresses badly.
+    """
+    return 3 if dtype.startswith("float") else 2
+
+
+def analyze_tif(path: str) -> dict:
+    """Report the tiling-relevant properties of a raster.
+
+    Args:
+        path: Path to the raster file.
+
+    Returns:
+        CRS, size, band count, dtype, whether it is tiled, its overview levels
+        and a guess at whether the data is categorical.
+    """
+    import rasterio as rio
+
+    with rio.open(path) as ds:
+        return {
+            "path": path,
+            "crs": str(ds.crs),
+            "epsg": (ds.crs.to_epsg() if ds.crs else None),
+            "width": ds.width,
+            "height": ds.height,
+            "bands": ds.count,
+            "dtype": ds.dtypes[0],
+            "tiled": _is_tiled(ds),
+            "overviews": [ds.overviews(i + 1) for i in range(ds.count)],
+            "categorical_guess": _guess_categorical(ds),
+        }
+
+
+def _write_cog(source, dst: str, resampling: str, dtype: str) -> None:
+    """Copy a dataset (or a warping view of one) out as a COG with overviews.
+
+    ``rasterio.shutil.copy`` is GDAL's ``CreateCopy``, so the pixels stream
+    rather than landing in a numpy array first -- a raster far larger than
+    memory still converts.
+    """
+    from rasterio.shutil import copy as rio_copy
+
+    rio_copy(
+        source,
+        dst,
+        driver="COG",
+        compress="DEFLATE",
+        level=6,
+        predictor=_predictor_for(dtype),
+        blocksize=BLOCK_SIZE,
+        overviews="AUTO",
+        resampling=resampling,
+        num_threads="ALL_CPUS",
+        bigtiff="IF_SAFER",
+    )
+
+
+def prepare_for_tiles(
+    path: str,
+    cache_dir: Optional[str] = None,
+    warp_to_3857: bool = False,
+    force: bool = False,
+    categorical: Optional[bool] = None,
+) -> dict:
+    """Return a tiling-optimized copy of a raster, building it if needed.
+
+    The copy is cached under ``cache_dir`` and reused on later calls, so repeat
+    adds of the same raster cost nothing.
+
+    Args:
+        path: Path to the source raster.
+        cache_dir: Where to keep the optimized copy. Defaults to
+            :func:`default_cache_dir`.
+        warp_to_3857: Reproject to Web Mercator, in the same pass that writes
+            the COG.
+        force: Rebuild even when a cached copy is available.
+        categorical: Whether the values are class codes, which decides between
+            NEAREST and AVERAGE overview resampling. Guessed from the dtype when
+            not given.
+
+    Returns:
+        ``{"path": optimized_path, "report": analyze_tif(optimized_path)}``.
+        ``path`` is the source itself when no work was needed.
+    """
+    import rasterio as rio
+    from rasterio.enums import Resampling
+    from rasterio.vrt import WarpedVRT
+
+    path = os.path.abspath(path)
+    rep = analyze_tif(path)
+    if categorical is None:
+        categorical = rep["categorical_guess"]
+    resampling = "NEAREST" if categorical else "AVERAGE"
+
+    # Open once (context-managed) instead of leaking a handle per rio.open call.
+    with rio.open(path) as ds:
+        need_reproj = _needs_reproject(ds, 3857) if warp_to_3857 else False
+        good_enough = rep["tiled"] and _has_overviews(ds) and not need_reproj
+
+    if good_enough and not force:
+        return {"path": path, "report": rep}
+
+    cache_dir = str(cache_dir or default_cache_dir())
+    os.makedirs(cache_dir, exist_ok=True)
+    tag = _hash_for_cache(path)
+    out = os.path.join(
+        cache_dir,
+        f"{os.path.basename(path)}.{tag}" + (".3857.cog.tif" if warp_to_3857 else ".cog.tif"),
+    )
+    # the tag covers the source's size and mtime, so an existing entry is this
+    # exact raster already prepared
+    if os.path.exists(out) and not force:
+        return {"path": out, "report": analyze_tif(out)}
+
+    with rio.open(path) as ds, _write_atomically(out) as tmp:
+        if warp_to_3857:
+            # the VRT warps lazily, so reprojecting costs no intermediate file
+            with WarpedVRT(ds, crs="EPSG:3857", resampling=Resampling[resampling.lower()]) as vrt:
+                _write_cog(vrt, tmp, resampling, rep["dtype"])
+        else:
+            _write_cog(ds, tmp, resampling, rep["dtype"])
+
+    return {"path": out, "report": analyze_tif(out)}

--- a/pysepal/templates/solara/solara_raster_app/app.py
+++ b/pysepal/templates/solara/solara_raster_app/app.py
@@ -109,6 +109,19 @@ def demo_rasters() -> dict:
 
 @solara.component
 def RasterAppDemo():
+    """Mount the notification bus, then the app that publishes to it.
+
+    ``use_notifications()`` resolves to a NoopNotifier while no provider is
+    mounted, and the tasks close over whatever it returned -- so the hook has to
+    run in a child of the provider, not alongside it.
+    """
+    # Toasts top-right, task progress pill bottom-right.
+    NotificationProvider()
+    RasterPanel()
+
+
+@solara.component
+def RasterPanel():
     """Map plus a panel of buttons, one per raster-rendering path."""
     setup_theme_colors()
     theme_state = get_current_theme_state()
@@ -187,9 +200,6 @@ def RasterAppDemo():
     clear_button = solara.use_memo(build_clear_button, [id(sepal_map)])
 
     source = "generated stand-ins" if rasters["synthetic"] else "real class maps"
-
-    # Toasts top-right, task progress pill bottom-right.
-    NotificationProvider()
 
     MapApp.element(
         app_title="Local rasters",

--- a/pysepal/templates/solara/solara_raster_app/app.py
+++ b/pysepal/templates/solara/solara_raster_app/app.py
@@ -19,13 +19,13 @@ pysepal$ ./run_solara.sh pysepal/templates/solara/solara_raster_app/app.py --por
 """
 
 import os
-import tempfile
 from pathlib import Path
 
 import solara
 
 import pysepal.sepalwidgets as sw
 from pysepal import mapping as sm
+from pysepal.scripts.scratch import scratch_root
 from pysepal.sepalwidgets.vue_app import MapApp
 from pysepal.solara import (
     get_current_theme_state,
@@ -99,7 +99,7 @@ def demo_rasters() -> dict:
         if congo.is_file() and hansen.is_file():
             return {"congo": congo, "hansen": hansen, "synthetic": False}
 
-    scratch = Path(tempfile.gettempdir()) / "pysepal-raster-demo"
+    scratch = scratch_root() / "pysepal-raster-demo"
     return {
         "congo": _synthetic_raster(scratch / "classes.tif", CONGO_COLORS),
         "hansen": _synthetic_raster(scratch / "loss.tif", HANSEN_COLORS),

--- a/pysepal/templates/solara/solara_raster_app/app.py
+++ b/pysepal/templates/solara/solara_raster_app/app.py
@@ -1,0 +1,237 @@
+"""Local raster rendering: continuous ramps, categorical class colors, big files.
+
+Three buttons, one per path through :meth:`~pysepal.mapping.SepalMap.add_raster`:
+a continuous colormap, exact per-class colors, and a raster large enough that
+preparing it has to happen off the event loop.
+
+Set ``PYSEPAL_DEMO_RASTER_DIR`` to a directory holding ``aa_test_congo.tif`` and
+``hansen_bolivia.tif`` to run against real class maps; without it the demo
+generates a small synthetic class raster so it still runs anywhere.
+
+The UI lives in :func:`RasterAppDemo` so the same code serves both runtimes --
+``Page`` is the Solara entrypoint and ``ui.ipynb`` is a thin Voila one.
+
+To run:
+
+```bash
+pysepal$ ./run_solara.sh pysepal/templates/solara/solara_raster_app/app.py --port 8901
+```
+"""
+
+import os
+import tempfile
+from pathlib import Path
+
+import solara
+
+import pysepal.sepalwidgets as sw
+from pysepal import mapping as sm
+from pysepal.sepalwidgets.vue_app import MapApp
+from pysepal.solara import (
+    get_current_theme_state,
+    setup_solara_server,
+    setup_theme_colors,
+)
+from pysepal.solara.components.task_button import TaskButtonComponent, use_task_button
+from pysepal.solara.notifications import NotificationProvider, use_notifications
+
+setup_solara_server(extra_asset_locations=[])
+
+#: Points the demo at real class maps instead of the generated stand-in.
+RASTER_DIR_ENV_VAR = "PYSEPAL_DEMO_RASTER_DIR"
+
+# aa_test_congo holds these nine classes; codes 2 and 4 are the ones a continuous
+# ramp stretched over 2-34 renders as good as black.
+CONGO_COLORS = {
+    2: "#8ecae6",
+    4: "#219ebc",
+    11: "#2d6a4f",
+    12: "#40916c",
+    13: "#95d5b2",
+    31: "#e9c46a",
+    32: "#f4a261",
+    33: "#e76f51",
+    34: "#9b2226",
+}
+
+# hansen loss year band: 0 is "no loss" and a real, sampleable class, not background
+HANSEN_COLORS = {0: "#1b4332", 5: "#e63946"}
+
+
+def _synthetic_raster(path: Path, codes: dict) -> Path:
+    """Write a small class raster, so the demo runs without the real products."""
+    import numpy as np
+    import rasterio as rio
+    from rasterio.transform import from_origin
+
+    if path.exists():
+        return path
+
+    values = sorted(codes)
+    size = 512
+    data = np.zeros((size, size), dtype="int16")
+    for band, value in enumerate(values):
+        data[:, band * size // len(values) : (band + 1) * size // len(values)] = value
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with rio.open(
+        path,
+        "w",
+        driver="GTiff",
+        height=size,
+        width=size,
+        count=1,
+        dtype="int16",
+        crs="EPSG:4326",
+        transform=from_origin(20, 0, 0.01, 0.01),
+    ) as dataset:
+        dataset.write(data, 1)
+
+    return path
+
+
+def demo_rasters() -> dict:
+    """Return the two rasters to draw, generating stand-ins when absent."""
+    directory = os.environ.get(RASTER_DIR_ENV_VAR)
+    if directory:
+        congo = Path(directory) / "aa_test_congo.tif"
+        hansen = Path(directory) / "hansen_bolivia.tif"
+        if congo.is_file() and hansen.is_file():
+            return {"congo": congo, "hansen": hansen, "synthetic": False}
+
+    scratch = Path(tempfile.gettempdir()) / "pysepal-raster-demo"
+    return {
+        "congo": _synthetic_raster(scratch / "classes.tif", CONGO_COLORS),
+        "hansen": _synthetic_raster(scratch / "loss.tif", HANSEN_COLORS),
+        "synthetic": True,
+    }
+
+
+@solara.component
+def RasterAppDemo():
+    """Map plus a panel of buttons, one per raster-rendering path."""
+    setup_theme_colors()
+    theme_state = get_current_theme_state()
+    notifications = use_notifications()
+
+    rasters = solara.use_memo(demo_rasters, [])
+
+    def build_map():
+        return sm.SepalMap(
+            zoom=3, center=[0, 0], gee=False, fullscreen=True, theme_state=theme_state
+        )
+
+    sepal_map = solara.use_memo(build_map, [])
+
+    async def add_continuous():
+        """What every raster looked like before class_colors: a stretched ramp."""
+        with notifications.track("Continuous colormap") as task:
+            task.step("preparing COG...")
+            await sepal_map.add_raster_async(
+                rasters["congo"],
+                layer_name="Classes (continuous)",
+                key="continuous",
+                colormap="inferno",
+            )
+        notifications.success("Continuous ramp added")
+
+    async def add_class_colors():
+        """The same raster, each class in its own color."""
+        with notifications.track("Class colors") as task:
+            task.step("preparing COG...")
+            await sepal_map.add_raster_async(
+                rasters["congo"],
+                layer_name="Classes (exact)",
+                key="classes",
+                class_colors=CONGO_COLORS,
+            )
+        notifications.success(f"{len(CONGO_COLORS)} classes added")
+
+    async def add_large():
+        """A raster with no overviews, which is the case ``optimize`` exists for."""
+        with notifications.track("Large raster") as task:
+            task.step("preparing COG with overviews...")
+            await sepal_map.add_raster_async(
+                rasters["hansen"],
+                layer_name="Loss year",
+                key="large",
+                class_colors=HANSEN_COLORS,
+            )
+        notifications.success("Large raster added")
+
+    continuous_task = solara.lab.use_task(
+        add_continuous, dependencies=None, raise_error=False, prefer_threaded=False
+    )
+    classes_task = solara.lab.use_task(
+        add_class_colors, dependencies=None, raise_error=False, prefer_threaded=False
+    )
+    large_task = solara.lab.use_task(
+        add_large, dependencies=None, raise_error=False, prefer_threaded=False
+    )
+
+    continuous_props = use_task_button(continuous_task, on_start=continuous_task)
+    classes_props = use_task_button(classes_task, on_start=classes_task)
+    large_props = use_task_button(large_task, on_start=large_task)
+
+    def build_clear_button():
+        """A plain ipyvuetify button, handed to MapApp intact with its handler."""
+        button = sw.Btn("clear rasters", small=True, block=True)
+
+        def clear():
+            for key in ("continuous", "classes", "large"):
+                sepal_map.remove_layer(key, none_ok=True)
+
+        button.on_event("click", lambda *args: clear())
+        return button
+
+    clear_button = solara.use_memo(build_clear_button, [id(sepal_map)])
+
+    source = "generated stand-ins" if rasters["synthetic"] else "real class maps"
+
+    # Toasts top-right, task progress pill bottom-right.
+    NotificationProvider()
+
+    MapApp.element(
+        app_title="Local rasters",
+        app_icon="mdi-layers",
+        main_map=[sepal_map],
+        steps_data=[],
+        right_panel_config={
+            "title": "Rasters",
+            "icon": "mdi-image",
+            "width": 380,
+            "description": "Each button renders a local raster through a different path.",
+        },
+        right_panel_content=[
+            {
+                "title": "Local rasters",
+                "icon": "mdi-image",
+                "content": [
+                    TaskButtonComponent(
+                        label="continuous ramp", **continuous_props, small=True, block=True
+                    ),
+                    TaskButtonComponent(
+                        label="class colors", **classes_props, small=True, block=True
+                    ),
+                    TaskButtonComponent(
+                        label="large raster", **large_props, small=True, block=True
+                    ),
+                    clear_button,
+                ],
+                "description": (
+                    f"Drawing {source}. A continuous ramp stretched across sparse class "
+                    f"codes renders them near-black; class_colors draws each one exactly. "
+                    f"Set {RASTER_DIR_ENV_VAR} to use real products."
+                ),
+            }
+        ],
+        right_panel_open=True,
+        theme_state=theme_state,
+        dialog_width=750,
+    )
+
+
+@solara.component
+def Page():
+    """Solara entrypoint -- no SEPAL session, the raster path is entirely local."""
+    RasterAppDemo()

--- a/pysepal/templates/solara/solara_raster_app/ui.ipynb
+++ b/pysepal/templates/solara/solara_raster_app/ui.ipynb
@@ -1,0 +1,29 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "voila-entrypoint",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from app import RasterAppDemo\n",
+    "\n",
+    "display(RasterAppDemo())\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "pysepal",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.10.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -360,6 +360,52 @@ def byte(tmp_path_factory: pytest.TempPathFactory) -> Path:
     return file
 
 
+@pytest.fixture(scope="session")
+def int16_classes(tmp_path_factory: pytest.TempPathFactory) -> Path:
+    """A two-class int16 raster, the shape most land cover products come in.
+
+    Returns:
+        the path to a raster of class 1 (left half) and class 2 (right half)
+    """
+    import numpy as np
+    import rasterio as rio
+    from rasterio.transform import from_origin
+
+    file = tmp_path_factory.mktemp("temp") / "classes.tif"
+    data = np.ones((64, 64), dtype="int16")
+    data[:, 32:] = 2
+    with rio.open(
+        file,
+        "w",
+        driver="GTiff",
+        height=64,
+        width=64,
+        count=1,
+        dtype="int16",
+        crs="EPSG:4326",
+        transform=from_origin(0, 0, 0.01, 0.01),
+    ) as ds:
+        ds.write(data, 1)
+
+    return file
+
+
+@pytest.fixture(scope="session")
+def _tile_cache_dir(tmp_path_factory: pytest.TempPathFactory) -> Path:
+    """Where prepared rasters are cached for the duration of the run."""
+    return tmp_path_factory.mktemp("tile-cache")
+
+
+@pytest.fixture(autouse=True)
+def _tile_cache(_tile_cache_dir: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Keep prepared rasters out of the developer's real ``~/.cache``.
+
+    The raster fixtures land on a new tmp path every session, so a shared cache
+    would gain an entry per run and never drop one.
+    """
+    monkeypatch.setenv("PYSEPAL_TILE_CACHE", str(_tile_cache_dir))
+
+
 # -- Planet credentials --------------------------------------------------------
 
 

--- a/tests/test_mapping/test_add_raster_styling.py
+++ b/tests/test_mapping/test_add_raster_styling.py
@@ -256,7 +256,7 @@ async def test_add_raster_async_matches_the_sync_call(int16_classes: Path) -> No
 
 @pytest.mark.asyncio
 async def test_add_raster_async_prepares_off_the_loop(byte: Path, monkeypatch) -> None:
-    # the whole point: the GDAL pass must not run on the thread driving the UI
+    # the whole point: rewriting the pixels must not run on the thread driving the UI
     import threading
 
     import pysepal.mapping.sepal_map as sepal_map

--- a/tests/test_mapping/test_add_raster_styling.py
+++ b/tests/test_mapping/test_add_raster_styling.py
@@ -387,6 +387,45 @@ def test_explicit_band_on_a_multi_band_source_uses_a_ramp(rgb: Path) -> None:
     assert params["colormap"] == "viridis"
 
 
+def _on_screen_width_px(layer, zoom: int) -> float:
+    """How wide the raster draws at ``zoom``; longitude is linear in Mercator px."""
+    (_, west), (_, east) = layer.bounds
+    return (east - west) * (256 * 2**zoom) / 360
+
+
+@pytest.mark.parametrize("fixture", ["byte", "rgb"])
+def test_fit_bounds_frames_the_whole_raster(fixture: str, request) -> None:
+    # localtileserver's default_zoom frames a raster in a 256px tile rather than
+    # in the map, which drew it about an eighth of the viewport wide
+    canvas_px = 1024  # the map's fallback canvas width, with no frontend attached
+    m = sm.SepalMap()
+    layer = m.add_raster(request.getfixturevalue(fixture), key="fit")
+
+    on_screen_px = _on_screen_width_px(layer, m.zoom)
+
+    # fills the viewport without spilling off it; the exact zoom is whichever
+    # axis runs out of pixels first, so height may be what binds
+    assert 0.25 * canvas_px < on_screen_px <= canvas_px
+
+
+def test_fit_bounds_centres_on_the_raster(byte: Path) -> None:
+    m = sm.SepalMap()
+    layer = m.add_raster(byte, key="centre")
+
+    (south, west), (north, east) = layer.bounds
+
+    assert south < m.center[0] < north
+    assert west < m.center[1] < east
+
+
+def test_fit_bounds_can_be_declined(byte: Path) -> None:
+    m = sm.SepalMap()
+    before = (m.center, m.zoom)
+    m.add_raster(byte, fit_bounds=False, key="still")
+
+    assert (m.center, m.zoom) == before
+
+
 def test_optimize_serves_a_prepared_copy(byte: Path) -> None:
     m = sm.SepalMap()
     layer = m.add_raster(byte, key="cog")

--- a/tests/test_mapping/test_add_raster_styling.py
+++ b/tests/test_mapping/test_add_raster_styling.py
@@ -244,6 +244,38 @@ def test_class_colors_ignore_a_caller_supplied_range(int16_classes: Path, caplog
     assert "vmin/vmax are ignored" in caplog.text
 
 
+@pytest.mark.asyncio
+async def test_add_raster_async_matches_the_sync_call(int16_classes: Path) -> None:
+    colors = {1: "#ff0000", 2: "#00ff00"}
+    m = sm.SepalMap()
+    layer = await m.add_raster_async(int16_classes, class_colors=colors, key="a")
+
+    assert m.find_layer("a") is layer
+    assert _rendered_colors(layer) == {(255, 0, 0), (0, 255, 0)}
+
+
+@pytest.mark.asyncio
+async def test_add_raster_async_prepares_off_the_loop(byte: Path, monkeypatch) -> None:
+    # the whole point: the GDAL pass must not run on the thread driving the UI
+    import threading
+
+    import pysepal.mapping.sepal_map as sepal_map
+
+    calling_thread = {}
+    real = sepal_map._optimize_for_tiles
+
+    def _record(*args, **kwargs):
+        calling_thread["name"] = threading.current_thread()
+        return real(*args, **kwargs)
+
+    monkeypatch.setattr(sepal_map, "_optimize_for_tiles", _record)
+
+    m = sm.SepalMap()
+    await m.add_raster_async(byte, key="off")
+
+    assert calling_thread["name"] is not threading.current_thread()
+
+
 def test_add_raster_points_the_inspector_at_the_source(byte: Path) -> None:
     # the served file may be a prepared COG copy; the v_inspector must report
     # values from the raster the caller supplied
@@ -345,6 +377,25 @@ def test_optimize_serves_a_prepared_copy(byte: Path) -> None:
     layer = m.add_raster(byte, key="cog")
 
     assert _served_file(layer) != str(byte)  # the cached COG, not the source
+
+
+def test_warp_reaches_the_tile_server(byte: Path) -> None:
+    import rasterio as rio
+
+    m = sm.SepalMap()
+    layer = m.add_raster(byte, warp_to_3857=True, key="warp")
+
+    with rio.open(_served_file(layer)) as ds:
+        assert ds.crs.to_epsg() == 3857
+
+
+def test_warp_without_optimize_says_so(byte: Path, caplog) -> None:
+    # reprojecting means writing a copy, which optimize=False forbids
+    m = sm.SepalMap()
+    layer = m.add_raster(byte, warp_to_3857=True, optimize=False, key="nowarp")
+
+    assert _served_file(layer) == str(byte)
+    assert "warp_to_3857 needs optimize=True" in caplog.text
 
 
 def test_optimize_false_serves_the_source_untouched(byte: Path) -> None:

--- a/tests/test_mapping/test_add_raster_styling.py
+++ b/tests/test_mapping/test_add_raster_styling.py
@@ -1,0 +1,356 @@
+"""How add_raster colors a raster, and that the choice reaches the tile server.
+
+``get_leaflet_tile_layer`` only forwards ``indexes``, ``colormap``, ``vmin``,
+``vmax``, ``nodata``, ``stretch`` and ``expression`` into the tile URL; every
+other keyword lands on the widget as an unrecognised trait and is dropped. So
+these assert on the URL query rather than on the layer object.
+"""
+
+from pathlib import Path
+from urllib.parse import parse_qs, urlparse
+
+import pytest
+from matplotlib.colors import LinearSegmentedColormap
+
+from pysepal import mapping as sm
+from pysepal.mapping.raster_style import (
+    _build_class_colormap,
+    _class_color_kwargs,
+    _densify_class_codes,
+    _hex_to_rgb,
+    _needs_dense_codes,
+)
+
+
+def _params(layer) -> dict:
+    """Tile URL query parameters, minus the filename."""
+    params = parse_qs(urlparse(layer.url).query)
+    params.pop("filename", None)
+    return {key: values[0] if len(values) == 1 else values for key, values in params.items()}
+
+
+def _served_file(layer) -> str:
+    return parse_qs(urlparse(layer.url).query)["filename"][0]
+
+
+def _rendered_colors(layer) -> set:
+    """The opaque RGB colors the tile server actually draws for this layer.
+
+    Renders through the layer's own URL parameters, so it measures what
+    ``add_raster`` asked for rather than what the test thinks it asked for.
+    """
+    import numpy as np
+    import rasterio as rio
+
+    params = _params(layer)
+    indexes = [int(i) for i in params["indexes"].split(",")] if "indexes" in params else None
+    png = layer.tile_server.thumbnail(
+        indexes=indexes,
+        colormap=params.get("colormap"),
+        vmin=params.get("vmin"),
+        vmax=params.get("vmax"),
+        nodata=params.get("nodata"),
+    )
+
+    with rio.MemoryFile(png) as memfile, memfile.open() as ds:
+        rgba = ds.read()
+    opaque = rgba[3] > 0 if rgba.shape[0] == 4 else np.ones(rgba.shape[1:], dtype=bool)
+    return {tuple(int(v) for v in c) for c in rgba[:3][:, opaque].T}
+
+
+def test_colormap_colors_class_zero():
+    cm = _build_class_colormap({0: "#ff0000", 5: "#00ff00"})
+    assert cm[0] == (255, 0, 0, 255)  # class 0 is a real class, not background
+    assert cm[5] == (0, 255, 0, 255)
+
+
+def test_colormap_holds_only_the_declared_classes():
+    # padding out to 256 entries would push rio-tiler onto its make_lut path,
+    # where a value above 255 wraps into a class and gets painted with its color
+    cm = _build_class_colormap({5: "#00ff00"})
+    assert cm == {5: (0, 255, 0, 255)}
+
+
+def test_colormap_accepts_short_hex():
+    assert _build_class_colormap({1: "#f00"}) == {1: (255, 0, 0, 255)}
+
+
+def test_hex_to_rgb_rejects_a_malformed_color():
+    with pytest.raises(ValueError):
+        _hex_to_rgb("#ff00")
+
+
+def test_class_color_kwargs_registers_a_colormap():
+    kwargs = _class_color_kwargs({1: "#ff0000"})
+    # a server-side registration key, not a raw dict: the only route that keeps
+    # per-class alpha. vmin/vmax neutralise localtileserver's rescale, which
+    # would otherwise turn the class codes into ramp positions.
+    assert kwargs["colormap"].startswith("custom:")
+    assert (kwargs["vmin"], kwargs["vmax"]) == (0, 255)
+
+
+def test_class_color_kwargs_returns_none_when_unavailable(monkeypatch):
+    import builtins
+
+    real_import = builtins.__import__
+
+    def _no_palettes(name, *args, **kwargs):
+        if name == "localtileserver.tiler.palettes":
+            raise ImportError("no palette registry")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", _no_palettes)
+    assert _class_color_kwargs({1: "#ff0000"}) is None
+
+
+def test_codes_within_a_byte_need_no_renumbering():
+    assert _needs_dense_codes({0: "#ff0000", 255: "#00ff00"}) is False
+
+
+def test_codes_outside_a_byte_need_renumbering():
+    assert _needs_dense_codes({1: "#ff0000", 300: "#00ff00"}) is True
+    assert _needs_dense_codes({-1: "#ff0000"}) is True
+
+
+def test_densify_renumbers_codes_and_colors(int16_classes: Path, tmp_path: Path) -> None:
+    import rasterio as rio
+
+    path, colors = _densify_class_codes(int16_classes, {1: "#ff0000", 2: "#00ff00"}, tmp_path)
+
+    assert colors == {1: "#ff0000", 2: "#00ff00"}  # already dense, order preserved
+    with rio.open(path) as ds:
+        assert ds.dtypes[0] == "uint8"
+
+
+def test_densify_maps_high_codes_onto_a_byte(int16_classes: Path, tmp_path: Path) -> None:
+    import numpy as np
+    import rasterio as rio
+    from rasterio.transform import from_origin
+
+    source = tmp_path / "high.tif"
+    data = np.full((8, 8), 300, dtype="int32")
+    data[:, 4:] = 1024
+    with rio.open(
+        source,
+        "w",
+        driver="GTiff",
+        height=8,
+        width=8,
+        count=1,
+        dtype="int32",
+        crs="EPSG:4326",
+        transform=from_origin(0, 0, 0.01, 0.01),
+    ) as ds:
+        ds.write(data, 1)
+
+    path, colors = _densify_class_codes(source, {300: "#0000ff", 1024: "#ffffff"}, tmp_path)
+
+    assert colors == {1: "#0000ff", 2: "#ffffff"}
+    with rio.open(path) as ds:
+        assert set(np.unique(ds.read(1))) == {1, 2}
+
+
+def test_densify_reuses_its_cached_copy(int16_classes: Path, tmp_path: Path) -> None:
+    first, _ = _densify_class_codes(int16_classes, {1: "#ff0000"}, tmp_path)
+    stamp = first.stat().st_mtime_ns
+    second, _ = _densify_class_codes(int16_classes, {1: "#ff0000"}, tmp_path)
+
+    assert second == first
+    assert second.stat().st_mtime_ns == stamp  # not rewritten
+
+
+def test_add_raster_with_class_colors(byte: Path) -> None:
+    m = sm.SepalMap()
+    layer = m.add_raster(byte, class_colors={1: "#ff0000", 2: "#00ff00"}, key="clas")
+
+    assert type(layer).__name__ == "BoundTileLayer"
+    assert m.find_layer("clas") is layer
+    assert _params(layer)["colormap"].startswith("custom:")
+
+
+def test_class_colors_draw_their_exact_colors(int16_classes: Path) -> None:
+    # regression: an int16 class map rendered fully transparent, because
+    # localtileserver rescales a non-uint8 tile onto 0-255 before the colormap
+    # and turned the class codes into ramp positions
+    m = sm.SepalMap()
+    layer = m.add_raster(int16_classes, class_colors={1: "#ff0000", 2: "#00ff00"}, key="i16")
+
+    assert _rendered_colors(layer) == {(255, 0, 0), (0, 255, 0)}
+
+
+def test_class_colors_above_a_byte_draw_their_exact_colors(tmp_path: Path) -> None:
+    import numpy as np
+    import rasterio as rio
+    from rasterio.transform import from_origin
+
+    source = tmp_path / "high.tif"
+    data = np.full((64, 64), 300, dtype="int32")
+    data[:, 32:] = 1024
+    with rio.open(
+        source,
+        "w",
+        driver="GTiff",
+        height=64,
+        width=64,
+        count=1,
+        dtype="int32",
+        crs="EPSG:4326",
+        transform=from_origin(0, 0, 0.01, 0.01),
+    ) as ds:
+        ds.write(data, 1)
+
+    m = sm.SepalMap()
+    layer = m.add_raster(source, class_colors={300: "#0000ff", 1024: "#ffffff"}, key="high")
+
+    assert _rendered_colors(layer) == {(0, 0, 255), (255, 255, 255)}
+
+
+def test_class_colors_leave_undeclared_values_transparent(tmp_path: Path) -> None:
+    import numpy as np
+    import rasterio as rio
+    from rasterio.transform import from_origin
+
+    source = tmp_path / "stray.tif"
+    data = np.ones((64, 64), dtype="int16")
+    data[:, 32:] = 257  # wraps onto class 1 if the renderer casts to uint8
+    with rio.open(
+        source,
+        "w",
+        driver="GTiff",
+        height=64,
+        width=64,
+        count=1,
+        dtype="int16",
+        crs="EPSG:4326",
+        transform=from_origin(0, 0, 0.01, 0.01),
+    ) as ds:
+        ds.write(data, 1)
+
+    m = sm.SepalMap()
+    layer = m.add_raster(source, class_colors={1: "#ff0000"}, key="stray")
+
+    assert _rendered_colors(layer) == {(255, 0, 0)}
+
+
+def test_class_colors_ignore_a_caller_supplied_range(int16_classes: Path, caplog) -> None:
+    # a caller's vmin/vmax would rescale the class codes and blank the raster
+    m = sm.SepalMap()
+    layer = m.add_raster(
+        int16_classes, class_colors={1: "#ff0000", 2: "#00ff00"}, vmin=1, vmax=2, key="pin"
+    )
+
+    params = _params(layer)
+    assert (params["vmin"], params["vmax"]) == ("0", "255")
+    assert "vmin/vmax are ignored" in caplog.text
+
+
+def test_add_raster_points_the_inspector_at_the_source(byte: Path) -> None:
+    # the served file may be a prepared COG copy; the v_inspector must report
+    # values from the raster the caller supplied
+    m = sm.SepalMap()
+    layer = m.add_raster(byte, class_colors={1: "#ff0000"}, key="clas")
+
+    assert layer.raster == str(byte)
+
+
+def test_empty_class_colors_takes_the_continuous_path(byte: Path) -> None:
+    m = sm.SepalMap()
+    layer = m.add_raster(byte, class_colors={}, layer_name="empty", key="empty")
+
+    assert type(layer).__name__ == "BoundTileLayer"
+    assert m.find_layer("empty") is layer
+
+
+def test_falls_back_to_continuous_when_registration_is_unavailable(byte: Path, monkeypatch) -> None:
+    import builtins
+
+    real_import = builtins.__import__
+
+    def _no_palettes(name, *args, **kwargs):
+        if name == "localtileserver.tiler.palettes":
+            raise ImportError("no palette registry")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", _no_palettes)
+
+    m = sm.SepalMap()
+    layer = m.add_raster(byte, class_colors={1: "#ff0000"}, layer_name="fb", key="fb")
+
+    assert type(layer).__name__ == "BoundTileLayer"
+    assert m.find_layer("fb") is layer
+
+
+def test_a_broken_class_color_is_not_swallowed(byte: Path) -> None:
+    # a bad hex used to fall back to the continuous ramp while logging that the
+    # palette registry was unavailable, which was never the actual problem
+    m = sm.SepalMap()
+    with pytest.raises(ValueError):
+        m.add_raster(byte, class_colors={1: "not-a-color"}, key="bad")
+
+
+def test_colormap_reaches_the_tile_server(byte: Path) -> None:
+    # regression: the colormap used to be sampled into a large-image style dict,
+    # which get_leaflet_tile_layer hands to the widget instead of the renderer --
+    # so every raster drew with localtileserver's default, whatever was asked for
+    m = sm.SepalMap()
+    layer = m.add_raster(byte, colormap="viridis", key="v")
+
+    assert _params(layer)["colormap"] == "viridis"
+
+
+def test_colormap_object_is_registered_server_side(byte: Path) -> None:
+    # a computed ramp (a QGIS translation, say) rather than a named one; this
+    # used to raise NameError because cmap was only bound for str colormaps
+    cmap = LinearSegmentedColormap.from_list("x", ["#228b22", "#ff0000"], N=256)
+    m = sm.SepalMap()
+    layer = m.add_raster(byte, colormap=cmap, key="c")
+
+    assert _params(layer)["colormap"].startswith("custom:")
+
+
+def test_value_range_and_nodata_reach_the_tile_server(byte: Path) -> None:
+    m = sm.SepalMap()
+    layer = m.add_raster(byte, colormap="viridis", vmin=1, vmax=14, nodata=0, key="p")
+
+    params = _params(layer)
+    assert (params["vmin"], params["vmax"], params["nodata"]) == ("1", "14", "0")
+
+
+def test_unpinned_range_leaves_the_stretch_to_the_file(byte: Path) -> None:
+    m = sm.SepalMap()
+    params = _params(m.add_raster(byte, key="auto"))
+
+    assert "vmin" not in params and "vmax" not in params
+
+
+def test_multi_band_source_renders_as_an_rgb_composite(rgb: Path) -> None:
+    m = sm.SepalMap()
+    params = _params(m.add_raster(rgb, key="rgb"))
+
+    # band indexes, no colormap: an RGB composite is not a ramp
+    assert params["indexes"] == "3,2,1"
+    assert "colormap" not in params
+
+
+def test_explicit_band_on_a_multi_band_source_uses_a_ramp(rgb: Path) -> None:
+    m = sm.SepalMap()
+    params = _params(m.add_raster(rgb, bands=2, colormap="viridis", key="one"))
+
+    assert params["indexes"] == "2"
+    assert params["colormap"] == "viridis"
+
+
+def test_optimize_serves_a_prepared_copy(byte: Path) -> None:
+    m = sm.SepalMap()
+    layer = m.add_raster(byte, key="cog")
+
+    assert _served_file(layer) != str(byte)  # the cached COG, not the source
+
+
+def test_optimize_false_serves_the_source_untouched(byte: Path) -> None:
+    # for a large raster you don't want duplicated into the tile cache, or one
+    # that already carries .ovr sidecars
+    m = sm.SepalMap()
+    layer = m.add_raster(byte, optimize=False, key="raw")
+
+    assert _served_file(layer) == str(byte)

--- a/tests/test_mapping/test_add_raster_styling.py
+++ b/tests/test_mapping/test_add_raster_styling.py
@@ -150,6 +150,21 @@ def test_densify_maps_high_codes_onto_a_byte(int16_classes: Path, tmp_path: Path
         assert set(np.unique(ds.read(1))) == {1, 2}
 
 
+def test_densify_keys_its_cache_on_the_classes_asked_for(
+    int16_classes: Path, tmp_path: Path
+) -> None:
+    # renumbering depends on the code set, so sharing one file between two
+    # different sets paints one class with another's colour
+    first, first_colors = _densify_class_codes(
+        int16_classes, {1: "#ff0000", 2: "#00ff00"}, tmp_path
+    )
+    second, second_colors = _densify_class_codes(int16_classes, {2: "#00ff00"}, tmp_path)
+
+    assert second != first
+    assert first_colors == {1: "#ff0000", 2: "#00ff00"}
+    assert second_colors == {1: "#00ff00"}  # class 2 renumbered to 1 on its own
+
+
 def test_densify_reuses_its_cached_copy(int16_classes: Path, tmp_path: Path) -> None:
     first, _ = _densify_class_codes(int16_classes, {1: "#ff0000"}, tmp_path)
     stamp = first.stat().st_mtime_ns

--- a/tests/test_mapping/test_tiling.py
+++ b/tests/test_mapping/test_tiling.py
@@ -1,0 +1,173 @@
+"""Preparing a raster for tile serving: COG conversion, caching and atomicity.
+
+Everything goes through rasterio's own GDAL. The ``gdal_translate`` /
+``gdaladdo`` / ``gdalwarp`` binaries cannot be a dependency -- they are not on
+PyPI -- so relying on them meant a ``pip install`` silently served unprepared,
+unprojected rasters.
+"""
+
+from pathlib import Path
+
+import pytest
+
+from pysepal.mapping.tiling import (
+    _predictor_for,
+    _write_atomically,
+    default_cache_dir,
+    prepare_for_tiles,
+)
+
+
+def _big_raster(path: Path, dtype: str = "int16", crs: str = "EPSG:4326") -> Path:
+    """A raster large enough to earn overviews."""
+    import numpy as np
+    import rasterio as rio
+    from rasterio.transform import from_origin
+
+    size = 1024
+    data = np.ones((size, size), dtype=dtype)
+    data[:, size // 2 :] = 2
+    with rio.open(
+        path,
+        "w",
+        driver="GTiff",
+        height=size,
+        width=size,
+        count=1,
+        dtype=dtype,
+        crs=crs,
+        transform=from_origin(0, 0, 0.001, 0.001),
+    ) as ds:
+        ds.write(data, 1)
+    return path
+
+
+def test_cache_dir_follows_the_env_var(monkeypatch, tmp_path):
+    monkeypatch.setenv("PYSEPAL_TILE_CACHE", str(tmp_path / "elsewhere"))
+
+    assert default_cache_dir() == tmp_path / "elsewhere"
+
+
+def test_predictor_matches_the_sample_format():
+    # predictor 2 is horizontal differencing, defined for integers only
+    assert _predictor_for("int16") == 2
+    assert _predictor_for("uint8") == 2
+    assert _predictor_for("float32") == 3
+
+
+def test_preparation_yields_a_tiled_cog_with_overviews(tmp_path: Path) -> None:
+    from localtileserver.validate import validate_cog
+
+    source = _big_raster(tmp_path / "src.tif")
+    result = prepare_for_tiles(str(source), cache_dir=str(tmp_path / "cache"))
+
+    assert validate_cog(result["path"])
+    assert result["report"]["tiled"]
+    assert result["report"]["overviews"][0]  # non-empty
+
+
+def test_a_float_raster_converts(tmp_path: Path) -> None:
+    # predictor 2 on floating point either errors or compresses badly
+    from localtileserver.validate import validate_cog
+
+    source = _big_raster(tmp_path / "float.tif", dtype="float32")
+    result = prepare_for_tiles(str(source), cache_dir=str(tmp_path / "cache"))
+
+    assert validate_cog(result["path"])
+    assert result["report"]["dtype"] == "float32"
+
+
+def test_prepared_raster_is_reused(byte: Path, tmp_path: Path) -> None:
+    # the COG used to be rebuilt on every add_raster, so a large raster paid a
+    # full conversion per call
+    first = prepare_for_tiles(str(byte), cache_dir=str(tmp_path))
+    stamp = Path(first["path"]).stat().st_mtime_ns
+
+    second = prepare_for_tiles(str(byte), cache_dir=str(tmp_path))
+
+    assert second["path"] == first["path"]
+    assert Path(second["path"]).stat().st_mtime_ns == stamp
+
+
+def test_force_rebuilds_the_prepared_raster(byte: Path, tmp_path: Path) -> None:
+    first = prepare_for_tiles(str(byte), cache_dir=str(tmp_path))
+    stamp = Path(first["path"]).stat().st_mtime_ns
+
+    second = prepare_for_tiles(str(byte), cache_dir=str(tmp_path), force=True)
+
+    assert second["path"] == first["path"]
+    assert Path(second["path"]).stat().st_mtime_ns != stamp
+
+
+def test_warping_reprojects_to_web_mercator(byte: Path, tmp_path: Path) -> None:
+    # sbae-design serves its uploads warped, so tiles are cut in the CRS they
+    # are served in instead of being reprojected per request
+    plain = prepare_for_tiles(str(byte), cache_dir=str(tmp_path))
+    warped = prepare_for_tiles(str(byte), cache_dir=str(tmp_path), warp_to_3857=True)
+
+    assert plain["report"]["epsg"] != 3857  # byte.tif is UTM
+    assert warped["report"]["epsg"] == 3857
+    assert warped["path"] != plain["path"]  # the two live side by side in the cache
+
+
+def test_warping_writes_no_intermediate(byte: Path, tmp_path: Path) -> None:
+    # the WarpedVRT reprojects lazily, so the COG copy is the only write
+    prepare_for_tiles(str(byte), cache_dir=str(tmp_path), warp_to_3857=True)
+
+    assert not list(tmp_path.glob("*.warp.tif"))
+    assert not list(tmp_path.glob("*.part"))
+
+
+def test_warping_survives_a_pruned_gdal_env(byte: Path, tmp_path: Path, monkeypatch) -> None:
+    # prune_foreign_gdal_env strips these; in-process GDAL finds its own data,
+    # which a subprocess resolved from another prefix could not
+    for var in ("PROJ_DATA", "PROJ_LIB", "GDAL_DATA"):
+        monkeypatch.delenv(var, raising=False)
+
+    result = prepare_for_tiles(str(byte), cache_dir=str(tmp_path), warp_to_3857=True)
+
+    assert result["report"]["epsg"] == 3857
+
+
+def test_an_already_good_raster_is_served_untouched(tmp_path: Path) -> None:
+    source = _big_raster(tmp_path / "src.tif")
+    prepared = prepare_for_tiles(str(source), cache_dir=str(tmp_path / "cache"))["path"]
+
+    # feeding the prepared COG back in has nothing left to do
+    again = prepare_for_tiles(prepared, cache_dir=str(tmp_path / "cache"))
+
+    assert again["path"] == prepared
+
+
+def test_a_failed_write_leaves_no_half_built_file(tmp_path: Path) -> None:
+    # a reader that opens a partial GeoTIFF fails as if the source were corrupt
+    target = tmp_path / "out.tif"
+
+    with pytest.raises(RuntimeError):
+        with _write_atomically(target) as tmp:
+            Path(tmp).write_bytes(b"half a raster")
+            raise RuntimeError("conversion exploded")
+
+    assert not target.exists()
+    assert list(tmp_path.iterdir()) == []
+
+
+def test_an_atomic_write_lands_on_the_target(tmp_path: Path) -> None:
+    target = tmp_path / "out.tif"
+
+    with _write_atomically(target) as tmp:
+        Path(tmp).write_bytes(b"a whole raster")
+
+    assert target.read_bytes() == b"a whole raster"
+
+
+def test_optimize_for_tiles_serves_the_raw_raster_on_failure(monkeypatch):
+    # best-effort: a broken optimization must not stop the raster from tiling
+    import pysepal.mapping.tiling as tiling
+
+    def _boom(*args, **kwargs):
+        raise RuntimeError("conversion exploded")
+
+    monkeypatch.setattr(tiling, "prepare_for_tiles", _boom)
+
+    assert tiling._optimize_for_tiles("/data/raster.tif") == "/data/raster.tif"

--- a/tests/test_mapping/test_tiling.py
+++ b/tests/test_mapping/test_tiling.py
@@ -11,6 +11,7 @@ from pathlib import Path
 import pytest
 
 from pysepal.mapping.tiling import (
+    _hash_for_cache,
     _predictor_for,
     _write_atomically,
     default_cache_dir,
@@ -109,6 +110,56 @@ def test_prepared_raster_is_reused(byte: Path, tmp_path: Path) -> None:
 
     assert second["path"] == first["path"]
     assert Path(second["path"]).stat().st_mtime_ns == stamp
+
+
+def test_resampling_choice_is_part_of_the_cache_identity(byte: Path, tmp_path: Path) -> None:
+    # NEAREST and AVERAGE overviews are different pixels; sharing one entry hands
+    # the second caller the first caller's resampling
+    categorical = prepare_for_tiles(str(byte), cache_dir=str(tmp_path), categorical=True)
+    continuous = prepare_for_tiles(str(byte), cache_dir=str(tmp_path), categorical=False)
+
+    assert categorical["path"] != continuous["path"]
+
+
+def test_a_same_size_rewrite_within_a_second_is_not_reused(tmp_path: Path) -> None:
+    # whole-second mtime would call these the same raster
+    import numpy as np
+    import rasterio as rio
+    from rasterio.transform import from_origin
+
+    source = tmp_path / "churn.tif"
+    profile = dict(
+        driver="GTiff",
+        height=1024,
+        width=1024,
+        count=1,
+        dtype="int16",
+        crs="EPSG:4326",
+        transform=from_origin(0, 0, 0.001, 0.001),
+    )
+    with rio.open(source, "w", **profile) as ds:
+        ds.write(np.ones((1024, 1024), dtype="int16"), 1)
+    first = _hash_for_cache(str(source))
+
+    with rio.open(source, "w", **profile) as ds:  # same byte count, same second
+        ds.write(np.full((1024, 1024), 2, dtype="int16"), 1)
+
+    assert _hash_for_cache(str(source)) != first
+
+
+def test_concurrent_writers_do_not_share_a_temp_file(tmp_path: Path) -> None:
+    # add_raster_async prepares in a thread pool, so a pid-only name collides
+    target = tmp_path / "out.tif"
+    seen = []
+
+    with _write_atomically(target) as first:
+        seen.append(first)
+        with _write_atomically(target) as second:
+            seen.append(second)
+            Path(second).write_bytes(b"second")
+        Path(first).write_bytes(b"first")
+
+    assert seen[0] != seen[1]
 
 
 def test_force_rebuilds_the_prepared_raster(byte: Path, tmp_path: Path) -> None:

--- a/tests/test_mapping/test_tiling.py
+++ b/tests/test_mapping/test_tiling.py
@@ -48,6 +48,28 @@ def test_cache_dir_follows_the_env_var(monkeypatch, tmp_path):
     assert default_cache_dir() == tmp_path / "elsewhere"
 
 
+def test_cache_dir_sits_on_scratch(monkeypatch, tmp_path):
+    # a derived COG on SEPAL's nfs4 home export would cross the network on every
+    # tile read and count against the user's quota
+    import pysepal.mapping.tiling as tiling
+
+    monkeypatch.delenv("PYSEPAL_TILE_CACHE", raising=False)
+    monkeypatch.setattr(tiling, "scratch_root", lambda: tmp_path)
+
+    assert default_cache_dir().parent == tmp_path
+
+
+def test_cache_dir_is_stable_across_calls(monkeypatch, tmp_path):
+    # scratch_dir() mints a new directory per call, which would mean nothing is
+    # ever reused; the cache needs a fixed name under the scratch root
+    import pysepal.mapping.tiling as tiling
+
+    monkeypatch.delenv("PYSEPAL_TILE_CACHE", raising=False)
+    monkeypatch.setattr(tiling, "scratch_root", lambda: tmp_path)
+
+    assert default_cache_dir() == default_cache_dir()
+
+
 def test_predictor_matches_the_sample_format():
     # predictor 2 is horizontal differencing, defined for integers only
     assert _predictor_for("int16") == 2


### PR DESCRIPTION
`add_raster`'s `colormap` never reached the tile server. It was sampled into a large-image `style` dict, which `get_leaflet_tile_layer` stopped reading when localtileserver 0.10.0 moved to rio-tiler — so every raster drew with the default palette regardless of what was asked for. Our pin was open-ended, so no commit here broke it, and no test caught it because they asserted only layer name and type.

Also in here:

- `class_colors` draws a categorical raster in exact per-class colours through a server-side LUT, pinned to the byte range — localtileserver rescales any non-uint8 tile onto 0–255 before applying the colormap, which was rendering int16 class maps fully transparent. Codes outside 0–255 are served from a renumbered uint8 copy.
- `add_raster_async`, mirroring the existing `add_ee_layer_async`. Preparing a 3.5-gigapixel raster takes ~14 s and froze the kernel for the duration.
- Rasters are prepared as cached COGs with overviews before serving, since rio-tiler otherwise reads full-resolution pixels for every tile.
- `fit_bounds` now zooms with `zoom_bounds`, as `add_ee_layer` already does. It was using localtileserver's `default_zoom`, which frames a raster in a single 256px tile — three levels out, drawing it about an eighth of the viewport wide — and centred on the canvas rather than the visible area, so MapApp's panels covered part of it.

**Heads-up on the dependency floor:** this raises localtileserver to `>=1.0.0` (released 2026-04-24), up from `0.10.1`. The colormap registry `class_colors` needs does not exist before 1.0, so on an older install the feature silently degrades to the continuous ramp — the exact bug this fixes. Anyone on 0.10.x needs the upgrade.

Preparation also used to shell out to `gdal_translate` / `gdaladdo` / `gdalwarp`. Those are not a declared dependency and cannot be — they are not on PyPI — so on a `pip install` they are simply absent and the fast path silently never ran, serving unprepared and unprojected rasters. It goes through rasterio's own GDAL now, and `rasterio` is declared explicitly (it was previously only a transitive dependency despite being imported directly). The tile cache moved from `~/.cache` to `scratch_root()`: on a SEPAL sandbox the home export is nfs4 and quota'd, so a COG there crossed the network on every tile read and counted against the user's storage.

Verified in a Solara app against real class maps — a 9-class Congo raster and a 59520×59309 Hansen loss layer — under both Solara and Voila, plus 501 passing tests. The demo used for that is committed at `pysepal/templates/solara/solara_raster_app/`; it reads `PYSEPAL_DEMO_RASTER_DIR` and otherwise generates int16 stand-ins so it runs without the source data.
